### PR TITLE
M2 P5: Indiagrams narrative-prose scrub — final M2 phase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help:
 	@echo "  icons            Regenerate macOS AppIcon.iconset + AppIcon.icns from 1024 source"
 	@echo "  screenshots      Capture App Store screenshots (iOS + macOS) to fastlane/screenshots/"
 	@echo "  release-dryrun   fastlane release tag:v0.0.0 skip_upload:true skip_tag:true"
-	@echo "  setup-github     Apply Indiagrams house-style branch protection to current repo"
+	@echo "  setup-github     Apply branch protection settings to current repo"
 	@echo "  phase-checklist  Print the GSD canonical per-phase checklist (usage: make phase-checklist N=3.1)"
 	@echo "  milestone-checklist  Print the GSD milestone wrap-up checklist (usage: make milestone-checklist M=1)"
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Swift 5.9](https://img.shields.io/badge/Swift-5.9-orange.svg)](https://swift.org)
 
-Boilerplate for iOS + macOS apps in the Indiagrams house style.
-Distilled from production iOS + macOS apps shipping under the indiagrams
-org — same XcodeGen layout, same fastlane release pipeline, same App Store
+Opinionated boilerplate for iOS + macOS apps.
+Distilled from production iOS + macOS apps shipping on the App Store —
+same XcodeGen layout, same fastlane release pipeline, same App Store
 submission tooling.
 
 ## Why this template
@@ -131,7 +131,7 @@ provisioning profiles via `-allowProvisioningUpdates`. Subsequent runs reuse the
 │   ├── ExportOptions-iOS.plist      # signed iOS App Store export options
 │   ├── ExportOptions-macOS-AppStore.plist
 │   └── lib/
-│       ├── resolve-dist-cert-sha.sh # cert SHA-1 disambiguation (shared across indiagrams projects)
+│       ├── resolve-dist-cert-sha.sh # cert SHA-1 disambiguation (shared library; SHA-pinned across consumer repos)
 │       └── SHA256SUMS               # pinned hashes; CI fails if lib/ drifts
 ├── fastlane/
 │   ├── Fastfile                     # release | take_screenshots | upload_screenshots | upload_metadata | submit_for_review
@@ -228,10 +228,10 @@ After creating your repo and pushing the first commit, run:
 ```bash
 make setup-github                                  # uses current repo's origin
 # or:
-bin/setup-github.sh indiagrams/myapp               # explicit target
+bin/setup-github.sh acme/myapp                     # explicit target
 ```
 
-This applies the Indiagrams house-style settings to your repo:
+This applies the following settings to your repo:
 
 - **Branch protection on `main`**:
   - Require PR before merging (no direct pushes — even for repo admins)

--- a/bin/setup-github.sh
+++ b/bin/setup-github.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# bin/setup-github.sh — apply Indiagrams house-style GitHub configuration to a
+# bin/setup-github.sh — apply standard GitHub configuration (branch protection, squash, auto-merge) to a
 # repo derived from this template.
 #
 # What it sets:
@@ -48,7 +48,7 @@ else
 fi
 
 if ! [[ "$REPO" =~ ^[^/]+/[^/]+$ ]]; then
-  fail "invalid repo '$REPO' — expected owner/name (e.g. indiagrams/myapp)"
+  fail "invalid repo '$REPO' — expected owner/name (e.g. acme/myapp)"
 fi
 
 step "Target: $REPO"
@@ -117,5 +117,5 @@ echo "$PROTECTION_JSON" | gh api -X PUT "repos/$REPO/branches/main/protection" \
 ok "main: PR-required, 3 CI checks (strict), enforce on admins, linear history"
 
 step "Done"
-ok "$REPO is configured to Indiagrams house style."
+ok "$REPO is configured (PR-required, 3 CI checks, squash-only, auto-merge)."
 ok "Direct pushes to main are blocked. Open PRs and let CI run."

--- a/ci/local-release-check.sh
+++ b/ci/local-release-check.sh
@@ -73,7 +73,7 @@ step() { printf '\n==> %s\n' "$*"; }
 ok()   { printf '    ✓ %s\n' "$*"; }
 fail() { printf '    ✗ %s\n' "$*" >&2; exit 1; }
 
-# Apple Distribution cert SHA-1 resolver — shared library across indiagrams projects.
+# Apple Distribution cert SHA-1 resolver — shared library; SHA-pinned across consumer repos.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/resolve-dist-cert-sha.sh"
 
 VERSION="${TAG#v}"

--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -107,7 +107,7 @@ first and let's talk.
 ## Tone
 
 We aim for a small, useful template. We say no to features that fit a
-specific Indiagrams use case but not the broader iOS/macOS world. We say
+specific organizational use case but not the broader iOS/macOS world. We say
 yes to fixes for the gotchas hiding in `xcodebuild`, `fastlane deliver`,
 `actool`, and `codesign` — because someone hit them, debugged them, and
 shouldn't have to do that again.


### PR DESCRIPTION
## Summary

**Phase 5: Indiagrams narrative-prose scrub** — Scrub remaining `Indiagrams`/`indiagrams` narrative qualifier refs from comments, narrative prose, help text, terminal output, and example slugs across 5 files (11 sites total). Preserve intentional URL refs + email alias + LICENSE Copyright. Status: verified ✓ (11/11 must-haves) + UAT ✓ (15/15) + SECURITY ✓ (10/10 STRIDE entries closed) + VALIDATION ✓ (Nyquist substantive — 12 gates green under adversarial re-execution).

**Final M2 phase** — once merged, M2 milestone (5 phases, 5 PRs: #7 / #11 / #12 / #13 / this PR) closes. M3 (rename script) starts next.

## Changes

5 atomic single-file commits:

| Commit | File | Sites | Change |
|---|---|---|---|
| `f2c2e4a` | `Makefile` | 1 | help-text: `Apply Indiagrams house-style branch protection` → `Apply branch protection settings` |
| `d644a07` | `README.md` | 5 | tagline (line 7) → `Opinionated boilerplate`, multi-line narrative (8-9), dir-tree comment (134), example slug (231) `indiagrams/myapp` → `acme/myapp`, section text (234) |
| `35c48b8` | `bin/setup-github.sh` | 3 | file header (2), error-message example slug (51), terminal output (120) |
| `0c651d0` | `ci/local-release-check.sh` | 1 | comment (76): `shared library across indiagrams projects` → `shared library; SHA-pinned across consumer repos` |
| `baf65ba` | `docs/PRINCIPLES.md` | 1 | narrative (110): `specific Indiagrams use case` → `specific organizational use case` |

Preserved (intentional through M2 — M3 P1 `bin/rename.sh` substitutes during fork-rename):
- `github.com/indiagrams/ios-macos-template` × 3 (CONTRIBUTING:132, README:3, README:47)
- `maintainers@indiagram.com` (singular alias) × 2 (CoC, SECURITY.md)
- `Copyright (c) 2026 Indiagram LLC` × 1 (LICENSE — MIT-required)

## Test plan

- [x] All 11 substitution sites carry new wording (per-site `grep -c` exact-match)
- [x] Drift sweep returns empty: `git grep -nw -e Indiagrams -e indiagrams -- . ':!.planning/**' ':!.gitignore' ':!LICENSE' | grep -vE '^CONTRIBUTING\.md:132:|^README\.md:3:|^README\.md:47:'`
- [x] 4-layer intentional-ref preservation (3 GitHub URLs + 2 email aliases + LICENSE Copyright)
- [x] T5 sweep + preservation ran BEFORE atomic commit (HIGH-2 carry from M2 P4 — closes failure-after-commit gap)
- [x] T5 Step 8 post-commit `git grep --cached -nw` belt-and-suspenders empty
- [x] `bash -n bin/setup-github.sh` and `bash -n ci/local-release-check.sh` exit 0
- [x] `make help | grep -F 'setup-github     Apply branch protection settings to current repo'` exit 0
- [x] `shasum -a 256 -c ci/lib/SHA256SUMS --ignore-missing --quiet` exit 0 (ci/lib unchanged)
- [x] 3-platform `make check*` (iOS device, iOS Simulator, macOS) all exit 0 — wrapped in `bash -euo pipefail <<'BASH'` heredoc (HIGH-1 carry from M2 P3 for zsh `${PIPESTATUS[0]}`)
- [x] CI: 3 jobs verify on this PR

## Plan iterations

1 in-house plan-check pass (PASS) + 1 cross-AI review (Gemini + Codex) → iteration 2 fixes 1 HIGH + 3 MEDIUM + 2 LOW:

- **HIGH-1 (Codex):** `git grep -nE '(\b|^)[Ii]ndiagrams\b'` silently false-passes — returns 0 hits when 14 are present. Same regex works in BSD grep but fails in `git grep`. Fix: replace with `git grep -nw -e Indiagrams -e indiagrams` form (verified live: returns all 14 expected hits, then empty after substitutions+allowlist).
- **MEDIUM-1 (Codex):** URL-context whole-line filter could hide mixed-context anomalies. Fix: replaced with explicit 3-tuple file:line allowlist `^CONTRIBUTING\.md:132:|^README\.md:3:|^README\.md:47:`.
- **MEDIUM-2 (Codex):** failure_handler not auto-wired; explicitly marked as MANUAL procedure (orchestrator-invoked after T6 step exit), same pattern as M2 P4.
- **MEDIUM (Gemini-rescored):** Makefile:22 description shortened from 84 chars to 48 chars (`Apply branch protection settings to current repo`). Within sibling 39-111 char range.
- **LOW-1 (Codex):** README:231 trailing whitespace adjusted to 21 spaces (`#` at column 52, matches sibling line 229).
- **LOW-2 (Codex):** `--cached` flag added to T5 Step 8 command for prose+command consistency.

The HIGH-1 finding is the same load-bearing failure mode as M2 P3's PIPESTATUS HIGH and M2 P4's macOS-plist HIGH — in-house plan-checker rubber-stamped a sweep pattern that silently false-passes; cross-AI review caught it. 4 consecutive M2 phases now have HIGH defects in-house plan-check missed.

Phase ran in 4m25s (no network roundtrip; all gates local).