### PR TITLE
M2 P1: SECURITY.md + CoC enforcement-contact migration

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at jpraju@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at maintainers@indiagram.com. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,83 @@
+# Security Policy
+
+This policy covers `ios-macos-template` itself — the build, release, and CI
+scaffolding that downstream consumer apps inherit. Apps derived from this
+template ship their own `SECURITY.md` and own their own disclosure process;
+this file is for vulnerabilities in the template's scaffolding, not in any
+particular fork built on top of it.
+
+## Reporting a Vulnerability
+
+Email: **maintainers@indiagram.com**
+
+Do NOT open a public GitHub issue for security bugs. Public issues are for
+non-security bugs and feature requests; for vulnerabilities, the email
+inbox is the only supported channel.
+
+We aim to acknowledge new reports within ~7 days — same response window as
+[`CONTRIBUTING.md`](CONTRIBUTING.md) and [`docs/PRINCIPLES.md`](docs/PRINCIPLES.md)
+#23. Acknowledgement, not resolution: the first reply confirms we have the
+report and are looking at it. Fix and release follow on their own timeline.
+
+We follow a 90-day coordinated-disclosure window. We target a fix and a
+release within 90 days of the initial report. After that window, the
+reporter is free to publish their findings regardless of the fix status.
+
+If the issue affects a downstream consumer app derived from this template
+(and not the template itself), please report to that app's maintainers
+instead — see "Out of Scope" below.
+
+A useful report includes:
+
+- A reproduction recipe — the exact commands or steps that trigger the
+  issue.
+- The affected file path or script (`ci/local-check.sh`, the `Fastfile`,
+  a workflow under `.github/workflows/`, etc.).
+- The impact you observed — what could an attacker do, on which surface.
+
+Keep it short. This is guidance, not a gating questionnaire.
+
+## In Scope
+
+This policy covers the template scaffolding itself:
+
+- Build configuration: `app/project.yml`, `Brewfile`, `Gemfile`, `Makefile`,
+  `lefthook.yml`.
+- CI workflows: `.github/workflows/`, the 3 PR jobs (`app (iOS device)`,
+  `app (iOS Simulator)`, `app (macOS)`).
+- Release scripts: `bin/`, `ci/`, `fastlane/` — including
+  `ci/local-check.sh`, `ci/local-release-check.sh`, `ci/lib/*.sh`, the
+  fastlane `Fastfile`, and helper tools.
+- The stub `HelloApp` (iOS + macOS), insofar as it exercises the
+  build/release pipeline. Bugs in the stub that demonstrate a flaw in the
+  template's scaffolding count; bugs in features a forker has added on top
+  of the stub do not.
+
+## Out of Scope
+
+Three categories of report belong elsewhere:
+
+- **Consumer apps derived from this template.** If you found a vulnerability
+  in an app built on top of this template, report it to that project's
+  maintainers — they own their own `SECURITY.md`. We do not have visibility
+  into how the template has been customized downstream.
+- **Third-party dependencies.** Vulnerabilities in XcodeGen, fastlane,
+  lefthook, GitHub Actions, or any other tool this template invokes should
+  be reported upstream to the owning project. We track Dependabot bumps for
+  `.github/workflows/` automatically (`docs/PRINCIPLES.md` #15) but we are
+  not the right inbox for upstream issues.
+- **Apple-platform vulnerabilities.** Bugs in iOS, macOS, Xcode, the
+  Simulator, codesign, App Store Connect, or any first-party Apple service
+  go to Apple's product security team — see
+  https://security.apple.com.
+
+## Supported Versions
+
+This template is currently pre-1.0 and private. There is no formal support
+window yet. Vulnerabilities are still in scope under this policy and will
+be triaged on a best-effort basis.
+
+Once `v1.0.0` is tagged and the repo is flipped public (planned for the M5
+milestone), this policy will apply to the latest released version of the
+template. Older tagged versions may receive fixes at maintainer discretion;
+upgrade to the latest is the supported path.


### PR DESCRIPTION
## Summary

**M2 Phase 1: SECURITY.md + CoC enforcement-contact migration**
**Goal (ROADMAP M2 P1):** Add `SECURITY.md` at repo root with PRINCIPLES.md #14 vulnerability-disclosure policy. Disclosure channel: `maintainers@indiagram.com`. 90-day coordinated-disclosure window. Migrate `CODE_OF_CONDUCT.md` enforcement contact to the role alias for "single maintainer inbox" consistency.
**Status:** Verified ✓ (9/9 automated must_haves; 1 deferred to post-merge GitHub-side render)

This phase closes the last public-repo file-set gap before M2's de-Indiagrams work begins (P2 onward). Both files now route to `maintainers@indiagram.com` — a Gmail "Send mail as" alias under display name "Indiagram Maintainers", set up specifically for this phase. Role alias chosen for industry convention, bus-factor resilience, and triage hygiene.

## Changes

### Plan 01-01 Task 1: Add `SECURITY.md`
- **New:** `SECURITY.md` (83 lines, atomic commit `56bc258`)
- `# Security Policy` H1; 4 H2 sections: `Reporting a Vulnerability`, `In Scope`, `Out of Scope`, `Supported Versions`
- Disclosure channel: `maintainers@indiagram.com` (forbids public-issue reports for security bugs)
- 90-day coordinated-disclosure window + ~7-day acknowledgement (PRINCIPLES.md #14 + #23)
- In-scope: template scaffolding (build/release/CI/scripts). Out-of-scope: consumer-app vulnerabilities (their own concern), third-party deps (report upstream), Apple platform (referral to `https://security.apple.com`)

### Plan 01-01 Task 2: Migrate CoC enforcement contact
- **Modified:** `CODE_OF_CONDUCT.md` line 40 only (atomic commit `07e8c55`, line count unchanged at 85)
- Single-line BSD-portable `sed -i ''` substitution replacing the prior maintainer contact with `maintainers@indiagram.com`
- PRINCIPLES.md #18 verbatim rule preserved — the Covenant template's `[INSERT CONTACT METHOD]` placeholder slot is explicitly designed to be filled with the maintainer's contact, so updating that contact is consistent with #18, not a violation. `git show --stat 07e8c55` reports `1 insertion(+), 1 deletion(-)` — substitution-as-line-replacement footprint, no Covenant text body edited.

## Verification

- [x] **Automated:** 9/9 must_haves verified by gsd-verifier
- [x] **UAT:** 8/8 tests claude-verified — file structure, required-prose checks, no-emojis tone match, CoC migration integrity, M1 artifacts intact, atomic-commit hygiene, PRINCIPLES.md #18 verbatim rule preserved
- [x] **Plan-checker:** passed iteration 1 with no issues
- [x] **Threat model:** empty STRIDE register; 1 accepted-risk entry recorded for the maintainer-alias disclosure (improvement over prior contact-disclosure pattern via role address)
- [x] **Nyquist coverage:** vacuously compliant (docs phase, no code surface)
- [ ] **CI:** 3 build jobs green (`app (iOS device)`, `app (iOS Simulator)`, `app (macOS)`) — automatic
- [ ] **After merge:** GitHub `/security/policy` page renders cleanly with H1 + all 4 H2 sections + working LICENSE + security.apple.com links + `maintainers@indiagram.com` visible
- [ ] **After merge:** Community Standards `/community` health check flips Security Policy from missing → detected

## Key Decisions

- **Disclosure channel = role alias.** Industry convention (`security@`, `maintainers@`), bus-factor resilience (re-routable at email provider without rewriting committed files), triage hygiene (separate inbox SLA from CoC + general project mail).
- **CoC migration folded into the same PR.** Single atomic merge ships both files with consistent contact rather than splitting into two PRs. CC2.1 verbatim rule preserved (only the contact-placeholder slot was filled, no Covenant body edits).
- **GitHub Private Vulnerability Reporting deferred to chore PR.** Mirrors M1's chore PR #3 (`allow_auto_merge`) pattern: enable PVR via `gh api -X PATCH` + add the same toggle to `bin/setup-github.sh` so consumer repos inherit + update SECURITY.md to mention PVR as alternative channel. Single chore PR after this one merges.

## Working-Tree Note

5 pre-existing unstaged `ci/*` + `fastlane/Fastfile` edits + untracked `docs/` are intentionally preserved (carried untouched since session start through 6 prior PRs). They predate this phase; both Phase 1 commits used pathspec to avoid sweeping them in. Working tree post-execution is byte-identical with pre-execution state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)