### PR TITLE
M2 P2: Bundle IDs — io.indiagrams.helloapp → com.example.helloapp

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -25,8 +25,8 @@ ASC_API_KEY_ISSUER_ID=
 ASC_API_KEY_BASE64=
 
 # ─── Optional ─────────────────────────────────────────────────────────────────
-# Override the bundle ID used by ci/bump-asc-version.rb. Default: io.indiagrams.helloapp
-# APP_BUNDLE_ID=io.indiagrams.myapp
+# Override the bundle ID used by ci/bump-asc-version.rb. Default: com.example.helloapp
+# APP_BUNDLE_ID=com.example.myapp
 
 # Override the marketing version used by ci/local-release-check.sh.
 # Defaults to the version derived from the tag (v0.1.0 → 0.1.0).

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Run `make bootstrap` once after cloning. After that, `git push` runs
 # ci/local-check.sh --fast automatically via lefthook.
 #
-# The stub app is named "HelloApp" with bundle id "io.indiagrams.helloapp".
+# The stub app is named "HelloApp" with bundle id "com.example.helloapp".
 # Rename for your project: see README.md → "Renaming the stub".
 
 .PHONY: bootstrap check check-ios check-macos check-sim build generate icons screenshots release-dryrun setup-github phase-checklist milestone-checklist help

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The stub uses these names:
 | Token | Value |
 |---|---|
 | App name (scheme + product) | `HelloApp` |
-| Bundle ID | `io.indiagrams.helloapp` |
+| Bundle ID | `com.example.helloapp` |
 | Team ID | `TEAM_ID_PLACEHOLDER` (overridden via `.env.local`) |
 | Project file | `app/HelloApp.xcodeproj` |
 | IPA | `build/HelloApp-{ver}.ipa` |
@@ -70,14 +70,14 @@ To rename for your project, search-replace these tokens across the repo:
 ```bash
 # Pick three strings:
 #   APP_NAME    e.g. MyApp        (scheme + product)
-#   BUNDLE_ID   e.g. io.indiagrams.myapp
+#   BUNDLE_ID   e.g. com.example.myapp
 #   DISPLAY     e.g. "My App"     (Bundle Display Name)
 
 # 1. Strings in source/config files
 grep -rl "HelloApp" --exclude-dir=.git --exclude="*.png" . \
   | xargs sed -i '' 's/HelloApp/MyApp/g'
-grep -rl "io.indiagrams.helloapp" --exclude-dir=.git . \
-  | xargs sed -i '' 's/io.indiagrams.helloapp/io.indiagrams.myapp/g'
+grep -rl "com.example.helloapp" --exclude-dir=.git . \
+  | xargs sed -i '' 's/com.example.helloapp/com.example.myapp/g'
 
 # 2. File paths
 mv app/iOS/HelloApp.entitlements        app/iOS/MyApp.entitlements

--- a/app/project.yml
+++ b/app/project.yml
@@ -5,7 +5,7 @@
 name: HelloApp
 
 options:
-  bundleIdPrefix: io.indiagrams
+  bundleIdPrefix: com.example
   deploymentTarget:
     iOS: "17.0"
     macOS: "14.0"
@@ -56,7 +56,7 @@ targets:
         ITSAppUsesNonExemptEncryption: false
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: io.indiagrams.helloapp
+        PRODUCT_BUNDLE_IDENTIFIER: com.example.helloapp
         TARGETED_DEVICE_FAMILY: "1,2"           # iPhone + iPad
         SUPPORTS_MACCATALYST: NO
         CODE_SIGN_ENTITLEMENTS: iOS/HelloApp.entitlements
@@ -92,7 +92,7 @@ targets:
         ITSAppUsesNonExemptEncryption: false
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: io.indiagrams.helloapp
+        PRODUCT_BUNDLE_IDENTIFIER: com.example.helloapp
         CODE_SIGN_ENTITLEMENTS: macOS/HelloApp.entitlements
         # Suppress actool's auto-injection of CFBundleIconName=AppIcon. Empty
         # value = actool emits Assets.car as before but does not set the key,
@@ -121,7 +121,7 @@ targets:
       - path: UITests
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: io.indiagrams.helloapp.uitests
+        PRODUCT_BUNDLE_IDENTIFIER: com.example.helloapp.uitests
         TEST_TARGET_NAME: HelloApp-iOS
         GENERATE_INFOPLIST_FILE: YES
         # SnapshotHelper.swift uses raw NSURLConnection patterns that warn
@@ -138,7 +138,7 @@ targets:
       - path: MacOSUITests
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: io.indiagrams.helloapp.macuitests
+        PRODUCT_BUNDLE_IDENTIFIER: com.example.helloapp.macuitests
         TEST_TARGET_NAME: HelloApp-macOS
         GENERATE_INFOPLIST_FILE: YES
     dependencies:

--- a/ci/bump-asc-version.rb
+++ b/ci/bump-asc-version.rb
@@ -10,7 +10,7 @@
 # Idempotent: skips bump/attach steps that are already at the target.
 #
 # Configuration:
-#   APP_BUNDLE_ID env var — defaults to "io.indiagrams.helloapp" (rename for your
+#   APP_BUNDLE_ID env var — defaults to "com.example.helloapp" (rename for your
 #   project; see README.md → "Renaming the stub").
 
 require 'spaceship'
@@ -30,7 +30,7 @@ token = Spaceship::ConnectAPI::Token.create(
 )
 Spaceship::ConnectAPI.token = token
 
-bundle_id = ENV.fetch("APP_BUNDLE_ID", "io.indiagrams.helloapp")
+bundle_id = ENV.fetch("APP_BUNDLE_ID", "com.example.helloapp")
 app = Spaceship::ConnectAPI::App.find(bundle_id) \
   or abort "error: app #{bundle_id} not found on ASC"
 

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -4,7 +4,7 @@
 # for the macOS app (Universal Purchase) so deliver picks the right
 # AppStoreVersion via the platform: arg.
 
-app_identifier "io.indiagrams.helloapp"
+app_identifier "com.example.helloapp"
 
 # Apple ID + Team ID come from .env.local (gitignored).
 apple_id ENV["FASTLANE_APPLE_ID"] if ENV["FASTLANE_APPLE_ID"]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -36,7 +36,7 @@ default_platform(:ios)
 
 # ─── Shared helpers ───────────────────────────────────────────────────────────
 
-APP_IDENTIFIER     = "io.indiagrams.helloapp"
+APP_IDENTIFIER     = "com.example.helloapp"
 IOS_SCHEME         = "HelloApp-iOS"
 MACOS_SCHEME       = "HelloApp-macOS"
 IPA_NAME_PATTERN   = "HelloApp-%s.ipa"   # printf with version


### PR DESCRIPTION
## Summary

**M2 Phase 2: Bundle IDs** — rename canonical bundle ID from `io.indiagrams.helloapp` (Indiagrams-internal) to `com.example.helloapp` (public placeholder) across 7 files via 7 atomic single-file commits.
**Goal (ROADMAP M2 P2):** Substitute the bundle ID in `app/project.yml`, `fastlane/{Fastfile,Appfile}`, `ci/bump-asc-version.rb`, with `make check` green on iOS device + macOS as the test gate.
**Status:** Verified ✓ (10/10 must_haves, status: passed; non-vacuous Nyquist; 8/8 closure rituals done)

This is the **first phase with a load-bearing build gate** — `make check` × 3 platforms (iOS device, iOS Sim, macOS) ran end-to-end against the regenerated xcodeproj and exited 0. Build artifacts confirm: pbxproj contains 8× `PRODUCT_BUNDLE_IDENTIFIER = com.example.helloapp` (Debug+Release × 4 targets) with zero `io.indiagrams` residue.

## Changes

### 7 atomic single-file commits (in order)

| # | SHA | File | What changed |
|---|---|---|---|
| T1 | `d42c889` | `app/project.yml` | 5 sites: `bundleIdPrefix` line 8 + 4 `PRODUCT_BUNDLE_IDENTIFIER` (iOS, macOS, iOS UITests, macOS UITests) |
| T2 | `f8dc65b` | `fastlane/Fastfile` | Line 39 `APP_IDENTIFIER` constant |
| T3 | `e8601c8` | `fastlane/Appfile` | `app_identifier` directive |
| T4 | `050ffc4` | `ci/bump-asc-version.rb` | 2 sites: line 13 comment + line 33 `ENV.fetch` fallback default |
| T5 | `e663839` | `Makefile` | Line 6 header comment (added to scope post-cross-AI-review BLOCKER) |
| T6 | `cbbe9f5` | `.env.local.example` | 2 sites (added at executor checkpoint when T5's repo-wide sweep caught leftover refs) |
| T7 | `ac6160b` | `README.md` | 5 sites — stub-state table + rename procedure source/target placeholders (added at executor checkpoint) |

### Knock-on effect on M2 P5

README's starting-state bundle-ID references are already updated by T7. M2 P5 (the README rename procedure update phase) shrinks to "swap manual sed block for `bin/rename.sh` once M3 P1 ships."

## Verification

- [x] **Plan-checker:** passed iteration 1 of revision 1 + revision 2 (state-drift accommodation after PRs #8/#9/#10 landed mid-flight)
- [x] **Cross-AI plan review** (`/gsd-review --codex --gemini`): Codex flagged 3 BLOCKERs the in-house plan-checker missed (Makefile reference, rollback contract, SUMMARY-vs-WT-invariant); all 3 addressed in plan revision iteration 1 — see `.planning/phases/02-bundle-ids/02-REVIEWS.md`
- [x] **Code review** (`/gsd-code-review` standard depth): status `clean`, 0 critical / 0 warning / 0 info findings across the 7 modified files
- [x] **Goal-backward verification** (gsd-verifier): 10/10 must_haves verified against live tree, status: `passed`
- [x] **UAT** (`/gsd-verify-work 2`): 8/8 tests claude-verified
- [x] **Security audit** (`/gsd-secure-phase 2`): 9-entry STRIDE register all closed (6 mitigated + verified, 3 n/a); `threats_open: 0`
- [x] **Validation** (`/gsd-validate-phase 2`): `nyquist_compliant: true` substantively (first non-vacuous in this project) — 8 tasks × 2+ automated gates each
- [x] **Build gate**: `make check` (iOS device) + `make check-sim` (iOS Simulator) + `make check-macos` (macOS) all exit 0
- [x] **pbxproj content**: 8× `com.example.helloapp`, 0× `io.indiagrams`
- [x] **Repo-wide drift sweep**: empty (excluding `.planning/` and `.gitignore`)
- [x] **Atomic-commit hygiene**: 7/7 commits modify exactly 1 file each
- [x] **Author-identity hygiene**: all 7 commits stamped with the GitHub noreply alias
- [ ] **CI**: 3 build jobs green (`app (iOS device)`, `app (iOS Simulator)`, `app (macOS)`) — automatic on push

## Key Decisions

- **Bundle-ID rename is a breaking structural-API change** per PRINCIPLES.md #10 ("Semver applies to template structure"). Pre-1.0 (M5 P4) is the right time. To be recorded in CHANGELOG when M4 P3 lands.
- **`com.example.helloapp` chosen as the placeholder** (rather than e.g., `org.example.helloapp`) — matches Apple's reverse-DNS convention + the `com.example` prefix that's industry-standard for templates/examples.
- **`com.example.myapp` as the rename-target placeholder** in user-facing docs (`.env.local.example`, `README.md` rename procedure) — different slug from the canonical `helloapp` so users see "from helloapp to myapp" as the rename pattern.
- **Forkers using `gh repo create --template`** inherit `com.example.helloapp` directly. They MUST substitute their own bundle ID before App Store Connect submission. M3 P1's `bin/rename.sh` will automate this; until then the README rename procedure (now updated to start from `com.example.helloapp`) is the manual fallback.
- **Rollback contract** (`<rollback>` block in plan): on T8 failure, `git reset --mixed "$(cat /tmp/m2p2-pre-phase-head)"` rewinds the branch but preserves substitutions as un-staged diffs (no PR-history noise from revert commits). Did not fire in this run; build gate passed first try.

## Plan-revision history (for transparency on the audit trail)

This phase went through 2 plan revisions before execution:
- **Revision 1** (post `/gsd-review`): added Makefile to scope (Codex caught), defined explicit rollback contract (Codex caught), clarified SUMMARY.md vs WT-invariant interaction (Codex caught). Plan-checker verified the fixes; 6 tasks total.
- **Revision 2** (post state-drift): PRs #8/#9/#10 landed on main while phase was idle — `chore/scrub-cross-repo-references` (PR #9) committed the previously-unstaged ci/fastlane carryover the plan was carrying through. Plan was updated to drop the carryover-fold-in narrative from T2, change all working-tree-count assertions from `5` → `0` (clean tree), update rollback rationale.
- **Executor scope-extension** (post T5 sweep checkpoint): T5's repo-wide drift sweep found 2 additional files (`.env.local.example`, `README.md`) the planning pre-flight had missed. Orchestrator authorized Option A — extend scope with 2 atomic commits — preserving the "zero io.indiagrams residue" must_have without rolling back the 5 already-correct commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)