### PR TITLE
docs: rewrite README for external readers — M1 P4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,29 @@
 # ios-macos-template
 
+[![CI](https://github.com/indiagrams/ios-macos-template/actions/workflows/pr.yml/badge.svg)](https://github.com/indiagrams/ios-macos-template/actions/workflows/pr.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Swift 5.9](https://img.shields.io/badge/Swift-5.9-orange.svg)](https://swift.org)
+
 Boilerplate for iOS + macOS apps in the Indiagrams house style.
-Distilled from [PrivateClaw](https://github.com/indiagrams/PrivateClaw) and
-[AnchorKey](https://github.com/indiagrams/AnchorKey) — same XcodeGen layout,
-same fastlane release pipeline, same App Store submission tooling.
+Distilled from production iOS + macOS apps shipping under the indiagrams
+org — same XcodeGen layout, same fastlane release pipeline, same App Store
+submission tooling.
+
+## Why this template
+
+- **XcodeGen-driven project file.** No `.xcodeproj` committed. The project
+  source-of-truth is `app/project.yml`; `xcodegen generate` materializes the
+  Xcode bundle. Diffs stay clean and merge conflicts on the project file
+  disappear.
+- **Lefthook pre-push gate.** `ci/local-check.sh --fast` (an unsigned iOS
+  device build) runs locally before every `git push`. CI on GitHub is a
+  confirmation, not a discovery channel — broken builds don't reach `main`'s
+  PR queue.
+- **Signed fastlane releases run locally, not in CI.** Apple cert
+  provisioning in GitHub Actions is hard, project-specific, and fragile.
+  `fastlane release tag:vX.Y.Z` runs from your laptop with the certs already
+  in your login Keychain. The pattern is documented (see "Setting up signing
+  + ASC" below); the CI burden is not adopted.
 
 What you get out of the box:
 
@@ -160,8 +180,8 @@ fastlane mac upload_screenshots
 
 ## Why these specific patterns
 
-These are not invented — they're hard-won from PrivateClaw (1.0 shipped) and
-AnchorKey (currently in TestFlight v0.0.11). Specific gotchas baked in:
+These are not invented — they're hard-won from real production iOS + macOS
+shipping pipelines. Specific gotchas baked in:
 
 - **iOS device build, not Simulator, as primary CI signal** — Simulator green
   with device red happens often (xcframework slice missing, entitlements
@@ -225,4 +245,4 @@ to match — the names must match the job `name:` attribute exactly.
 
 ## License
 
-Internal Indiagrams template. Not for external distribution.
+MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
- Drop the `Internal Indiagrams template. Not for external distribution.` footer (line 228 of pre-PR README).
- Add 3 clickable badges at the top: CI (GitHub Actions `pr.yml`), License: MIT (shields.io → `LICENSE`), Swift 5.9 (shields.io → `swift.org`). Swift version sourced from `app/project.yml:20` at execute-time.
- Add `## Why this template` section (3 bullets — XcodeGen-driven project file, lefthook pre-push gate, signed fastlane releases run locally not in CI). Section sits between the tagline paragraph and `What you get out of the box:`.
- Replace the existing `## License` body (which used to be the dropped footer) with `MIT — see [LICENSE](LICENSE).`.
- Fold in pre-existing unstaged README edits that scrubbed `PrivateClaw` / `AnchorKey` private-repo references in the tagline + "Why these specific patterns" intro (those edits had been carried untouched through PRs #2-5; M1 P4 was their natural home).
- M1 P4 is the **last M1 phase** — closes "external-facing scaffolding."

## Test plan
- [x] Local: 10/10 automated must_haves verified by `gsd-verifier` (`04-VERIFICATION.md`, status: `human_needed` — only the GitHub-render check is deferred)
- [x] Local: 9/9 UAT tests claude-verified by `/gsd-verify-work 4` (`04-UAT.md`) — footer drop, 3 badges, exactly 3 Why bullets, PRINCIPLES.md #7 fold, drift guards, no emojis, atomic-commit hygiene, tone match
- [x] Local: PRINCIPLES.md #7 satisfied — `head -50 README.md` includes H1 + 3 badges + Why H2 + start of "What you get out of the box" / Quickstart fenced block
- [x] Local: 8 existing major sections preserved (Quickstart, Renaming the stub, Setting up signing + ASC, Repo layout, Common workflows, Why these specific patterns, GitHub configuration, License)
- [x] Local: Swift `5.9` cross-checked against `app/project.yml:20` at execute-time
- [ ] CI: 3 build jobs green (`app (iOS device)`, `app (iOS Simulator)`, `app (macOS)`) — automatic; this PR modifies only README.md so no source-code touched
- [ ] After merge — README renders cleanly on github.com (the explicit ROADMAP M1 P4 test): visit the repo home page, confirm CI badge shows "passing", License badge resolves via shields.io, Swift 5.9 badge resolves via shields.io, em-dashes render correctly, no orphan link references
- [ ] After merge — Community Standards `/community` health check: README detection still positive (re-confirms the new content didn't break the existing detection)

## Notes
- One atomic commit (`eb7735d`), README.md only. Working tree's 5 pre-existing unstaged ci/fastlane edits + untracked `docs/` preserved throughout (still pending — likely M2 / planning scratch).
- One follow-on flagged in `04-SECURITY.md` for M3 P1 (`bin/rename.sh`): the rename script must substitute the `indiagrams/ios-macos-template` slug in the README CI badge URL. This joins the existing M3 P1 substitution list (bundle ID + CoC contact email + PR-template CI-job names) — total 4 targets the rename script must hit.
- The lower-case "indiagrams" / "Indiagrams house style" mentions still in the tagline are out of scope for M1 P4 — deeper de-org work is M2.

## After this lands
- `/gsd-complete-milestone` — archive M1
- `/gsd-new-milestone` — start M2 (de-Indiagrams the stub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)