### PR TITLE
docs: add CONTRIBUTING.md + CODE_OF_CONDUCT.md — M1 P2

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at jpraju@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,143 @@
+# Contributing to ios-macos-template
+
+This is a small, opinionated template for iOS + macOS apps. We say yes to
+fixes for the gotchas hiding in `xcodebuild`, `fastlane deliver`, `actool`,
+and `codesign` — because someone hit them, debugged them, and shouldn't
+have to do that again. We say no to features that fit a specific use case
+but not the broader iOS/macOS world.
+
+Before opening a PR, ask:
+
+- Does this fix a sharp edge a stranger would hit?
+- Does it preserve the "5-minute clone-to-first-build" promise?
+- Does it generalize, or is it specific to your project?
+
+If the answer to all three is yes, open a PR. If you're unsure, open an issue first.
+
+## Quickstart
+
+```bash
+# 1. Fork on GitHub, then clone your fork
+git clone https://github.com/<you>/ios-macos-template.git
+cd ios-macos-template
+
+# 2. One-time setup (brew bundle, lefthook install, xcodegen, bundle install)
+make bootstrap
+
+# 3. Create a topic branch
+git checkout -b fix/short-description
+
+# 4. Make your change
+
+# 5. Verify locally — must be green before pushing
+make check
+
+# 6. Push (lefthook also runs ci/local-check.sh --fast as a pre-push hook)
+git push -u origin fix/short-description
+
+# 7. Open a PR against main
+gh pr create
+```
+
+`make check` is the floor. If it's red locally, the PR won't merge — branch
+protection enforces this for everyone, maintainers included
+([PRINCIPLES.md](docs/PRINCIPLES.md) #4). The pre-push hook runs
+`ci/local-check.sh --fast` automatically, which is the same iOS-device
+build CI runs on every PR — so by the time you push, you've already passed
+the primary signal.
+
+## What every PR needs
+
+1. **Three CI checks green.** Branch protection on `main` enforces this.
+   The required jobs are:
+   - `app (iOS device)`
+   - `app (iOS Simulator)`
+   - `app (macOS)`
+
+   These names are pinned in `.github/workflows/pr.yml` and mirrored in
+   `bin/setup-github.sh`. Renaming a job means updating both — see
+   [PRINCIPLES.md](docs/PRINCIPLES.md) #10 (semver applies to template
+   structure).
+
+2. **A Test plan in the PR description.** Even one-line typo fixes. Even
+   docs-only changes. The point is the muscle memory — you confirm to
+   yourself that you actually verified the change before asking a reviewer
+   to. For docs-only changes, "rendered the file on github.com — looks
+   correct" is a valid Test plan.
+
+3. **Squash-merge only, linear history.** No merge commits. No rebase
+   merges. Repo settings enforce squash-merge. `git log` reads like a
+   sequence of features, not a tangle
+   ([PRINCIPLES.md](docs/PRINCIPLES.md) #3).
+
+4. **CHANGELOG entry in the same PR as the change.** `CHANGELOG.md`
+   doesn't exist yet — it lands with the v1.0.0 public release. Until
+   then, the convention is git-log-driven; once the file exists, this
+   rule applies per [PRINCIPLES.md](docs/PRINCIPLES.md) #9.
+
+## Cross-repo coordination: `ci/lib/`
+
+Files in `ci/lib/` (today: `ci/lib/resolve-dist-cert-sha.sh` and
+`ci/lib/SHA256SUMS`) are SHA-pinned. They are byte-identical with the
+same files in downstream consumer repos derived from this template.
+`ci/local-check.sh`'s `verify_helpers_in_sync` step verifies the
+`SHA256SUMS` match on every run; drift is a CI failure, not a warning
+([PRINCIPLES.md](docs/PRINCIPLES.md) #5).
+
+If your PR modifies anything under `ci/lib/`:
+
+1. Call it out clearly in the PR description.
+2. Regenerate the hashes:
+   ```bash
+   shasum -a 256 ci/lib/*.sh > ci/lib/SHA256SUMS
+   ```
+3. Expect the maintainer to coordinate the rollout — the same
+   byte-identical change must land in every downstream consumer repo
+   derived from this template in the same release cycle. This is why
+   `ci/lib/` changes are slower than other PRs. It's not a bottleneck
+   imposed for fun; it's the cost of keeping the shared helpers actually
+   shared.
+
+## Code of Conduct
+
+By participating in this project, you agree to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md). This project adopts the
+Contributor Covenant 2.1 verbatim — no edits, no custom carve-outs
+([PRINCIPLES.md](docs/PRINCIPLES.md) #18).
+
+## Style notes
+
+The full operating manual is [docs/PRINCIPLES.md](docs/PRINCIPLES.md)
+(24 rules). The ones a contributor will hit on day one:
+
+- **Every script has a "why" header comment** (rule 6) — explain the
+  constraint, the incident, or the gotcha that justified writing the
+  script. The *what* is in the code; the *why* belongs at the top.
+- **README answers what / why / how in the first 50 lines** (rule 7) —
+  beyond that is reference material. A reader should know if this
+  template is for them without scrolling.
+- **Non-obvious patterns get a "Why this exists" section** (rule 8) —
+  both in source comments AND in the README. If you remove the pattern,
+  you remove its explanation too.
+- **No secrets in any committed file, ever** (rule 13). `.env*`, `*.p8`,
+  `*.pem`, and `*.mobileprovision` are gitignored. If you're adding a
+  new secret-shaped file, add the pattern to `.gitignore` in the same
+  PR.
+
+## Discussing before opening a PR
+
+For larger changes — anything touching `ci/lib/`, the release pipeline,
+the renaming script (when it lands), or the public template "API"
+(directory layout, script names, Makefile targets) — open a [GitHub
+issue](https://github.com/indiagrams/ios-macos-template/issues) first.
+We'll discuss the shape before you spend time on the implementation.
+
+(Issue templates are coming in a near-term update; for now, free-form is fine.)
+
+## Response time
+
+Issues and PRs get a first response within ~7 days
+([PRINCIPLES.md](docs/PRINCIPLES.md) #23). That might be "looking at
+it", "let's iterate on the approach", or "this isn't the right fit,
+here's why" — acknowledgement, not resolution. We don't promise
+resolution timelines; we do promise we won't ghost you.


### PR DESCRIPTION
## Summary
- Add `CONTRIBUTING.md` (143 lines) at repo root: fork→branch→`make check`→PR flow, the 3 CI job names byte-identical with `pr.yml`, `ci/lib/` cross-repo coordination explained without naming downstream consumer repos, ~7-day first-response, links to CoC + `docs/PRINCIPLES.md`.
- Add `CODE_OF_CONDUCT.md` (85 lines) at repo root: Contributor Covenant 2.1 verbatim per `docs/PRINCIPLES.md` #18 ("verbatim, no edits, no carve-outs"). Fetched from `contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md`. `[INSERT CONTACT METHOD]` substituted with `jpraju@gmail.com` (maintainer's public email — already on GitHub profile).
- M1 P2 prerequisite for the public-flip (M5 P3). With this merged, GitHub's Community Standards health check should detect both files alongside the LICENSE landed in PR #2.

## Test plan
- [x] Local: 13/13 must_haves verified by `gsd-verifier` (`02-VERIFICATION.md`)
- [x] Local: 5/5 UAT tests claude-verified by `/gsd-verify-work 2` (`02-UAT.md`) — file structure, tone/no-emojis, CC2.1 verbatim integrity, contact substitution, atomic-commit hygiene
- [x] Local: 3 CI job names in `CONTRIBUTING.md` byte-identical with `.github/workflows/pr.yml` (verified: `app (iOS device)`, `app (iOS Simulator)`, `app (macOS)`)
- [x] Local: portable consumer-repo leak check returns 0 leaks — only `indiagrams/ios-macos-template` self-reference present
- [x] Local: `[INSERT CONTACT METHOD]` placeholder is gone from CoC; `jpraju@gmail.com` present in Enforcement section
- [ ] CI: 3 build jobs green (`app (iOS device)`, `app (iOS Simulator)`, `app (macOS)`) — automatic; this PR adds 2 root-level Markdown files only, no source-code touched
- [ ] After merge: GitHub `/community` health-check tab flips Code of Conduct + Contributing from missing → detected
- Deferred to M5 P3: Code of Conduct + Contributing badges visible on the public repo home page once the visibility flip lands

## Notes
- Two atomic commits (`3764808` CONTRIBUTING, `ab344ad` CoC), one file each. Working tree's 6 pre-existing unstaged edits + untracked `docs/` preserved throughout.
- Plan-side defects caught and recorded for follow-up: PCRE-lookahead-on-BSD-grep (fixed iteration 1), CoC line-count band miscalibration (the canonical CC 2.1 is 85 lines unwrapped — plan assumed 100-160 wrapped), CC2.1 canonical URL drift (plan used `.../code_of_conduct.md`; current path is `.../code_of_conduct/code_of_conduct.md`).
- One follow-on flagged for M3 P1 (`bin/rename.sh`) in `02-SECURITY.md`: the rename script must substitute `jpraju@gmail.com` in `CODE_OF_CONDUCT.md` so forkers don't inherit the template maintainer as their CoC enforcement contact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)