### PR TITLE
chore(setup-github): enable allow_auto_merge in repo settings

### DIFF
--- a/bin/setup-github.sh
+++ b/bin/setup-github.sh
@@ -67,8 +67,9 @@ gh api -X PATCH "repos/$REPO" \
   -F allow_merge_commit=false \
   -F allow_rebase_merge=false \
   -F delete_branch_on_merge=true \
+  -F allow_auto_merge=true \
   --silent
-ok "squash-only merge, auto-delete head branches"
+ok "squash-only merge, auto-delete head branches, auto-merge enabled"
 
 # ── 2. Branch protection on main ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- One-line addition to `bin/setup-github.sh`: `-F allow_auto_merge=true` in the repo-settings PATCH alongside the existing `allow_squash_merge` / `delete_branch_on_merge` toggles.
- Update success-line text to reflect the additional setting.
- Surfaced while merging PR #2 — `gh pr merge --auto --squash --delete-branch` failed with `Auto merge is not allowed for this repository (enablePullRequestAutoMerge)` until I toggled it by hand on this repo. Folding it into the script so the next consumer-repo bootstrap has it out of the box and the squash-merge house style is fully self-configuring.

## Test plan
- [x] Local: `git diff bin/setup-github.sh` is exactly +1 line in the `gh api PATCH` block + 1 message-line update; nothing else touched
- [x] Local: 6 pre-existing unstaged edits + `?? docs/` preserved through the commit (atomic pathspec commit)
- [ ] CI: 3 build jobs green (`app (iOS device)`, `app (iOS Simulator)`, `app (macOS)`) — automatic; `bin/` not in build path so should pass clean
- [ ] After merge, re-running `bin/setup-github.sh indiagrams/ios-macos-template` is idempotent (the setting is already true on this repo from PR #2's manual toggle — re-applying same value is a no-op)
- Future verification: when M5 P2 (`Verify bin/setup-github.sh works for any org`) runs, the smoke-test repo will inherit `allow_auto_merge=true` automatically without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)