### PR TITLE
docs: add issue + PR templates — M1 P3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,67 @@
+---
+name: Bug report
+about: Report a bug in the template scaffolding (build, CI, fastlane, scripts)
+title: '[BUG] '
+labels: [bug]
+assignees: []
+---
+
+<!--
+Thanks for taking the time to file a bug. The template only gets better
+when sharp edges get reported. The sections below help us reproduce what
+you hit; please fill in what you can — partial reports are fine, we'll
+ask follow-ups in the thread.
+
+PRINCIPLES.md #19: bug reports without reproduction steps don't get
+closed — they get a gentle nudge back to the template. The form exists
+to help you write a useful issue, not to gate participation.
+-->
+
+## What's broken
+
+<!-- One or two sentences. What did you try to do, and what went wrong? -->
+
+## Steps to reproduce
+
+<!-- Numbered list, ideally a minimal repro. The smaller the example, the faster the fix. -->
+
+1.
+2.
+3.
+
+## Expected vs actual
+
+<!-- What you expected to happen, and what actually happened. -->
+
+**Expected:**
+
+**Actual:**
+
+## Environment
+
+<!-- Fill in what applies. Template version = the commit SHA or tag you cloned from. -->
+
+- macOS version:
+- Xcode version (`xcodebuild -version`):
+- Device / simulator (if relevant):
+- Template version (commit SHA or tag):
+
+## Logs / output
+
+<!-- Paste the relevant output inside the fenced block below. `make check` failures, `xcodebuild` errors, fastlane traces, etc. Trim to the relevant lines if it's long. -->
+
+```
+<paste here>
+```
+
+## Anything you've already tried
+
+<!-- Optional but useful — saves us from suggesting things you've already ruled out. -->
+
+-
+
+## Checklist before submitting
+
+- [ ] I've searched existing issues for duplicates.
+- [ ] I've read [CONTRIBUTING.md](../../CONTRIBUTING.md).
+- [ ] I'm running `make check` locally and the failure reproduces.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,43 @@
+---
+name: Feature request
+about: Suggest an enhancement to the template (new gotcha documented, new helper script, new CI job)
+title: '[FEATURE] '
+labels: [enhancement]
+assignees: []
+---
+
+<!--
+Thanks for proposing an enhancement. Before filling this in, skim
+docs/PRINCIPLES.md — the template is intentionally small and opinionated,
+and the "Tone" section explains what we say yes to and what we don't.
+
+PRINCIPLES.md #19: feature requests without a use case don't get closed —
+they get a gentle nudge back to the template. The form exists to help you
+write a useful proposal, not to gate participation.
+-->
+
+## Use case
+
+<!-- What problem does this solve? Who hits it? Concrete is better than abstract — a short anecdote of the friction beats a generic "it would be nice if". -->
+
+## Proposed solution
+
+<!-- What does the change look like? A rough sketch is fine — file paths, command names, or pseudocode. We'll iterate on details in the thread. -->
+
+## Alternatives considered
+
+<!-- Other ways to solve this problem you thought about and ruled out, and why. Helps us avoid suggesting them in review. -->
+
+-
+
+## The 3 questions
+
+<!-- From docs/PRINCIPLES.md "Tone" section. The template is small on purpose; these are the filter. Answering "yes" to all three is the bar for a feature being a good fit — answering "no" or "I'm not sure" to any is the signal that the proposal probably wants more discussion before code. -->
+
+- [ ] Does this fix a sharp edge a stranger would hit?
+- [ ] Does it preserve the "5-minute clone-to-first-build" promise?
+- [ ] Does it generalize, or is it specific to your project?
+
+## Anything else
+
+<!-- Context, screenshots, links to upstream issues (Apple Feedback, fastlane GitHub, xcodegen GitHub), prior art in similar templates, etc. Optional. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+<!--
+PRINCIPLES.md #20: every PR has a Test plan. Even docs-only PRs. Even
+single-character typo fixes. "Verified the typo is fixed" is a valid
+Test plan — the point is the muscle memory.
+
+Replace the placeholder bullets below with the real Summary + Test plan
+for your change. Delete this comment if you like; it doesn't render in
+the rendered PR body either way.
+-->
+
+## Summary
+
+-
+-
+-
+
+## Test plan
+
+- [ ] Local: `make check` green
+- [ ] CI: 3 build jobs green (`app (iOS device)`, `app (iOS Simulator)`, `app (macOS)`) — automatic
+- [ ]


### PR DESCRIPTION
## Summary
- Add `.github/ISSUE_TEMPLATE/bug_report.md` (67 lines) — frontmatter (name/about/title/labels) + 7 body sections (broken / repro / expected-vs-actual / environment / logs / tried / checklist). Tone matches PRINCIPLES.md #19 (gentle redirection, not gating).
- Add `.github/ISSUE_TEMPLATE/feature_request.md` (43 lines) — 5 body sections including the 3 PRINCIPLES.md "Tone" questions verbatim (byte-identical with `docs/PRINCIPLES.md` lines 117-119, verified via `diff`).
- Add `.github/pull_request_template.md` (21 lines) — `## Summary` + `## Test plan` mirroring the format used by PRs #2/#3/#4. CI-jobs line byte-pinned to `.github/workflows/pr.yml` job names via plan-time `diff` cross-check.
- M1 P3 prerequisite for the public-flip. Companion to the LICENSE (PR #2), CONTRIBUTING.md + CoC (PR #4) work landed earlier this session.

## Test plan
- [x] Local: 21/21 automated must_haves verified by `gsd-verifier` (`03-VERIFICATION.md`)
- [x] Local: 5/5 UAT tests claude-verified by `/gsd-verify-work 3` (`03-UAT.md`) — frontmatter parseability, body-section coverage, 3 "Tone" questions byte-identity, CI-jobs `diff` against pr.yml, atomic-commit hygiene
- [x] Local: emoji scan over U+1F000-U+1FFFF + U+2600-U+27BF returns 0 matches in all 3 templates
- [x] Local: no `🤖 Generated with [Claude Code]` footer in PR template (that scaffolding stays Claude-Code-specific for individual PR descriptions, not the human-facing template)
- [x] Local: `assignees: []` empty in both issue templates — opening an issue does NOT auto-disclose the maintainer's GitHub handle
- [ ] CI: 3 build jobs green (`app (iOS device)`, `app (iOS Simulator)`, `app (macOS)`) — automatic
- [ ] After merge — Issue picker rendering: `https://github.com/indiagrams/ios-macos-template/issues/new/choose` shows both Bug report + Feature request cards
- [ ] After merge — PR auto-prefill: opening the NEXT PR against main (after this one merges) auto-injects the `pull_request_template.md` body. (This PR is set via `gh pr create --body`, so its description is explicit; the auto-prefill behavior will be observable on the next PR after #5 lands.)
- [ ] After merge — `https://github.com/indiagrams/ios-macos-template/community` health-check flips Issue templates + Pull request template from missing → detected

## Notes
- 3 atomic commits (`6635e10` bug_report, `61b5ebf` feature_request, `639dcd8` pull_request_template), one file each. Working tree's 6 pre-existing unstaged edits + untracked `docs/` preserved throughout.
- One operational concern flagged for M3 P1 (`bin/rename.sh`) in `03-SECURITY.md`: the rename script must substitute the 3 `app (...)` strings in `pull_request_template.md` if a forker renames their CI jobs, OR document explicitly that template-string updates are forker-side. Joins the existing M3 P1 follow-on (CoC contact email substitution) flagged in `02-SECURITY.md`.
- Markdown templates (`.md`), not YAML issue forms (`.yml`) — per ROADMAP. PRINCIPLES.md #19 favors friendly help over strict gating; `.md` is the friendlier shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)