### PR TITLE
chore(security): split SECURITY.md Response H2 out of Reporting section

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,15 +14,6 @@ Do NOT open a public GitHub issue for security bugs. Public issues are for
 non-security bugs and feature requests; for vulnerabilities, the email
 inbox is the only supported channel.
 
-We aim to acknowledge new reports within ~7 days — same response window as
-[`CONTRIBUTING.md`](CONTRIBUTING.md) and [`docs/PRINCIPLES.md`](docs/PRINCIPLES.md)
-#23. Acknowledgement, not resolution: the first reply confirms we have the
-report and are looking at it. Fix and release follow on their own timeline.
-
-We follow a 90-day coordinated-disclosure window. We target a fix and a
-release within 90 days of the initial report. After that window, the
-reporter is free to publish their findings regardless of the fix status.
-
 If the issue affects a downstream consumer app derived from this template
 (and not the template itself), please report to that app's maintainers
 instead — see "Out of Scope" below.
@@ -36,6 +27,17 @@ A useful report includes:
 - The impact you observed — what could an attacker do, on which surface.
 
 Keep it short. This is guidance, not a gating questionnaire.
+
+## Response
+
+We aim to acknowledge new reports within ~7 days — same response window as
+[`CONTRIBUTING.md`](CONTRIBUTING.md) and [`docs/PRINCIPLES.md`](docs/PRINCIPLES.md)
+#23. Acknowledgement, not resolution: the first reply confirms we have the
+report and are looking at it. Fix and release follow on their own timeline.
+
+We follow a 90-day coordinated-disclosure window. We target a fix and a
+release within 90 days of the initial report. After that window, the
+reporter is free to publish their findings regardless of the fix status.
 
 ## In Scope
 


### PR DESCRIPTION
## Summary

Polish follow-on to PR #7 (M2 P1 SECURITY.md). The rendered GitHub `/security/policy` page (verified post-merge) had response-time commitments buried inside `## Reporting a Vulnerability` as paragraphs — easy to miss when scanning. This chore PR splits them out into a dedicated `## Response` H2 section so the SLA is visible at a glance.

## Changes

1 atomic single-file commit: `53abb64` — `docs(security): split out Response H2 section`

Net structure (5 H2 sections, was 4):

| Section | Content |
|---|---|
| `## Reporting a Vulnerability` | HOW to report — email, no public issues, downstream-app referral, useful-report format |
| `## Response` (NEW) | WHEN you'll hear back — ~7-day acknowledgement, 90-day coordinated-disclosure window |
| `## In Scope` | unchanged |
| `## Out of Scope` | unchanged |
| `## Supported Versions` | unchanged |

Diff: `+11 / -9` (paragraphs moved + new H2 heading; no semantic content change).

Downstream-app referral stayed in `Reporting` (logical fit — it tells the reporter where to redirect, not when they'll hear back).

## Test plan

- [x] `grep -c '^## ' SECURITY.md` returns 5 (was 4)
- [x] All 5 H2 sections in correct order: Reporting → Response → In Scope → Out of Scope → Supported Versions
- [x] `maintainers@indiagram.com` email still in Reporting section
- [x] 7-day + 90-day commitments now in dedicated Response section
- [x] No content lost in the move (diff is symmetric: 11 insertions including new H2 + paragraph reflow; 9 deletions for the same paragraphs in their old location)
- [x] CI: 3 jobs (`app (iOS device)`, `app (iOS Simulator)`, `app (macOS)`) — verifying on this PR (build is unaffected by SECURITY.md edits but matches main branch protection)

Companion to PR #7 (M2 P1). Mirrors the M1 chore PR #3 pattern (small, scoped, atomic doc/config follow-on).