### PR TITLE
chore(ci): scrub cross-repo references in resolve-dist-cert-sha.sh + sibling files

### DIFF
--- a/ci/gen-macos-icons.swift
+++ b/ci/gen-macos-icons.swift
@@ -157,7 +157,7 @@ let slots: [Slot] = [
 // Render to a temp .iconset directory (used by iconutil), and copy each PNG
 // into the .appiconset directory so the asset catalog stays in sync.
 let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory())
-  .appendingPathComponent("anchorkey-iconset-\(ProcessInfo.processInfo.processIdentifier)")
+  .appendingPathComponent("appicon-iconset-\(ProcessInfo.processInfo.processIdentifier)")
 let iconsetDir = tmpDir.appendingPathComponent("AppIcon.iconset")
 try? FileManager.default.removeItem(at: tmpDir)
 try FileManager.default.createDirectory(at: iconsetDir, withIntermediateDirectories: true)

--- a/ci/lib/SHA256SUMS
+++ b/ci/lib/SHA256SUMS
@@ -1,1 +1,1 @@
-788be2b481a67297414790b7602ec1b382f9517e57488097d34d7c36e5e24bb5  ci/lib/resolve-dist-cert-sha.sh
+5318197716d59030871402577b8da7f66b985fccf346bdc6324bda489d7cf8f6  ci/lib/resolve-dist-cert-sha.sh

--- a/ci/lib/resolve-dist-cert-sha.sh
+++ b/ci/lib/resolve-dist-cert-sha.sh
@@ -1,20 +1,23 @@
-# Apple Distribution cert SHA-1 resolver — shared across indiagrams release pipelines.
+# Apple Distribution cert SHA-1 resolver — shared across release pipelines.
 #
-# DO NOT EDIT DIVERGENTLY. Identical copies live in:
-#   - github.com/indiagrams/PrivateClaw  ci/lib/resolve-dist-cert-sha.sh
-#   - github.com/indiagrams/AnchorKey    ci/lib/resolve-dist-cert-sha.sh
+# DO NOT EDIT DIVERGENTLY. Byte-identical copies live in this template and in
+# downstream consumer projects that derive from it. Each project pins this
+# file's SHA-256 in its own `ci/lib/SHA256SUMS`; ci/local-check.sh fails the
+# build if the local copy drifts from the pinned hash.
 #
-# Any new project signing for Apple Developer team A26TJZ8QHQ should copy this
-# file as-is. When you change one project's copy, update the other(s) in the
-# same release cycle. `make verify-helpers-in-sync` (in each repo) compares
-# the local copy against a canonical SHA-256 — CI fails if they drift.
+# When you change one project's copy, propagate the same edit to every other
+# project that consumes it within the same release cycle — otherwise the
+# consumer projects' next CI run will fail until they update.
+#
+# Any new project signing for an Apple Developer team can copy this file
+# as-is and adopt the same `verify_helpers_in_sync` check pattern.
 #
 # WHY THIS EXISTS
 # ---------------
 # The `Apple Distribution: <name> (<team-id>)` common name is shared across
 # every Apple Distribution cert issued to that team. When a developer machine
-# carries certs for multiple apps (e.g. PrivateClaw + AnchorKey under the same
-# personal team), `codesign --sign "Apple Distribution"` and exportArchive's
+# carries certs for multiple apps under the same team,
+# `codesign --sign "Apple Distribution"` and exportArchive's
 # `signingCertificate: "Apple Distribution"` both become ambiguous and pick
 # one randomly. Symptoms:
 #   - exportArchive: "Provisioning profile X doesn't include signing

--- a/ci/local-check.sh
+++ b/ci/local-check.sh
@@ -43,8 +43,9 @@ require_cmd() {
 }
 
 # Verify shared release helpers (ci/lib/) match their pinned SHA-256s.
-# Identical copies live in indiagrams/PrivateClaw + indiagrams/AnchorKey + this
-# template. Drift would silently re-introduce per-project divergence.
+# Identical copies live in this template and downstream consumer projects.
+# Drift would silently re-introduce per-project divergence — the exact
+# problem the lib was created to prevent.
 verify_helpers_in_sync() {
   if [ ! -f ci/lib/SHA256SUMS ] || [ ! -d ci/lib ]; then
     fail "ci/lib/SHA256SUMS missing — shared helper integrity cannot be checked"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,7 +1,7 @@
 # fastlane/Fastfile
 #
-# iOS + macOS release pipeline. Modeled on indiagrams/PrivateClaw +
-# indiagrams/AnchorKey production pipelines.
+# iOS + macOS release pipeline. Modeled on production iOS + macOS shipping
+# pipelines used in real App Store submissions.
 #
 # Usage:
 #   set -a; source .env.local; set +a; fastlane release tag:v0.1.0


### PR DESCRIPTION
## Summary

Comment-only edits + `ci/lib/SHA256SUMS` regen. No behavior change. Restores the byte-identical invariant for `ci/lib/resolve-dist-cert-sha.sh` across this template and downstream consumer projects.

The same scrub already merged in:
- indiagrams/AnchorKey #25
- indiagrams/PrivateClaw #384

This PR closes the loop in the third repo.

## Files

| File | Change |
|---|---|
| `ci/lib/resolve-dist-cert-sha.sh` | Header + multi-app-team example scrubbed of explicit "PrivateClaw + AnchorKey" names |
| `ci/lib/SHA256SUMS` | Regenerated → `5318197716d59030...` (was `788be2b481a67297...`) — matches the new content |
| `ci/local-check.sh` | `verify_helpers_in_sync` comment scrubbed |
| `ci/gen-macos-icons.swift` | tmpdir name `anchorkey-iconset-*` → `appicon-iconset-*` (cosmetic) |
| `fastlane/Fastfile` | Header comment scrubbed |

## Why

This template is on its way to public visibility (planned M5). Naming private consumer repos in the public template would leak the inventory.

## Cross-repo coordination

After this lands, all three repos hash `resolve-dist-cert-sha.sh` to the same value (`5318197716d59030871402577b8da7f66b985fccf346bdc6324bda489d7cf8f6`) and the byte-identical SHA invariant is restored.

## Test plan

- [x] `make check` (iOS device build) green
- [x] `shasum -a 256 -c ci/lib/SHA256SUMS --quiet` passes
- [x] No semantic changes to any script — only comment edits + tmpdir rename
- [ ] CI: 3 jobs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)