### PR TITLE
M2 P3: Marketing/support URLs — indiagram.com → example.com

### DIFF
--- a/fastlane/metadata/en-US/marketing_url.txt
+++ b/fastlane/metadata/en-US/marketing_url.txt
@@ -1,1 +1,1 @@
-https://indiagram.com
+https://example.com

--- a/fastlane/metadata/en-US/privacy_url.txt
+++ b/fastlane/metadata/en-US/privacy_url.txt
@@ -1,1 +1,1 @@
-https://indiagram.com/privacy
+https://example.com/privacy

--- a/fastlane/metadata/en-US/support_url.txt
+++ b/fastlane/metadata/en-US/support_url.txt
@@ -1,1 +1,1 @@
-https://indiagram.com/support
+https://example.com/support


### PR DESCRIPTION
## Summary

**Phase 3: Marketing/support URLs** — Substitute org-specific URLs `https://indiagram.com[/path]` → `https://example.com[/path]` in the 3 fastlane App Store metadata files. Status: verified ✓ (10/10 must-haves) + UAT ✓ (12/12) + SECURITY ✓ (12/12 STRIDE entries closed) + VALIDATION ✓ (Nyquist substantive, 8 gates green under adversarial re-execution).

`example.com` is RFC-2606 §3 reserved-for-documentation — the public-template-friendly placeholder. Forkers replace via `bin/rename.sh` (M3 P1) before real ASC submission.

## Changes

3 atomic single-file commits, one per metadata file:

| Commit | File | New value |
|---|---|---|
| `c5396ef` | `fastlane/metadata/en-US/marketing_url.txt` | `https://example.com` |
| `a117e2e` | `fastlane/metadata/en-US/privacy_url.txt` | `https://example.com/privacy` |
| `fe123b5` | `fastlane/metadata/en-US/support_url.txt` | `https://example.com/support` |

## Test plan

- [x] All 3 metadata files contain expected `https://example.com[/path]` URLs (`cat` × 3)
- [x] Repo-wide URL drift sweep returns empty: `git grep -lE 'https://indiagram\.com' -- ':!.planning' ':!.gitignore'` (LOW-10 form per cross-AI review)
- [x] Intentional refs preserved (substitution didn't overshoot):
  - [x] `maintainers@indiagram.com` (email alias) still in `CODE_OF_CONDUCT.md` and `SECURITY.md`
  - [x] `indiagrams/ios-macos-template` (org slug) still in `README.md` (×2)
- [x] β file-backed URI::HTTPS validation passes — `ruby -e 'require "uri"; ... URI.parse(File.read(path).strip).is_a?(URI::HTTPS) && uri.host'` × 3 files
- [x] α (`fastlane ios upload_metadata`) hit Case A3 (ASC env vars unset on dev box → fastlane fails fast at `app_store_connect_api_key`); accepted via option (b). Real deliver-side ASC validation deferred to forker's first real release per T-03-07 RFC-2606 placeholder framing
- [x] 3 atomic single-file commits (each `git log -1 --name-only` shows exactly 1 file)
- [x] Working tree clean before/between/after every commit
- [x] CI: 3 build jobs (`app (iOS device)`, `app (iOS Simulator)`, `app (macOS)`) — verifying on this PR

## Plan iterations

This plan went through 4 iterations + cross-AI peer review:
- **Iteration 1** (in-house plan-check): caught BLOCKER — original gate `fastlane release tag:v0.0.0 skip_upload:true skip_tag:true` never invoked `deliver` (the `release` lane only calls `pilot` for TestFlight, not `deliver` for metadata)
- **Iteration 2:** swapped to `fastlane ios upload_metadata` (which does call `deliver`); caught BLOCKER — the corrected gate is side-effecting (`skip_metadata: false, force: true` would push placeholder metadata to ASC if creds + real app exist)
- **Iteration 3:** added 3-layer env-var preflight guard (env override / TTY check / typed phrase confirmation)
- **Iteration 4** (post-cross-AI Gemini + Codex review): fixed 5 HIGH concerns the in-house process missed — zsh-vs-Bash `${PIPESTATUS[0]}` (wrap T4 in `bash -euo pipefail` heredoc), β was tautology over hardcoded constants (rewrote to read files), `read -r` non-interactive-safe (`/dev/tty` + exact-phrase confirmation), `/tmp` marker fragility (moved to `.planning/tmp/` + ancestor + lineage check), softened deliver-validation-ordering claim

5-case classifier (A1 → A_MIXED → A3 → A2 → A4) ran under bash heredoc on this workspace's `/bin/zsh` outer shell; HIGH-1 fix verified at execution time.