### PR TITLE
Add bin/setup-github.sh — one-shot Indiagrams house-style repo config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # The stub app is named "HelloApp" with bundle id "io.indiagrams.helloapp".
 # Rename for your project: see README.md → "Renaming the stub".
 
-.PHONY: bootstrap check check-ios check-macos check-sim build generate icons screenshots release-dryrun help
+.PHONY: bootstrap check check-ios check-macos check-sim build generate icons screenshots release-dryrun setup-github help
 
 help:
 	@echo "Targets:"
@@ -19,6 +19,7 @@ help:
 	@echo "  icons            Regenerate macOS AppIcon.iconset + AppIcon.icns from 1024 source"
 	@echo "  screenshots      Capture App Store screenshots (iOS + macOS) to fastlane/screenshots/"
 	@echo "  release-dryrun   fastlane release tag:v0.0.0 skip_upload:true skip_tag:true"
+	@echo "  setup-github     Apply Indiagrams house-style branch protection to current repo"
 
 bootstrap:
 	brew bundle
@@ -52,3 +53,6 @@ screenshots:
 
 release-dryrun:
 	bundle exec fastlane release tag:v0.0.0 skip_upload:true skip_tag:true
+
+setup-github:
+	bin/setup-github.sh

--- a/README.md
+++ b/README.md
@@ -192,13 +192,36 @@ AnchorKey (currently in TestFlight v0.0.11). Specific gotchas baked in:
   .icns regardless of catalog input. Replacing it with a hand-rolled 10-size
   version is the only reliable way to get sharp icons at every system size.
 
-## Branch protection
+## GitHub configuration (one-shot)
 
-Enable on the GitHub repo settings:
+After creating your repo and pushing the first commit, run:
 
-- Require pull request reviews before merging
-- Require status checks to pass: `app (iOS device)`, `app (iOS Simulator)`, `app (macOS)`
-- Include administrators
+```bash
+make setup-github                                  # uses current repo's origin
+# or:
+bin/setup-github.sh indiagrams/myapp               # explicit target
+```
+
+This applies the Indiagrams house-style settings to your repo:
+
+- **Branch protection on `main`**:
+  - Require PR before merging (no direct pushes — even for repo admins)
+  - Require 3 CI checks green: `app (iOS device)`, `app (iOS Simulator)`, `app (macOS)`
+  - Require checks to be up-to-date with `main` before merge (strict mode)
+  - Enforce on admins (no bypass)
+  - Require linear history
+  - Require conversation resolution before merge
+  - Block force-pushes + branch deletion
+- **Repo merge style**: squash-only (no merge commits, no rebase merges)
+- **Auto-delete head branches** after merge
+
+The script is idempotent — safe to re-run when you change settings or the
+PR job names. It uses `gh api` and needs `gh auth status` to show the
+`admin:repo` scope.
+
+If your CI job names diverge from the defaults (e.g. you renamed jobs in
+`.github/workflows/pr.yml`), edit the `checks` array in `bin/setup-github.sh`
+to match — the names must match the job `name:` attribute exactly.
 
 ## License
 

--- a/bin/setup-github.sh
+++ b/bin/setup-github.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# bin/setup-github.sh — apply Indiagrams house-style GitHub configuration to a
+# repo derived from this template.
+#
+# What it sets:
+#   - Default branch: main
+#   - Branch protection on main:
+#       * Require PR before merging (no direct pushes)
+#       * Require 3 status checks: app (iOS device), app (iOS Simulator), app (macOS)
+#       * Require status checks to be up-to-date before merge
+#       * Enforce on admins (no bypass — same rules apply to repo owner)
+#       * Require linear history
+#   - Disable merge commits + rebase merges (squash-only)
+#   - Auto-delete head branches after merge
+#
+# Usage:
+#   bin/setup-github.sh                              # uses current repo's origin
+#   bin/setup-github.sh owner/repo                   # explicit target
+#
+# Prerequisites:
+#   - gh CLI authenticated with admin:repo scope (`gh auth status` shows it)
+#   - You are the repo admin (or an org admin)
+#
+# Idempotent — safe to re-run; existing settings are overwritten with these.
+
+set -euo pipefail
+
+step() { printf '\n==> %s\n' "$*"; }
+ok()   { printf '    ✓ %s\n' "$*"; }
+fail() { printf '    ✗ %s\n' "$*" >&2; exit 1; }
+
+# ── Resolve target repo ───────────────────────────────────────────────────────
+
+if [ $# -ge 1 ]; then
+  REPO="$1"
+else
+  # Try to read from the current repo's origin remote.
+  if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    fail "not in a git repository — pass a repo as 'owner/name' or run from a clone"
+  fi
+  origin=$(git config --get remote.origin.url 2>/dev/null || true)
+  [ -z "$origin" ] && fail "no origin remote — pass a repo as 'owner/name'"
+  # Normalize: strip git@github.com: / https://github.com/ / .git
+  REPO=$(echo "$origin" \
+    | sed -E -e 's#^git@github\.com:##' \
+             -e 's#^https://github\.com/##' \
+             -e 's#\.git$##')
+fi
+
+if ! [[ "$REPO" =~ ^[^/]+/[^/]+$ ]]; then
+  fail "invalid repo '$REPO' — expected owner/name (e.g. indiagrams/myapp)"
+fi
+
+step "Target: $REPO"
+
+# Sanity-check repo exists + we can reach it.
+if ! gh api "repos/$REPO" --silent 2>/dev/null; then
+  fail "cannot reach $REPO via gh API — check 'gh auth status' and that the repo exists"
+fi
+ok "repo reachable"
+
+# ── 1. Repo settings: squash-only merge, auto-delete head branches ────────────
+
+step "Repo settings"
+gh api -X PATCH "repos/$REPO" \
+  -F allow_squash_merge=true \
+  -F allow_merge_commit=false \
+  -F allow_rebase_merge=false \
+  -F delete_branch_on_merge=true \
+  --silent
+ok "squash-only merge, auto-delete head branches"
+
+# ── 2. Branch protection on main ──────────────────────────────────────────────
+
+step "Branch protection on main"
+
+# Use a heredoc JSON body — gh api -F doesn't gracefully nest the required_status_checks
+# array of objects. Required check names must match the job 'name:' attributes
+# in .github/workflows/pr.yml.
+PROTECTION_JSON=$(cat <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "checks": [
+      { "context": "app (iOS device)" },
+      { "context": "app (iOS Simulator)" },
+      { "context": "app (macOS)" }
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 0
+  },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": true,
+  "lock_branch": false,
+  "allow_fork_syncing": false
+}
+JSON
+)
+
+# `--input -` reads JSON body from stdin. PUT replaces existing protection.
+echo "$PROTECTION_JSON" | gh api -X PUT "repos/$REPO/branches/main/protection" \
+  -H "Accept: application/vnd.github+json" \
+  --input - --silent || {
+  # If the branch doesn't exist yet (fresh repo with no commits on main),
+  # PUT returns 404. Make this error clearer.
+  fail "could not apply protection — does '$REPO' have a 'main' branch yet? Push at least one commit first."
+}
+ok "main: PR-required, 3 CI checks (strict), enforce on admins, linear history"
+
+step "Done"
+ok "$REPO is configured to Indiagrams house style."
+ok "Direct pushes to main are blocked. Open PRs and let CI run."


### PR DESCRIPTION
## Summary

- Adds `bin/setup-github.sh` (and `make setup-github`) to apply branch protection + repo settings on a fresh-from-template repo without clicking through GitHub's UI.
- Settings applied: PR-required, 3 CI checks (iOS device, iOS Simulator, macOS) strict-mode, admin enforcement, linear history, squash-only merge, auto-delete head branches.
- Already used to bootstrap protection on this template repo itself.
- README + Makefile updated to document the workflow.

## Test plan

- [x] Ran the script against `indiagrams/ios-macos-template` — protection + repo settings applied (verified via `gh api`)
- [x] Idempotent — re-running produces no errors
- [ ] CI runs on this PR (will surface required check names to GitHub for the first time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)