### PR TITLE
M3 P1: bin/rename.sh fork-rename script

### DIFF
--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -326,8 +326,14 @@ PATHSPEC_EXCLUSIONS=(
 #   - '&'  → in sed replacement, '&' = entire match. Escape to '\&'.
 #   - '\'  → backslash. Escape to '\\'.
 #   - '|'  → already rejected at gate, but escape to '\|' as belt-suspenders.
-# The order matters: backslash MUST be escaped first (otherwise its escape
-# would re-escape the others).
+#
+# In a single regex pass, match any of \ & | in the bracket expression
+# and prefix with \. The replacement \\& re-emits the matched literal
+# preceded by a backslash, producing the sed-replacement-safe form.
+# (BSD sed's bracket expression DOES match a literal backslash inside
+# [\&|] — verified empirically on macOS.) Because this is a single
+# pass, no ordering concerns apply: each `\`, `&`, or `|` is matched
+# at most once and replaced atomically with its escaped form.
 sed_escape_replacement() {
   printf '%s' "$1" | sed -e 's/[\&|]/\\&/g'
 }

--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -101,6 +101,114 @@ for arg in "$@"; do
   esac
 done
 
-# The remaining arg parsing (positional + flags) lands in T2.
-# T1 only delivers: shebang, helpers, print_usage, -h/--help detection.
-# All other functionality is added incrementally in T2-T8.
+# ── Globals (set by parse_args; consumed by gate functions + main) ───────
+APP_NAME=""
+BUNDLE_ID=""
+DISPLAY_NAME=""
+EMAIL=""
+SLUG=""
+DRY_RUN=0
+FORCE=0
+
+# ── Argument parsing (function; called by main in T7) ────────────────────
+# MEDIUM-3 split-flag rejection: --email VAL / --slug VAL reject
+# missing values AND values starting with '-'.
+parse_args() {
+  local POSITIONAL=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -h|--help)
+        print_usage; exit 0 ;;
+      --dry-run)
+        DRY_RUN=1; shift ;;
+      --force)
+        FORCE=1; shift ;;
+      --email=*)
+        EMAIL="${1#--email=}"; shift ;;
+      --email)
+        [ $# -ge 2 ] || fail "--email requires a value (e.g. --email=address@example.com)"
+        case "$2" in -*) fail "--email value cannot start with '-' (got '$2')";; esac
+        EMAIL="$2"; shift 2 ;;
+      --slug=*)
+        SLUG="${1#--slug=}"; shift ;;
+      --slug)
+        [ $# -ge 2 ] || fail "--slug requires a value (e.g. --slug=acme/myapp)"
+        case "$2" in -*) fail "--slug value cannot start with '-' (got '$2')";; esac
+        SLUG="$2"; shift 2 ;;
+      -*)
+        fail "unknown flag '$1' — run with -h for usage" ;;
+      *)
+        POSITIONAL+=("$1"); shift ;;
+    esac
+  done
+
+  if [ "${#POSITIONAL[@]}" -lt 3 ]; then
+    fail "missing required positional args — usage: bin/rename.sh APP_NAME BUNDLE_ID DISPLAY_NAME --email=EMAIL [--slug=OWNER/REPO]"
+  fi
+  APP_NAME="${POSITIONAL[0]}"
+  BUNDLE_ID="${POSITIONAL[1]}"
+  DISPLAY_NAME="${POSITIONAL[2]}"
+}
+
+# ── HIGH-7 input-gate helper (function; called by validate_args) ─────────
+# The sed delimiter is `|` and BSD sed cannot handle multi-line
+# replacements via single-line `s|...|...|` form. Reject these
+# characters at the gate so downstream sed_escape_replacement only
+# has to handle &, \, |.
+reject_special_chars() {
+  local label="$1" value="$2"
+  case "$value" in
+    *$'\n'*) fail "$label contains a newline — not supported (got: $(printf %q "$value"))" ;;
+  esac
+  case "$value" in
+    *'|'*) fail "$label contains '|' — not supported (sed delimiter; got: $value)" ;;
+  esac
+}
+
+# ── Args-validation gates 3, 4, 5, 5b, 5c (function; called by main) ─────
+# Cheap regex + non-empty + special-char checks. Does NOT include
+# gate 2 (xcodegen — file-system-touching), gates 7+8 (clean-tree +
+# on-main — git-state-touching) — those are gate_xcodegen_present(),
+# gate_clean_tree(), gate_on_main() defined in T7.
+validate_args() {
+  step "Pre-flight gates (args validation)"
+
+  # Gate 3: APP_NAME is a valid Swift identifier
+  [[ "$APP_NAME" =~ ^[A-Z][a-zA-Z0-9]*$ ]] || \
+    fail "invalid APP_NAME '$APP_NAME' — must match ^[A-Z][a-zA-Z0-9]*$ (e.g. MyApp, no spaces)"
+  ok "APP_NAME '$APP_NAME' is a valid Swift identifier"
+
+  # Gate 4: BUNDLE_ID matches reverse-DNS pattern
+  [[ "$BUNDLE_ID" =~ ^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+$ ]] || \
+    fail "invalid BUNDLE_ID '$BUNDLE_ID' — must match reverse-DNS lowercase (e.g. com.acme.myapp)"
+  ok "BUNDLE_ID '$BUNDLE_ID' matches reverse-DNS pattern"
+
+  # Gate 5: DISPLAY_NAME non-empty + HIGH-7 input rejection
+  [ -n "$DISPLAY_NAME" ] || fail "DISPLAY_NAME is empty — pass a non-empty third positional arg (e.g. \"My App\")"
+  reject_special_chars "DISPLAY_NAME" "$DISPLAY_NAME"
+  ok "DISPLAY_NAME '$DISPLAY_NAME' is non-empty (no newline / '|')"
+
+  # Gate 5b: --email required + HIGH-7 input rejection
+  [ -n "$EMAIL" ] || fail "--email is required — pass --email=address@example.com"
+  reject_special_chars "EMAIL" "$EMAIL"
+  ok "--email '$EMAIL' provided (no newline / '|')"
+
+  # Gate 5c: --slug auto-derive if omitted, then HIGH-7 + format check
+  if [ -z "$SLUG" ]; then
+    local ORIGIN
+    ORIGIN=$(git config --get remote.origin.url 2>/dev/null || true)
+    [ -n "$ORIGIN" ] || \
+      fail "--slug not provided AND no origin remote — pass --slug=OWNER/REPO or set origin"
+    SLUG=$(echo "$ORIGIN" \
+      | sed -E -e 's#^git@github\.com:##' \
+               -e 's#^https://github\.com/##' \
+               -e 's#\.git$##')
+    ok "--slug auto-derived from origin: '$SLUG'"
+  else
+    ok "--slug '$SLUG' explicit"
+  fi
+  reject_special_chars "SLUG" "$SLUG"
+  [[ "$SLUG" =~ ^[^/]+/[^/]+$ ]] || \
+    fail "invalid --slug '$SLUG' — expected OWNER/REPO (e.g. acme/myapp)"
+  ok "SLUG format OK"
+}

--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -455,3 +455,69 @@ apply_substitutions() {
     fail "HIGH-6 violation: $REMAINING placeholder match(es) remain after Step G"
   ok "placeholder fully replaced (0 remaining)"
 }
+
+# ── Idempotency + partial-rename detection (REQ-6, REQ-10; HIGH-3) ───────
+
+# Returns 0 if fully renamed (caller should silent-exit-0).
+# Returns 1 if partial-rename state (caller should fail unless --force).
+# Returns 2 if pre-rename state (caller should proceed normally).
+check_idempotency() {
+  local target_xcodeproj="app/$APP_NAME.xcodeproj"
+  local target_swift="app/Shared/$APP_NAME.swift"
+  local target_ios_ent="app/iOS/$APP_NAME.entitlements"
+  local target_macos_ent="app/macOS/$APP_NAME.entitlements"
+
+  local source_swift="app/Shared/HelloApp.swift"
+  local source_ios_ent="app/iOS/HelloApp.entitlements"
+  local source_macos_ent="app/macOS/HelloApp.entitlements"
+
+  local renamed=0
+  [ -d "$target_xcodeproj" ] && renamed=$((renamed + 1))
+  [ -f "$target_swift" ] && [ ! -f "$source_swift" ] && renamed=$((renamed + 1))
+  [ -f "$target_ios_ent" ] && [ ! -f "$source_ios_ent" ] && renamed=$((renamed + 1))
+  [ -f "$target_macos_ent" ] && [ ! -f "$source_macos_ent" ] && renamed=$((renamed + 1))
+
+  local source_present=0
+  [ -f "$source_swift" ] && source_present=$((source_present + 1))
+  [ -f "$source_ios_ent" ] && source_present=$((source_present + 1))
+  [ -f "$source_macos_ent" ] && source_present=$((source_present + 1))
+
+  if [ "$renamed" -ge 3 ] && [ "$source_present" -eq 0 ]; then
+    return 0  # idempotent no-op (full rename detected)
+  fi
+
+  if [ "$renamed" -eq 0 ] && [ "$source_present" -ge 3 ]; then
+    return 2  # proceed with normal rename
+  fi
+
+  return 1
+}
+
+# ── File-path renames via git mv (REQ-3; D-1 mv-after-sed ordering) ──────
+
+rename_file_paths() {
+  step "Renaming file paths (3 git mv operations)"
+
+  local pairs=(
+    "app/Shared/HelloApp.swift:app/Shared/$APP_NAME.swift"
+    "app/iOS/HelloApp.entitlements:app/iOS/$APP_NAME.entitlements"
+    "app/macOS/HelloApp.entitlements:app/macOS/$APP_NAME.entitlements"
+  )
+
+  local pair src dst
+  for pair in "${pairs[@]}"; do
+    src="${pair%%:*}"
+    dst="${pair##*:}"
+
+    if [ ! -f "$src" ]; then
+      fail "rename source missing: $src — repo state unexpected"
+    fi
+
+    if [ -e "$dst" ]; then
+      fail "rename target already exists: $dst — refusing to overwrite"
+    fi
+
+    git mv "$src" "$dst"
+    ok "$src -> $dst"
+  done
+}

--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -318,22 +318,6 @@ PATHSPEC_EXCLUSIONS=(
   ':!ci/test-rename.sh'
 )
 
-enumerate_targets() {
-  git grep -nw \
-    -e HelloApp \
-    -F -e com.example.helloapp \
-    -F -e maintainers@indiagram.com \
-    -e '<year>' \
-    -F -e 'indiagrams/ios-macos-template' \
-    -- . "${PATHSPEC_EXCLUSIONS[@]}" \
-    2>/dev/null \
-    || true
-}
-
-enumerate_target_files() {
-  enumerate_targets | awk -F: '{print $1}' | sort -u
-}
-
 # ── Substitutions (REQ-2, REQ-9; D-1; HIGH-6 placeholder + HIGH-7 escape) ─
 
 # HIGH-7 closure: escape sed replacement metacharacters &, \, |.

--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -421,8 +421,20 @@ apply_substitutions() {
   # Step F: HelloApp -> $APP_NAME (broad sweep; placeholder unaffected
   # because __GSD_DISPLAY_PLACEHOLDER__ contains no HelloApp substring)
   # APP_NAME is regex-validated [A-Z][a-zA-Z0-9]*; no escape needed.
+  #
+  # NOTE: enumeration is `git grep -l` (NO -w word-boundary). The other
+  # surfaces (com.example.helloapp / maintainers@indiagram.com / slug /
+  # <year>) are full-token strings, but `HelloApp` appears as a SUBSTRING
+  # inside `HelloAppApp` (the SwiftUI @main struct name in
+  # app/Shared/HelloApp.swift line 4). With -w, that file is not
+  # enumerated → sed never visits it → post-rename file `MyApp.swift`
+  # contains residual `HelloAppApp`, violating AC-4 (zero `HelloApp`
+  # substring matches post-rename). Without -w, every file containing
+  # the literal `HelloApp` substring is visited; sed's replacement
+  # pattern is also non-word-bounded so `HelloAppApp` correctly becomes
+  # `MyAppApp`. (Goal-backward verification gap-closure G-01.)
   step "Substituting HelloApp -> $APP_NAME (broad sweep)"
-  { git grep -lw -e 'HelloApp' -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null || true; } \
+  { git grep -l -e 'HelloApp' -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null || true; } \
     | while read -r f; do
         sed -i '' "s|HelloApp|$APP_NAME|g" "$f"
         ok "HelloApp substituted in $f"
@@ -631,18 +643,25 @@ EOF
 # ── Main orchestration (iter-5 BLOCKER-3 — canonical call order) ─────────
 
 main() {
-  step "Pre-flight"
-
   # 1. Args parsing (defined in T2)
   parse_args "$@"
 
-  # 2. Args validation: gates 3, 4, 5, 5b, 5c (defined in T2)
-  validate_args
-
-  # 3. Idempotency dispatch — case 0/1/2 (HIGH-3: BEFORE clean-tree)
-  # Gate 7: working tree clean (line-tagged for HIGH-3 line-number assertion)
-  # — NOTE: the actual call to gate_clean_tree is below; this dispatch
-  # MUST appear before that line in the file.
+  # 2. Idempotency dispatch — case 0/1/2 (HIGH-3: BEFORE clean-tree).
+  # Goal-backward gap-closure G-02: the dispatch MUST run before
+  # validate_args (which prints "==> Pre-flight gates (args validation)").
+  # SPEC REQ-6 / AC-13 require the case-0 path to produce NO stdout.
+  # Running validate_args first violates that contract on a fully-
+  # renamed tree.
+  #
+  # Trade-off: APP_NAME hasn't been regex-validated yet at this point,
+  # so check_idempotency runs against a potentially-invalid
+  # `app/$APP_NAME.xcodeproj` path. This is structurally safe because:
+  #   - If APP_NAME is invalid, no target paths exist, so case is 2
+  #     (or 1 if some-but-not-all source paths missing). Either way
+  #     control falls through to validate_args, which rejects the
+  #     invalid APP_NAME with the correct error.
+  #   - If APP_NAME is valid AND matches a fully-renamed state, case
+  #     is 0 → silent exit 0 (the desired contract).
   set +e
   check_idempotency
   local IDEMPOT=$?
@@ -666,7 +685,11 @@ main() {
       exit 0
       ;;
     1)
-      # Partial-rename state. Per MEDIUM-4, --force bypasses this gate.
+      # Partial-rename state OR APP_NAME mismatch. Per MEDIUM-4,
+      # --force bypasses this gate. validate_args will fire below
+      # so an invalid APP_NAME on this branch surfaces as the
+      # validate_args error, not as partial-rename noise.
+      step "Pre-flight"
       if [ "$FORCE" = "1" ]; then
         step "Idempotency check"
         ok "partial-rename state detected; --force bypass enabled — proceeding"
@@ -676,10 +699,14 @@ main() {
       fi
       ;;
     2)
+      step "Pre-flight"
       step "Idempotency check"
       ok "pre-rename state confirmed — proceeding with rename"
       ;;
   esac
+
+  # 3. Args validation: gates 3, 4, 5, 5b, 5c (defined in T2)
+  validate_args
 
   # 4. xcodegen presence (gate 2)
   gate_xcodegen_present

--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -287,3 +287,49 @@ rollback() {
 trap 'rollback' ERR
 trap 'rollback' INT TERM
 trap 'rollback' EXIT
+
+# ── Substitution-target enumeration (REQ-2; HIGH-2 + MEDIUM-1 closure) ───
+
+# Why -nw -e P1 -e P2 (not -nE '(\b|^)P\b'):
+# M2 P5 cross-AI HIGH-1 (Codex): the regex form silently false-passes
+# in git grep — returns 0 hits when 14 are present. -nw is git-grep-
+# native and reliable. Carry-forward.
+#
+# Why -F on com.example.helloapp / maintainers@indiagram.com /
+# indiagrams/ios-macos-template (MEDIUM-1):
+# Without -F, the literal `.` in these patterns is regex any-char.
+# `git grep -nw -e com.example.helloapp` would match `comXexampleXhelloapp`
+# (none exist in tree, but the principle is wrong). -F treats the
+# pattern as fixed-string. -F + -w combine correctly in git grep.
+#
+# Why :!bin/rename.sh :!ci/test-rename.sh exclusions (HIGH-2):
+# bin/rename.sh contains every substitution-surface literal in its
+# print_usage block, error messages, sed patterns, etc. Without
+# exclusion, the broad HelloApp -> APP_NAME sweep would rewrite the
+# running script — corrupting future runs. Same for ci/test-rename.sh
+# (contains HelloApp, com.example.helloapp, etc. in test fixtures).
+
+# The shared pathspec exclusion list (used everywhere)
+PATHSPEC_EXCLUSIONS=(
+  ':!.planning'
+  ':!LICENSE'
+  ':!app/HelloApp.xcodeproj'
+  ':!bin/rename.sh'
+  ':!ci/test-rename.sh'
+)
+
+enumerate_targets() {
+  git grep -nw \
+    -e HelloApp \
+    -F -e com.example.helloapp \
+    -F -e maintainers@indiagram.com \
+    -e '<year>' \
+    -F -e 'indiagrams/ios-macos-template' \
+    -- . "${PATHSPEC_EXCLUSIONS[@]}" \
+    2>/dev/null \
+    || true
+}
+
+enumerate_target_files() {
+  enumerate_targets | awk -F: '{print $1}' | sort -u
+}

--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -660,9 +660,18 @@ main() {
 
   case "$IDEMPOT" in
     0)
-      # Already-renamed — silent exit 0 per REQ-6 + SPEC AC-13.
-      # No step(), no ok(), no stdout. Disarm traps (no rollback
-      # needed because no mutations occurred).
+      # Already-renamed.
+      # WR-02: under --dry-run, the user's intent is "show me what
+      # WOULD change." Silent exit 0 leaves them unsure whether the
+      # script crashed, no-oped, or mis-parsed flags. Print an
+      # explicit "nothing to preview" message before exiting.
+      if [ "$DRY_RUN" = "1" ]; then
+        step "DRY RUN — already-renamed state detected"
+        ok "no substitutions would be applied (re-run idempotent)"
+      fi
+      # Real run on already-renamed tree: silent exit 0 per REQ-6 +
+      # SPEC AC-13. No step(), no ok(), no stdout. Disarm traps (no
+      # rollback needed because no mutations occurred).
       trap - ERR EXIT INT TERM
       exit 0
       ;;

--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# bin/rename.sh — fork-rename script for the ios-macos-template.
+#
+# Substitutes 5 identity surfaces + 1 derived value, renames file paths,
+# regenerates xcodeproj. Atomic (all-or-nothing via reset-hard rollback),
+# idempotent (silent no-op on re-run with same args), pre-flight-gated.
+#
+# Usage:
+#   bin/rename.sh APP_NAME BUNDLE_ID DISPLAY_NAME --email=EMAIL [--slug=OWNER/REPO] [--dry-run] [--force]
+#   bin/rename.sh -h                                # print this usage
+#   bin/rename.sh --help                            # alias for -h
+#
+# Required positional args:
+#   APP_NAME       Swift identifier — capitalized, no spaces/dashes/dots/leading digits
+#                  (regex: ^[A-Z][a-zA-Z0-9]*$; e.g. MyApp)
+#   BUNDLE_ID      Reverse-DNS, lowercase, dot-separated; no underscores/uppercase
+#                  (regex: ^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+$; e.g. com.acme.myapp)
+#   DISPLAY_NAME   Non-empty display name (Apple allows spaces/punctuation).
+#                  MUST NOT contain newline or '|' (sed delimiter).
+#
+# Required flag:
+#   --email=EMAIL  Maintainer/security contact email; substitutes
+#                  maintainers@indiagram.com across CODE_OF_CONDUCT.md
+#                  and SECURITY.md. MUST NOT contain newline or '|'.
+#
+# Optional flags:
+#   --slug=OWNER/REPO   GitHub org/repo slug; substitutes
+#                       indiagrams/ios-macos-template across README.md +
+#                       CONTRIBUTING.md. If omitted, auto-derives from
+#                       `git remote get-url origin`. MUST NOT contain
+#                       newline or '|'.
+#   --dry-run           Preview substitutions without applying.
+#   --force             Override the on-main-branch gate AND the partial-
+#                       rename detection gate. Other gates (args validation,
+#                       xcodegen presence, sed escapes) still fire.
+#
+# Argument forms:
+#   --email=VAL    (preferred, equal-sign form)
+#   --email VAL    (split form — VAL must be non-empty and not start with '-')
+#
+# Pre-flight gate ORDER (canonical; cross-AI HIGH-3 + MEDIUM-2 fix):
+#   1. Args parsing (split-flag values rejected if missing or '-'-prefixed)
+#   2. xcodegen on PATH
+#   3. APP_NAME matches ^[A-Z][a-zA-Z0-9]*$
+#   4. BUNDLE_ID matches ^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+$
+#   5. DISPLAY_NAME non-empty AND no newline/'|'
+#   5b. EMAIL non-empty AND no newline/'|'
+#   5c. SLUG non-empty (auto-derived if absent) AND no newline/'|' AND OWNER/REPO format
+#   6. Idempotency check (BEFORE clean-tree gate per HIGH-3) —
+#      case 0 = silent exit 0 (already renamed)
+#      case 1 = partial-rename fail (unless --force)
+#      case 2 = proceed
+#   7. Working tree is clean (git status --short empty — strict, includes
+#      untracked files; this prevents data-loss via reset-hard)
+#   8. Current branch is `main` (override via --force)
+#
+# Idempotency:
+#   Re-running with SAME args after a successful first run detects
+#   already-renamed state via structural file-path signal counting;
+#   exits 0 silently. The check runs BEFORE the clean-tree gate so a
+#   second invocation on a dirty post-first-rename tree still resolves
+#   correctly.
+#
+# All-or-nothing (HIGH-1 reset-hard rollback — replaces broken git stash):
+#   Pre-flight Gate 7 (clean tree) ensures HEAD == working tree pre-mutation.
+#   Any failure in sed/mv/xcodegen steps triggers ERR/EXIT/INT/TERM trap
+#   which executes:
+#     1. rm -rf app/$APP_NAME.xcodeproj  (regenerated dir is gitignored)
+#     2. git reset --hard HEAD --quiet   (restores tracked-file mods + git mv)
+#     3. git clean -fd --quiet           (removes new untracked files; NOT -fdx)
+#   Exits 1 with stderr "rolled back to pre-rename state."
+#
+# Constraints:
+#   - bash 3.2+ (macOS default); no bash 4+ features
+#   - BSD-portable sed (sed -i '', | delimiter, escaped dots)
+#   - sed replacement values escaped via sed_escape_replacement (HIGH-7)
+#   - No new external dependencies (git, bash, sed, mv, find, grep, xcodegen)
+
+set -euo pipefail
+
+step() { printf '\n==> %s\n' "$*"; }
+ok()   { printf '    ✓ %s\n' "$*"; }
+fail() { printf '    ✗ %s\n' "$*" >&2; exit 1; }
+
+print_usage() {
+  # Print every comment line from line 2 until just before the
+  # `set -euo pipefail` body line. Pattern-anchored so the usage block
+  # adapts as we extend it across T1-T8 incremental edits.
+  sed -n '2,/^set -euo pipefail$/{ /^set -euo pipefail$/!p; }' "$0" | sed 's/^# \{0,1\}//'
+}
+
+# ── Argument parsing ──────────────────────────────────────────────────────
+# Detect -h / --help BEFORE positional consumption so `bin/rename.sh -h`
+# works without any other args (REQ-1, AC-2).
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+  esac
+done
+
+# The remaining arg parsing (positional + flags) lands in T2.
+# T1 only delivers: shebang, helpers, print_usage, -h/--help detection.
+# All other functionality is added incrementally in T2-T8.

--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -521,3 +521,181 @@ rename_file_paths() {
     ok "$src -> $dst"
   done
 }
+
+# ── Pre-flight gate functions (called by main; iter-5 BLOCKER-3) ─────────
+#
+# File-scope is reserved for: helpers (T1) + function defs (T2-T7) +
+# trap arming (T3) + main "$@" invocation (this file's last line).
+# Everything else lives inside main() so call order is canonical
+# AND every callee is defined when called (resolves BLOCKER-3).
+
+gate_xcodegen_present() {
+  command -v xcodegen >/dev/null 2>&1 || \
+    fail "xcodegen not found — run \`make bootstrap\` first"
+  ok "xcodegen on PATH"
+}
+
+gate_clean_tree() {
+  # NOTE: We deliberately DO NOT pass --untracked-files=no here.
+  # Forker-facing script must catch untracked files (e.g.
+  # .env.local, notes.md, WIP edits) so they don't get touched
+  # by reset-hard rollback.
+  if [ "$(git status --short | wc -l | tr -d ' ')" != "0" ]; then
+    fail "working tree not clean — commit, stash, or remove untracked files before running rename"
+  fi
+  ok "working tree clean"
+}
+
+gate_on_main() {
+  local BRANCH
+  BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  if [ "$BRANCH" != "main" ] && [ "$FORCE" != "1" ]; then
+    fail "not on main branch (currently: $BRANCH) — run with --force to override"
+  fi
+  ok "branch check: $BRANCH (force=$FORCE)"
+}
+
+# ── xcodegen regen (REQ-4; D-1 step 3) ───────────────────────────────────
+
+regen_xcodeproj() {
+  step "Regenerating xcodeproj via xcodegen"
+
+  grep -q "^name: $APP_NAME$" app/project.yml || \
+    fail "project.yml \`name:\` not substituted to '$APP_NAME' — sed sweep regression"
+  ok "project.yml \`name: $APP_NAME\` confirmed pre-xcodegen"
+
+  if [ -d "app/HelloApp.xcodeproj" ]; then
+    rm -rf "app/HelloApp.xcodeproj"
+    ok "removed gitignored app/HelloApp.xcodeproj"
+  fi
+
+  ( cd app && xcodegen generate ) || \
+    fail "xcodegen generate failed — check app/project.yml syntax post-substitution"
+
+  [ -d "app/$APP_NAME.xcodeproj" ] || \
+    fail "xcodegen completed but app/$APP_NAME.xcodeproj/ not created — unexpected"
+  ok "app/$APP_NAME.xcodeproj/ regenerated"
+}
+
+# ── --dry-run preview (REQ-8; T8 will extend this) ───────────────────────
+
+print_dry_run_plan() {
+  step "DRY RUN — no files will be modified"
+
+  echo
+  echo "Substitution surfaces detected (via 'git grep -nw'):"
+  enumerate_target_files | while read -r f; do
+    echo "  $f"
+  done
+
+  echo
+  echo "Substitution plan:"
+  echo "  HelloApp                       -> $APP_NAME (broad sweep, after placeholder set)"
+  echo "  com.example.helloapp           -> $BUNDLE_ID"
+  echo "  HelloApp (display contexts)    -> $DISPLAY_NAME (5 sites via __GSD_DISPLAY_PLACEHOLDER__)"
+  echo "  maintainers@indiagram.com      -> $EMAIL"
+  echo "  indiagrams/ios-macos-template  -> $SLUG"
+  echo "  <year>                         -> $(date +%Y)"
+
+  echo
+  echo "File-path renames:"
+  echo "  app/Shared/HelloApp.swift       -> app/Shared/$APP_NAME.swift"
+  echo "  app/iOS/HelloApp.entitlements   -> app/iOS/$APP_NAME.entitlements"
+  echo "  app/macOS/HelloApp.entitlements -> app/macOS/$APP_NAME.entitlements"
+
+  echo
+  echo "xcodegen regen:"
+  echo "  cd app && xcodegen generate  ->  app/$APP_NAME.xcodeproj/"
+
+  echo
+  ok "dry run complete — re-run without --dry-run to apply"
+}
+
+# ── Main orchestration (iter-5 BLOCKER-3 — canonical call order) ─────────
+
+main() {
+  step "Pre-flight"
+
+  # 1. Args parsing (defined in T2)
+  parse_args "$@"
+
+  # 2. Args validation: gates 3, 4, 5, 5b, 5c (defined in T2)
+  validate_args
+
+  # 3. Idempotency dispatch — case 0/1/2 (HIGH-3: BEFORE clean-tree)
+  # Gate 7: working tree clean (line-tagged for HIGH-3 line-number assertion)
+  # — NOTE: the actual call to gate_clean_tree is below; this dispatch
+  # MUST appear before that line in the file.
+  set +e
+  check_idempotency
+  local IDEMPOT=$?
+  set -e
+
+  case "$IDEMPOT" in
+    0)
+      # Already-renamed — silent exit 0 per REQ-6 + SPEC AC-13.
+      # No step(), no ok(), no stdout. Disarm traps (no rollback
+      # needed because no mutations occurred).
+      trap - ERR EXIT INT TERM
+      exit 0
+      ;;
+    1)
+      # Partial-rename state. Per MEDIUM-4, --force bypasses this gate.
+      if [ "$FORCE" = "1" ]; then
+        step "Idempotency check"
+        ok "partial-rename state detected; --force bypass enabled — proceeding"
+      else
+        step "Idempotency check"
+        fail "partial-rename state detected — restore manually or run --force to override"
+      fi
+      ;;
+    2)
+      step "Idempotency check"
+      ok "pre-rename state confirmed — proceeding with rename"
+      ;;
+  esac
+
+  # 4. xcodegen presence (gate 2)
+  gate_xcodegen_present
+
+  # 5+6. Mutation-scoped gates: clean-tree + on-main. Skipped on --dry-run.
+  if [ "$DRY_RUN" != "1" ]; then
+    # Gate 7: working tree clean
+        gate_clean_tree
+    # Gate 8: on main (override via --force per MEDIUM-4)
+        gate_on_main
+  else
+    ok "Gates 7+8 (clean-tree + on-main) skipped on --dry-run path"
+  fi
+
+  step "All pre-flight gates passed"
+
+  # 7. --dry-run path — no mutations.
+  if [ "$DRY_RUN" = "1" ]; then
+    print_dry_run_plan
+    trap - ERR EXIT INT TERM
+    exit 0
+  fi
+
+  # 8-10. Real rename: traps from T3 are armed. Helpers fire in D-1 order.
+  # iter-6 BLOCKER-iter5-1: arm rollback's destructive-op path.
+  # All gates passed; about to make destructive changes. Setting
+  # MUTATION_STARTED=1 here ensures rollback() executes its full
+  # body (rm -rf xcodeproj + git reset --hard + git clean) on any
+  # failure from this line forward. A trap firing BEFORE this line
+  # (e.g. on a pre-flight gate failure) is a no-op rollback,
+  # protecting the forker's dirty working tree.
+      MUTATION_STARTED=1
+      apply_substitutions
+      rename_file_paths
+      regen_xcodeproj
+
+  # Success path: disarm rollback traps (no stash to drop per HIGH-1)
+  trap - ERR EXIT INT TERM
+
+  step "Rename complete"
+  ok "$APP_NAME ($BUNDLE_ID) — \"$DISPLAY_NAME\""
+  ok "next: run 'make check' to verify the build is green"
+}
+
+main "$@"

--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -212,3 +212,78 @@ validate_args() {
     fail "invalid --slug '$SLUG' — expected OWNER/REPO (e.g. acme/myapp)"
   ok "SLUG format OK"
 }
+
+# ── Reset-hard rollback (REQ-7; HIGH-1 closure — replaces broken stash) ───
+#
+# Background: the prior plan iteration used `git stash push --include-untracked`
+# to capture pre-state. On a clean working tree (which Gate 7 requires),
+# `git stash` creates NO entry and SNAPSHOT_CREATED stays 0 → rollback
+# was a no-op → mutations were never undone. Cross-AI HIGH-1.
+#
+# Fix: leverage Gate 7's clean-tree precondition. Pre-mutation HEAD ==
+# working tree, so `git reset --hard HEAD` restores tracked-file
+# modifications and `git mv` staging. Plus:
+#
+#   - rm -rf app/$APP_NAME.xcodeproj  (regenerated dir is gitignored;
+#     `git clean -fd` without -x won't touch it)
+#   - git clean -fd                    (removes new untracked files;
+#     NEVER -fdx — forker's .env.local would be deleted)
+#
+# No git stash. No SNAPSHOT_REF. No snapshot_drop_on_success.
+#
+# iter-6 BLOCKER-iter5-1 closure: MUTATION_STARTED guard flag prevents
+# the trap from firing destructive ops on a pre-mutation gate failure
+# (e.g. dirty-tree gate fails → trap → reset --hard → DESTROYS the
+# forker's uncommitted work). The flag is initialized to 0 here at
+# file scope and flipped to 1 inside main() right before the first
+# mutation call (apply_substitutions). rollback() early-outs unless
+# the flag is set.
+
+ROLLBACK_DONE=0
+MUTATION_STARTED=0  # set to 1 in main() right before first mutation
+
+rollback() {
+  # Idempotent — only fires once even if both ERR and EXIT trip.
+  [ "$ROLLBACK_DONE" = "1" ] && return 0
+  ROLLBACK_DONE=1
+
+  # iter-6 BLOCKER-iter5-1: pre-mutation early-out. If no mutations
+  # were made, nothing to roll back — and running git reset --hard
+  # HEAD on a forker's dirty working tree (e.g. when the clean-tree
+  # gate failed and triggered the EXIT trap) would DESTROY the
+  # forker's uncommitted work. main() flips MUTATION_STARTED=1
+  # right before the first mutation call (apply_substitutions); any
+  # failure BEFORE that point lands here as a no-op rollback.
+  [ "$MUTATION_STARTED" = "1" ] || return 0
+
+  printf '    ✗ rolling back to pre-rename state...\n' >&2
+
+  # Step 1: remove the regenerated xcodeproj if T7 ran (it's gitignored,
+  # so `git clean -fd` without -x won't touch it). APP_NAME may be
+  # unset if rollback fires before arg parsing — guard.
+  if [ -n "${APP_NAME:-}" ] && [ -d "app/$APP_NAME.xcodeproj" ]; then
+    rm -rf "app/$APP_NAME.xcodeproj" 2>/dev/null || true
+  fi
+
+  # Step 2: git reset --hard restores tracked-file modifications +
+  # git mv staging back to HEAD.
+  if git reset --hard HEAD --quiet 2>/dev/null; then
+    # Step 3: git clean -fd removes any NEW untracked files xcodegen
+    # may have created alongside. NOT -fdx — forker's .env.local etc.
+    # are precious. Pre-flight Gate 7 already required clean tree, so
+    # there should be nothing else to clean except what THIS script
+    # introduced.
+    git clean -fd --quiet 2>/dev/null || true
+    printf '    ✗ rolled back to pre-rename state.\n' >&2
+  else
+    printf '    ✗ git reset --hard HEAD failed; manual recovery required.\n' >&2
+    printf '    ✗ inspect: git status; git log --oneline -5\n' >&2
+  fi
+}
+
+# Trap on ERR + EXIT + signals (Ctrl-C = INT, kill = TERM)
+# The traps remain armed for the entire mutation phase (T5/T6/T7); they
+# are disarmed by main() on the success path via `trap - ERR EXIT INT TERM`.
+trap 'rollback' ERR
+trap 'rollback' INT TERM
+trap 'rollback' EXIT

--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -583,19 +583,39 @@ print_dry_run_plan() {
   step "DRY RUN — no files will be modified"
 
   echo
-  echo "Substitution surfaces detected (via 'git grep -nw'):"
-  enumerate_target_files | while read -r f; do
-    echo "  $f"
-  done
+  echo "Substitution surfaces by file (via 'git grep -cw' with -F for fixed-literal patterns):"
+
+  # Per-pattern enumeration. -F applied to fixed-literal patterns
+  # (MEDIUM-1); HelloApp + <year> have no regex metachars.
+  # All grep invocations use PATHSPEC_EXCLUSIONS from T4 (HIGH-2:
+  # excludes :!bin/rename.sh and :!ci/test-rename.sh).
+  local pat fflag label
+  while IFS='|' read -r pat fflag label; do
+    echo
+    echo "  $label"
+    if [ "$fflag" = "F" ]; then
+      git grep -cw -F -e "$pat" -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null \
+        | awk -F: '$2 > 0 { printf "    %-50s %d match(es)\n", $1, $2 }' \
+        || echo "    (no matches)"
+    else
+      git grep -cw -e "$pat" -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null \
+        | awk -F: '$2 > 0 { printf "    %-50s %d match(es)\n", $1, $2 }' \
+        || echo "    (no matches)"
+    fi
+  done <<EOF
+HelloApp||HelloApp -> $APP_NAME (broad sweep)
+com.example.helloapp|F|com.example.helloapp -> $BUNDLE_ID
+maintainers@indiagram.com|F|maintainers@indiagram.com -> $EMAIL
+<year>||<year> -> $(date +%Y)
+indiagrams/ios-macos-template|F|indiagrams/ios-macos-template -> $SLUG
+EOF
 
   echo
-  echo "Substitution plan:"
-  echo "  HelloApp                       -> $APP_NAME (broad sweep, after placeholder set)"
-  echo "  com.example.helloapp           -> $BUNDLE_ID"
-  echo "  HelloApp (display contexts)    -> $DISPLAY_NAME (5 sites via __GSD_DISPLAY_PLACEHOLDER__)"
-  echo "  maintainers@indiagram.com      -> $EMAIL"
-  echo "  indiagrams/ios-macos-template  -> $SLUG"
-  echo "  <year>                         -> $(date +%Y)"
+  echo "DISPLAY_NAME anchored sites (-> $DISPLAY_NAME via __GSD_DISPLAY_PLACEHOLDER__):"
+  echo "  app/project.yml: CFBundleDisplayName (2 sites — iOS + macOS)"
+  echo "  app/Shared/ContentView.swift: Text(\"HelloApp\")"
+  echo "  app/UITests/AppStoreScreenshotTests.swift: staticTexts[\"HelloApp\"]"
+  echo "  fastlane/metadata/en-US/name.txt: whole-file"
 
   echo
   echo "File-path renames:"

--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -333,3 +333,125 @@ enumerate_targets() {
 enumerate_target_files() {
   enumerate_targets | awk -F: '{print $1}' | sort -u
 }
+
+# ── Substitutions (REQ-2, REQ-9; D-1; HIGH-6 placeholder + HIGH-7 escape) ─
+
+# HIGH-7 closure: escape sed replacement metacharacters &, \, |.
+# Input gates (T2 reject_special_chars) already reject newlines and '|'
+# in DISPLAY_NAME/EMAIL/SLUG, so this helper handles the residual cases:
+#   - '&'  → in sed replacement, '&' = entire match. Escape to '\&'.
+#   - '\'  → backslash. Escape to '\\'.
+#   - '|'  → already rejected at gate, but escape to '\|' as belt-suspenders.
+# The order matters: backslash MUST be escaped first (otherwise its escape
+# would re-escape the others).
+sed_escape_replacement() {
+  printf '%s' "$1" | sed -e 's/[\&|]/\\&/g'
+}
+
+# The DISPLAY_NAME placeholder (HIGH-6 closure). Chosen so it does NOT
+# contain HelloApp, com.example.helloapp, maintainers@indiagram.com,
+# <year>, indiagrams/ios-macos-template — none of the broad sweeps
+# will mutate it. Verified zero hits in current tree.
+DISPLAY_PLACEHOLDER='__GSD_DISPLAY_PLACEHOLDER__'
+
+apply_substitutions() {
+  local year escaped_email escaped_slug escaped_display
+  year=$(date +%Y)
+  escaped_email=$(sed_escape_replacement "$EMAIL")
+  escaped_slug=$(sed_escape_replacement "$SLUG")
+  escaped_display=$(sed_escape_replacement "$DISPLAY_NAME")
+
+  # Step A: <year> -> current year (3 source sites; pre-xcodegen)
+  step "Substituting <year> -> $year"
+  git grep -lw -e '<year>' -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null \
+    | while read -r f; do
+        sed -i '' "s|<year>|$year|g" "$f"
+        ok "<year> substituted in $f"
+      done
+
+  # Step B: com.example.helloapp -> $BUNDLE_ID
+  # BUNDLE_ID is regex-validated to match ^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+$
+  # so cannot contain &, \, |, newline. No escape needed.
+  step "Substituting com.example.helloapp -> $BUNDLE_ID"
+  git grep -lw -F -e 'com.example.helloapp' -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null \
+    | while read -r f; do
+        sed -i '' "s|com\.example\.helloapp|$BUNDLE_ID|g" "$f"
+        ok "bundle ID substituted in $f"
+      done
+
+  # Step C: maintainers@indiagram.com -> $EMAIL (escaped — HIGH-7)
+  step "Substituting maintainers@indiagram.com -> $EMAIL"
+  git grep -lw -F -e 'maintainers@indiagram.com' -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null \
+    | while read -r f; do
+        sed -i '' "s|maintainers@indiagram\.com|$escaped_email|g" "$f"
+        ok "email substituted in $f"
+      done
+
+  # Step D: indiagrams/ios-macos-template -> $SLUG (escaped — HIGH-7)
+  step "Substituting indiagrams/ios-macos-template -> $SLUG"
+  git grep -lw -F -e 'indiagrams/ios-macos-template' -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null \
+    | while read -r f; do
+        sed -i '' "s|indiagrams/ios-macos-template|$escaped_slug|g" "$f"
+        ok "GitHub slug substituted in $f"
+      done
+
+  # Step E_NEW: DISPLAY_NAME anchored sites -> placeholder (HIGH-6 closure)
+  # The placeholder is a literal string with no regex metachars and
+  # no HelloApp/com.example.helloapp/etc. literal substrings — it
+  # passes through Step F (broad HelloApp -> APP_NAME sweep) untouched.
+  step "Replacing DISPLAY_NAME sites with placeholder (HIGH-6)"
+
+  if [ -f app/project.yml ]; then
+    sed -i '' "s|CFBundleDisplayName: HelloApp|CFBundleDisplayName: $DISPLAY_PLACEHOLDER|g" app/project.yml
+    ok "DISPLAY placeholder set in app/project.yml (2 CFBundleDisplayName sites)"
+  fi
+
+  if [ -f app/Shared/ContentView.swift ]; then
+    sed -i '' "s|Text(\"HelloApp\")|Text(\"$DISPLAY_PLACEHOLDER\")|g" app/Shared/ContentView.swift
+    ok "DISPLAY placeholder set in app/Shared/ContentView.swift"
+  fi
+
+  if [ -f app/UITests/AppStoreScreenshotTests.swift ]; then
+    sed -i '' "s|staticTexts\[\"HelloApp\"\]|staticTexts[\"$DISPLAY_PLACEHOLDER\"]|g" app/UITests/AppStoreScreenshotTests.swift
+    ok "DISPLAY placeholder set in app/UITests/AppStoreScreenshotTests.swift"
+  fi
+
+  if [ -f fastlane/metadata/en-US/name.txt ]; then
+    sed -i '' "s|^HelloApp$|$DISPLAY_PLACEHOLDER|" fastlane/metadata/en-US/name.txt
+    ok "DISPLAY placeholder set in fastlane/metadata/en-US/name.txt"
+  fi
+
+  # Step F: HelloApp -> $APP_NAME (broad sweep; placeholder unaffected
+  # because __GSD_DISPLAY_PLACEHOLDER__ contains no HelloApp substring)
+  # APP_NAME is regex-validated [A-Z][a-zA-Z0-9]*; no escape needed.
+  step "Substituting HelloApp -> $APP_NAME (broad sweep)"
+  git grep -lw -e 'HelloApp' -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null \
+    | while read -r f; do
+        sed -i '' "s|HelloApp|$APP_NAME|g" "$f"
+        ok "HelloApp substituted in $f"
+      done
+
+  # HIGH-2 belt-and-suspenders assertion: bin/rename.sh and
+  # ci/test-rename.sh MUST be bit-identical to pre-substitution.
+  # Pathspec exclusion is the primary defense; this is the falsifiable
+  # check that the defense worked.
+  git diff --quiet -- bin/rename.sh ci/test-rename.sh 2>/dev/null \
+    || fail "HIGH-2 violation: bin/rename.sh or ci/test-rename.sh modified by substitution sweep"
+  ok "self-exclusion verified — bin/rename.sh + ci/test-rename.sh unchanged"
+
+  # Step G_NEW: placeholder -> $DISPLAY_NAME (escaped — HIGH-7)
+  step "Replacing placeholder with DISPLAY_NAME (HIGH-6)"
+  git grep -lw -F -e "$DISPLAY_PLACEHOLDER" -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null \
+    | while read -r f; do
+        sed -i '' "s|$DISPLAY_PLACEHOLDER|$escaped_display|g" "$f"
+        ok "DISPLAY_NAME substituted in $f"
+      done
+
+  # HIGH-6 verifiable assertion: zero placeholder matches post-Step-G.
+  # If the placeholder remains anywhere, Step G failed to clean up.
+  REMAINING=$(git grep -F -c -e "$DISPLAY_PLACEHOLDER" -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null \
+              | awk -F: 'BEGIN{s=0} $2>0{s+=$2} END{print s}' || true)
+  [ "${REMAINING:-0}" = "0" ] || \
+    fail "HIGH-6 violation: $REMAINING placeholder match(es) remain after Step G"
+  ok "placeholder fully replaced (0 remaining)"
+}

--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -362,8 +362,15 @@ apply_substitutions() {
   escaped_display=$(sed_escape_replacement "$DISPLAY_NAME")
 
   # Step A: <year> -> current year (3 source sites; pre-xcodegen)
+  # WR-01: wrap `git grep` in a brace group with `|| true` so a no-match
+  # (`git grep` exit 1) does not abort the pipeline under
+  # `set -euo pipefail`. Without this, the --force partial-rename path
+  # spuriously triggers rollback when some surfaces are already
+  # substituted. Brace group is required because `|` binds tighter than
+  # `||`; a bare `git grep ... || true | while ...` would short-circuit
+  # the entire pipeline on success.
   step "Substituting <year> -> $year"
-  git grep -lw -e '<year>' -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null \
+  { git grep -lw -e '<year>' -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null || true; } \
     | while read -r f; do
         sed -i '' "s|<year>|$year|g" "$f"
         ok "<year> substituted in $f"
@@ -373,7 +380,7 @@ apply_substitutions() {
   # BUNDLE_ID is regex-validated to match ^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+$
   # so cannot contain &, \, |, newline. No escape needed.
   step "Substituting com.example.helloapp -> $BUNDLE_ID"
-  git grep -lw -F -e 'com.example.helloapp' -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null \
+  { git grep -lw -F -e 'com.example.helloapp' -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null || true; } \
     | while read -r f; do
         sed -i '' "s|com\.example\.helloapp|$BUNDLE_ID|g" "$f"
         ok "bundle ID substituted in $f"
@@ -381,7 +388,7 @@ apply_substitutions() {
 
   # Step C: maintainers@indiagram.com -> $EMAIL (escaped — HIGH-7)
   step "Substituting maintainers@indiagram.com -> $EMAIL"
-  git grep -lw -F -e 'maintainers@indiagram.com' -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null \
+  { git grep -lw -F -e 'maintainers@indiagram.com' -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null || true; } \
     | while read -r f; do
         sed -i '' "s|maintainers@indiagram\.com|$escaped_email|g" "$f"
         ok "email substituted in $f"
@@ -389,7 +396,7 @@ apply_substitutions() {
 
   # Step D: indiagrams/ios-macos-template -> $SLUG (escaped — HIGH-7)
   step "Substituting indiagrams/ios-macos-template -> $SLUG"
-  git grep -lw -F -e 'indiagrams/ios-macos-template' -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null \
+  { git grep -lw -F -e 'indiagrams/ios-macos-template' -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null || true; } \
     | while read -r f; do
         sed -i '' "s|indiagrams/ios-macos-template|$escaped_slug|g" "$f"
         ok "GitHub slug substituted in $f"
@@ -425,7 +432,7 @@ apply_substitutions() {
   # because __GSD_DISPLAY_PLACEHOLDER__ contains no HelloApp substring)
   # APP_NAME is regex-validated [A-Z][a-zA-Z0-9]*; no escape needed.
   step "Substituting HelloApp -> $APP_NAME (broad sweep)"
-  git grep -lw -e 'HelloApp' -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null \
+  { git grep -lw -e 'HelloApp' -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null || true; } \
     | while read -r f; do
         sed -i '' "s|HelloApp|$APP_NAME|g" "$f"
         ok "HelloApp substituted in $f"
@@ -441,7 +448,7 @@ apply_substitutions() {
 
   # Step G_NEW: placeholder -> $DISPLAY_NAME (escaped — HIGH-7)
   step "Replacing placeholder with DISPLAY_NAME (HIGH-6)"
-  git grep -lw -F -e "$DISPLAY_PLACEHOLDER" -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null \
+  { git grep -lw -F -e "$DISPLAY_PLACEHOLDER" -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null || true; } \
     | while read -r f; do
         sed -i '' "s|$DISPLAY_PLACEHOLDER|$escaped_display|g" "$f"
         ok "DISPLAY_NAME substituted in $f"

--- a/ci/test-rename-gates.sh
+++ b/ci/test-rename-gates.sh
@@ -1,0 +1,483 @@
+#!/usr/bin/env bash
+# ci/test-rename-gates.sh — fast gate-coverage tests for bin/rename.sh.
+#
+# Complements ci/test-rename.sh (the slow end-to-end integration test
+# that runs `make check*` × 3 platforms) by exercising the script's
+# pre-flight gate behaviors, --dry-run mode, --force semantics,
+# --slug auto-derive, special-character DISPLAY_NAME handling,
+# partial-rename detection, and -h/--help — all without invoking
+# xcodebuild. Runs in <30s vs the 5-10 min integration-test budget.
+#
+# Closes M3 P1 Nyquist coverage gaps:
+#   AC-2  — `bin/rename.sh -h` prints usage with all 5 args
+#   AC-15 — pre-flight failure (dirty tree) exits 1 with explicit stderr
+#   AC-16 — pre-flight failure (invalid APP_NAME) exits 1
+#   AC-17 — pre-flight failure (invalid BUNDLE_ID) exits 1
+#   AC-18 — --dry-run produces stdout describing changes; tree unchanged after
+#   AC-21 — `.planning/` is not modified by the script
+#   REQ-1 — auto-derive --slug from `git remote get-url origin`
+#   REQ-5 — pre-flight gates (empty DISPLAY_NAME, missing --email,
+#           split-flag rejection, '|' in DISPLAY_NAME)
+#   REQ-8 — --dry-run mode shows what WOULD change without applying
+#   REQ-10 — partial-rename detection + --force bypass
+#
+# Plus the 5 explicit gaps from .planning/.../01-ADD-TESTS.md:
+#   - --dry-run output is non-empty + tree-clean after
+#   - --force scenarios (branch + partial-rename bypass)
+#   - --slug auto-derive from origin URL (both git@ and https forms)
+#   - Special-character DISPLAY_NAME (apostrophe, ampersand, backslash)
+#   - Re-rename to a different APP_NAME → case-1 partial-rename fail
+#
+# Usage:
+#   ci/test-rename-gates.sh    # run from repo root
+#
+# Exit 0 = green; non-zero = a gate behaved unexpectedly.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMPDIRS=()
+
+step() { printf '\n==> %s\n' "$*"; }
+ok()   { printf '    ✓ %s\n' "$*"; }
+fail() { printf '    ✗ %s\n' "$*" >&2; exit 1; }
+
+cleanup() {
+  local d
+  for d in "${TMPDIRS[@]}"; do
+    [ -n "$d" ] && [ -d "$d" ] && rm -rf "$d"
+  done
+}
+trap 'cleanup' EXIT INT TERM
+
+# Make a fresh clone in a tmpdir, force-set main, return the path on stdout.
+fresh_clone() {
+  local td
+  td="$(mktemp -d -t test-rename-gates-XXXXXX)"
+  TMPDIRS+=("$td")
+  git clone --no-hardlinks --quiet "$REPO_ROOT" "$td"
+  ( cd "$td" && git checkout --quiet -B main HEAD )
+  printf '%s' "$td"
+}
+
+# ── Pre-flight ────────────────────────────────────────────────────────────
+
+step "Pre-flight"
+cd "$REPO_ROOT"
+test -x bin/rename.sh || fail "bin/rename.sh not executable in $REPO_ROOT"
+command -v git >/dev/null || fail "git not on PATH"
+ok "tools present"
+
+# ── AC-1 (extension): bin/rename.sh starts with #!/usr/bin/env bash ───────
+#
+# The integration test asserts `test -x bin/rename.sh` but does NOT verify
+# the shebang line per AC-1's exact wording. Falsifiable check.
+
+step "AC-1: shebang is #!/usr/bin/env bash"
+SHEBANG=$(head -1 "$REPO_ROOT/bin/rename.sh")
+test "$SHEBANG" = "#!/usr/bin/env bash" || \
+  fail "AC-1: shebang is '$SHEBANG' (expected '#!/usr/bin/env bash')"
+ok "shebang verified"
+
+# ── AC-2 + REQ-1: -h and --help print usage with all 5 args ───────────────
+#
+# Per SPEC AC-2: "bin/rename.sh -h prints usage with all 5 args documented."
+# The 5 args are APP_NAME, BUNDLE_ID, DISPLAY_NAME, --email, --slug.
+# Both -h and --help paths must work (REQ-1 hybrid surface).
+
+step "AC-2: bin/rename.sh -h prints usage with all 5 args"
+set +e
+H_OUT=$(cd "$REPO_ROOT" && bin/rename.sh -h 2>&1)
+H_EXIT=$?
+set -e
+test "$H_EXIT" -eq 0 || fail "AC-2: -h exited $H_EXIT (expected 0)"
+test -n "$H_OUT" || fail "AC-2: -h produced empty output"
+echo "$H_OUT" | grep -q "APP_NAME"     || fail "AC-2: -h missing APP_NAME"
+echo "$H_OUT" | grep -q "BUNDLE_ID"    || fail "AC-2: -h missing BUNDLE_ID"
+echo "$H_OUT" | grep -q "DISPLAY_NAME" || fail "AC-2: -h missing DISPLAY_NAME"
+echo "$H_OUT" | grep -q -- "--email"   || fail "AC-2: -h missing --email"
+echo "$H_OUT" | grep -q -- "--slug"    || fail "AC-2: -h missing --slug"
+ok "-h prints usage with all 5 args (APP_NAME / BUNDLE_ID / DISPLAY_NAME / --email / --slug)"
+
+step "REQ-1: bin/rename.sh --help is an alias for -h"
+set +e
+HELP_OUT=$(cd "$REPO_ROOT" && bin/rename.sh --help 2>&1)
+HELP_EXIT=$?
+set -e
+test "$HELP_EXIT" -eq 0 || fail "REQ-1: --help exited $HELP_EXIT (expected 0)"
+test -n "$HELP_OUT" || fail "REQ-1: --help produced empty output"
+echo "$HELP_OUT" | grep -q "APP_NAME" || fail "REQ-1: --help missing APP_NAME"
+ok "--help works as alias for -h"
+
+# ── AC-15 + REQ-5: pre-flight failure on dirty tree exits 1 ───────────────
+#
+# Per SPEC AC-15: "Pre-flight failure (dirty tree) exits 1 with explicit
+# stderr identifying the gate." The integration test does not exercise
+# this; manually verified per VERIFICATION.md spot-check only.
+
+step "AC-15: dirty tree exits 1 with stderr identifying the gate"
+TD=$(fresh_clone)
+( cd "$TD" && touch .junk-probe )
+set +e
+DT_OUT=$(cd "$TD" && bin/rename.sh MyApp com.acme.myapp "My App" \
+  --email=test@acme.com --slug=test/myapp 2>&1)
+DT_EXIT=$?
+set -e
+test "$DT_EXIT" -ne 0 || fail "AC-15: dirty tree should exit non-zero (got $DT_EXIT); output: $DT_OUT"
+echo "$DT_OUT" | grep -q "working tree not clean" || \
+  fail "AC-15: stderr does not identify clean-tree gate; got: $DT_OUT"
+ok "AC-15 verified — dirty tree exits $DT_EXIT with 'working tree not clean' stderr"
+
+# ── AC-16 + REQ-5: invalid APP_NAME exits 1 ───────────────────────────────
+#
+# SPEC AC-16: "Pre-flight failure (invalid APP_NAME — e.g. lowercase
+# or contains space) exits 1." Three falsifiable rejection forms:
+# space, lowercase, leading digit.
+
+step "AC-16: invalid APP_NAME exits 1 (3 rejection forms)"
+
+for INVALID in "my app" "lowercase" "9starts-digit"; do
+  set +e
+  AN_OUT=$(cd "$REPO_ROOT" && bin/rename.sh "$INVALID" com.acme.myapp "My App" \
+    --email=test@acme.com 2>&1)
+  AN_EXIT=$?
+  set -e
+  test "$AN_EXIT" -ne 0 || \
+    fail "AC-16: APP_NAME '$INVALID' should exit non-zero (got $AN_EXIT); output: $AN_OUT"
+  echo "$AN_OUT" | grep -q "invalid APP_NAME" || \
+    fail "AC-16: stderr for '$INVALID' missing 'invalid APP_NAME'; got: $AN_OUT"
+  ok "APP_NAME '$INVALID' rejected (exit $AN_EXIT)"
+done
+
+# ── AC-17 + REQ-5: invalid BUNDLE_ID exits 1 ──────────────────────────────
+#
+# SPEC AC-17: "Pre-flight failure (invalid BUNDLE_ID — e.g. UPPERCASE
+# or no dots) exits 1." Three falsifiable rejection forms.
+
+step "AC-17: invalid BUNDLE_ID exits 1 (3 rejection forms)"
+
+for INVALID in "My.App" "no-dots" "com.UPPER.case"; do
+  set +e
+  BI_OUT=$(cd "$REPO_ROOT" && bin/rename.sh MyApp "$INVALID" "My App" \
+    --email=test@acme.com 2>&1)
+  BI_EXIT=$?
+  set -e
+  test "$BI_EXIT" -ne 0 || \
+    fail "AC-17: BUNDLE_ID '$INVALID' should exit non-zero (got $BI_EXIT); output: $BI_OUT"
+  echo "$BI_OUT" | grep -q "invalid BUNDLE_ID" || \
+    fail "AC-17: stderr for '$INVALID' missing 'invalid BUNDLE_ID'; got: $BI_OUT"
+  ok "BUNDLE_ID '$INVALID' rejected (exit $BI_EXIT)"
+done
+
+# ── REQ-5: empty DISPLAY_NAME exits 1 ─────────────────────────────────────
+
+step "REQ-5: empty DISPLAY_NAME exits 1"
+set +e
+ED_OUT=$(cd "$REPO_ROOT" && bin/rename.sh MyApp com.acme.myapp "" \
+  --email=test@acme.com 2>&1)
+ED_EXIT=$?
+set -e
+test "$ED_EXIT" -ne 0 || \
+  fail "REQ-5: empty DISPLAY_NAME should exit non-zero (got $ED_EXIT); output: $ED_OUT"
+echo "$ED_OUT" | grep -q "DISPLAY_NAME is empty" || \
+  fail "REQ-5: stderr missing 'DISPLAY_NAME is empty'; got: $ED_OUT"
+ok "empty DISPLAY_NAME rejected (exit $ED_EXIT)"
+
+# ── REQ-5: missing --email exits 1 ────────────────────────────────────────
+
+step "REQ-5: missing --email exits 1"
+set +e
+ME_OUT=$(cd "$REPO_ROOT" && bin/rename.sh MyApp com.acme.myapp "My App" 2>&1)
+ME_EXIT=$?
+set -e
+test "$ME_EXIT" -ne 0 || \
+  fail "REQ-5: missing --email should exit non-zero (got $ME_EXIT); output: $ME_OUT"
+echo "$ME_OUT" | grep -q -- "--email is required" || \
+  fail "REQ-5: stderr missing '--email is required'; got: $ME_OUT"
+ok "missing --email rejected (exit $ME_EXIT)"
+
+# ── REQ-5 + MEDIUM-3: split-flag rejection (--email --slug=foo/bar) ───────
+#
+# Per MEDIUM-3 closure: --email VAL form rejects '-'-prefixed values
+# so '--email --slug=foo/bar' doesn't consume the next flag as the
+# email value. Falsifiable via explicit '-'-prefix.
+
+step "REQ-5 (MEDIUM-3): split-flag rejection on '-'-prefixed value"
+set +e
+SF_OUT=$(cd "$REPO_ROOT" && bin/rename.sh MyApp com.acme.myapp "My App" \
+  --email --slug=foo/bar 2>&1)
+SF_EXIT=$?
+set -e
+test "$SF_EXIT" -ne 0 || \
+  fail "MEDIUM-3: split-flag '-'-prefix should exit non-zero (got $SF_EXIT); output: $SF_OUT"
+echo "$SF_OUT" | grep -q "cannot start with '-'" || \
+  fail "MEDIUM-3: stderr missing 'cannot start with -'; got: $SF_OUT"
+ok "split-flag '-'-prefix rejected (exit $SF_EXIT)"
+
+# ── REQ-5 + HIGH-7: '|' in DISPLAY_NAME exits 1 ──────────────────────────
+
+step "REQ-5 (HIGH-7): '|' in DISPLAY_NAME rejected (sed-delimiter safety)"
+set +e
+PIPE_OUT=$(cd "$REPO_ROOT" && bin/rename.sh MyApp com.acme.myapp "My|App" \
+  --email=test@acme.com 2>&1)
+PIPE_EXIT=$?
+set -e
+test "$PIPE_EXIT" -ne 0 || \
+  fail "HIGH-7: DISPLAY_NAME with '|' should exit non-zero (got $PIPE_EXIT); output: $PIPE_OUT"
+echo "$PIPE_OUT" | grep -q "DISPLAY_NAME contains '|'" || \
+  fail "HIGH-7: stderr missing \"DISPLAY_NAME contains '|'\"; got: $PIPE_OUT"
+ok "'|' in DISPLAY_NAME rejected (exit $PIPE_EXIT)"
+
+# ── AC-18 + REQ-8: --dry-run prints plan + tree unchanged ─────────────────
+#
+# Per SPEC AC-18: "--dry-run produces stdout output describing intended
+# changes; git status --short returns empty after the dry-run."
+# Falsifiable assertion that BOTH conditions hold.
+
+step "AC-18 + REQ-8: --dry-run produces plan + leaves tree clean"
+TD=$(fresh_clone)
+STATUS_BEFORE=$(cd "$TD" && git status --short | sort)
+
+set +e
+DR_OUT=$(cd "$TD" && bin/rename.sh MyApp com.acme.myapp "My App" \
+  --email=test@acme.com --slug=test/myapp --dry-run 2>&1)
+DR_EXIT=$?
+set -e
+
+STATUS_AFTER=$(cd "$TD" && git status --short | sort)
+
+test "$DR_EXIT" -eq 0 || fail "AC-18: --dry-run exited $DR_EXIT (expected 0); output: $DR_OUT"
+test -n "$DR_OUT" || fail "AC-18: --dry-run produced empty stdout"
+echo "$DR_OUT" | grep -q "DRY RUN" || \
+  fail "AC-18: --dry-run output missing 'DRY RUN' header; got: $DR_OUT"
+echo "$DR_OUT" | grep -q "match(es)" || \
+  fail "AC-18: --dry-run output missing per-file match counts; got: $DR_OUT"
+echo "$DR_OUT" | grep -q "File-path renames:" || \
+  fail "AC-18: --dry-run output missing file-path-rename plan; got: $DR_OUT"
+echo "$DR_OUT" | grep -q "xcodegen regen:" || \
+  fail "AC-18: --dry-run output missing xcodegen-regen plan; got: $DR_OUT"
+test "$STATUS_BEFORE" = "$STATUS_AFTER" || \
+  fail "AC-18: --dry-run modified tree:
+BEFORE: $STATUS_BEFORE
+AFTER:  $STATUS_AFTER"
+ok "--dry-run printed plan + tree unchanged (exit 0; $(echo "$DR_OUT" | wc -l | tr -d ' ') lines)"
+
+# Also verify post-rename --dry-run announces "already-renamed" (WR-02)
+step "WR-02: --dry-run on already-renamed announces 'already-renamed'"
+set +e
+( cd "$TD" && bin/rename.sh MyApp com.acme.myapp "My App" \
+    --email=test@acme.com --slug=test/myapp >/dev/null 2>&1 )
+set -e
+set +e
+DR2_OUT=$(cd "$TD" && bin/rename.sh MyApp com.acme.myapp "My App" \
+  --email=test@acme.com --slug=test/myapp --dry-run 2>&1)
+DR2_EXIT=$?
+set -e
+test "$DR2_EXIT" -eq 0 || fail "WR-02: post-rename --dry-run exited $DR2_EXIT"
+echo "$DR2_OUT" | grep -q "already-renamed" || \
+  fail "WR-02: post-rename --dry-run missing 'already-renamed'; got: $DR2_OUT"
+ok "post-rename --dry-run announces 'already-renamed'"
+
+# ── AC-21: .planning/ is not modified by the script ───────────────────────
+#
+# Per SPEC AC-21: ".planning/ and app/HelloApp.xcodeproj/ are not
+# modified by the script." Defense-in-depth pathspec exclusion check —
+# drop a sentinel file into .planning/ before rename, assert it's
+# byte-identical after.
+
+step "AC-21: .planning/ sentinel file untouched after rename"
+TD=$(fresh_clone)
+( cd "$TD" && mkdir -p .planning && \
+    printf 'sentinel for AC-21 %s\n' "$(date +%s)" > .planning/probe.txt )
+SENTINEL_BEFORE=$(cd "$TD" && shasum -a 256 .planning/probe.txt | awk '{print $1}')
+( cd "$TD" && bin/rename.sh MyApp com.acme.myapp "My App" \
+    --email=test@acme.com --slug=test/myapp >/dev/null 2>&1 ) || \
+  fail "AC-21 setup: rename failed unexpectedly"
+test -f "$TD/.planning/probe.txt" || fail "AC-21: .planning/probe.txt deleted"
+SENTINEL_AFTER=$(cd "$TD" && shasum -a 256 .planning/probe.txt | awk '{print $1}')
+test "$SENTINEL_BEFORE" = "$SENTINEL_AFTER" || \
+  fail "AC-21: .planning/probe.txt modified
+BEFORE: $SENTINEL_BEFORE
+AFTER:  $SENTINEL_AFTER"
+ok "AC-21 verified — .planning/probe.txt byte-identical (sha256 $SENTINEL_AFTER)"
+
+# ── REQ-1: --slug auto-derive from origin URL (git@ form) ─────────────────
+#
+# Per SPEC REQ-1: if --slug omitted, auto-derive from `git remote get-url
+# origin`. Two URL forms supported: git@github.com:OWNER/REPO.git and
+# https://github.com/OWNER/REPO.git. Falsifiable via dry-run output
+# inspection.
+
+step "REQ-1: --slug auto-derive from origin (git@ form)"
+TD=$(fresh_clone)
+( cd "$TD" && git remote set-url origin "git@github.com:acme/myapp.git" )
+set +e
+SLUG_OUT=$(cd "$TD" && bin/rename.sh MyApp com.acme.myapp "My App" \
+  --email=test@acme.com --dry-run 2>&1)
+SLUG_EXIT=$?
+set -e
+test "$SLUG_EXIT" -eq 0 || fail "REQ-1: auto-derive (git@ form) exited $SLUG_EXIT"
+echo "$SLUG_OUT" | grep -q "auto-derived from origin: 'acme/myapp'" || \
+  fail "REQ-1: git@ form did not auto-derive 'acme/myapp'; got: $SLUG_OUT"
+ok "git@github.com:acme/myapp.git -> 'acme/myapp'"
+
+step "REQ-1: --slug auto-derive from origin (https form)"
+TD=$(fresh_clone)
+( cd "$TD" && git remote set-url origin "https://github.com/acme/myapp.git" )
+set +e
+SLUG_OUT=$(cd "$TD" && bin/rename.sh MyApp com.acme.myapp "My App" \
+  --email=test@acme.com --dry-run 2>&1)
+SLUG_EXIT=$?
+set -e
+test "$SLUG_EXIT" -eq 0 || fail "REQ-1: auto-derive (https form) exited $SLUG_EXIT"
+echo "$SLUG_OUT" | grep -q "auto-derived from origin: 'acme/myapp'" || \
+  fail "REQ-1: https form did not auto-derive 'acme/myapp'; got: $SLUG_OUT"
+ok "https://github.com/acme/myapp.git -> 'acme/myapp'"
+
+# ── HIGH-7 / sed-escape: special-character DISPLAY_NAME ───────────────────
+#
+# DISPLAY_NAMEs containing apostrophe + ampersand + backslash exercise
+# sed_escape_replacement (BLOCKER-1: \\& in replacement; BSD-portable).
+# Falsifiable: post-rename, the literal special chars must appear in
+# the substituted artifacts (name.txt, ContentView.swift, etc.) — NO
+# corruption from sed metacharacter mishandling.
+
+step "HIGH-7: special-character DISPLAY_NAME (apostrophe + ampersand)"
+TD=$(fresh_clone)
+SPECIAL_DISPLAY="Joe's & Co"
+( cd "$TD" && bin/rename.sh MyApp com.acme.myapp "$SPECIAL_DISPLAY" \
+    --email=test@acme.com --slug=test/myapp >/dev/null 2>&1 ) || \
+  fail "HIGH-7: rename with special-char DISPLAY failed (apostrophe + ampersand)"
+NAME_TXT=$(cd "$TD" && cat fastlane/metadata/en-US/name.txt)
+test "$NAME_TXT" = "$SPECIAL_DISPLAY" || \
+  fail "HIGH-7: name.txt content '$NAME_TXT' (expected '$SPECIAL_DISPLAY')"
+( cd "$TD" && grep -qF "Text(\"$SPECIAL_DISPLAY\")" app/Shared/ContentView.swift ) || \
+  fail "HIGH-7: ContentView.swift missing Text(\"$SPECIAL_DISPLAY\")"
+ok "apostrophe + ampersand DISPLAY_NAME survived sed_escape (literal preserved)"
+
+step "HIGH-7: special-character DISPLAY_NAME (backslash)"
+TD=$(fresh_clone)
+BACKSLASH_DISPLAY='My\App'
+( cd "$TD" && bin/rename.sh MyApp com.acme.myapp "$BACKSLASH_DISPLAY" \
+    --email=test@acme.com --slug=test/myapp >/dev/null 2>&1 ) || \
+  fail "HIGH-7: rename with backslash DISPLAY failed"
+NAME_TXT=$(cd "$TD" && cat fastlane/metadata/en-US/name.txt)
+test "$NAME_TXT" = "$BACKSLASH_DISPLAY" || \
+  fail "HIGH-7: name.txt content '$NAME_TXT' (expected '$BACKSLASH_DISPLAY')"
+ok "backslash DISPLAY_NAME survived sed_escape (literal preserved)"
+
+# ── REQ-10: partial-rename detection + --force bypass ─────────────────────
+#
+# Per SPEC REQ-10: corrupting state post-rename (e.g. moving a renamed
+# file back) triggers exit 1 with "partial-rename state detected" stderr.
+# --force bypasses the gate (per MEDIUM-4). Two falsifiable paths.
+
+step "REQ-10: partial-rename detected (move one renamed file back) exits 1"
+TD=$(fresh_clone)
+( cd "$TD" && bin/rename.sh MyApp com.acme.myapp "My App" \
+    --email=test@acme.com --slug=test/myapp >/dev/null 2>&1 ) || \
+  fail "REQ-10 setup: initial rename failed"
+( cd "$TD" && git add -A && git commit --quiet -m "first rename" )
+# Corrupt state: move ONE renamed file back to its original name.
+( cd "$TD" && git mv app/Shared/MyApp.swift app/Shared/HelloApp.swift && \
+    git commit --quiet -am "partial-rename corruption" )
+
+set +e
+PR_OUT=$(cd "$TD" && bin/rename.sh MyApp com.acme.myapp "My App" \
+  --email=test@acme.com --slug=test/myapp 2>&1)
+PR_EXIT=$?
+set -e
+test "$PR_EXIT" -ne 0 || \
+  fail "REQ-10: partial-rename should exit non-zero (got $PR_EXIT); output: $PR_OUT"
+echo "$PR_OUT" | grep -q "partial-rename state detected" || \
+  fail "REQ-10: stderr missing 'partial-rename state detected'; got: $PR_OUT"
+ok "partial-rename detected (exit $PR_EXIT) — restore-or-force guidance emitted"
+
+step "REQ-10 (MEDIUM-4): --force bypasses partial-rename gate"
+# Same TD as above. With --force, the partial-rename gate is bypassed.
+# The script then proceeds to git mv but the source file is missing
+# for one of the 3 pairs (we moved MyApp.swift back but the other two
+# were already renamed) — that's an EXPECTED downstream failure that
+# proves the bypass worked: control reached past the gate.
+set +e
+FB_OUT=$(cd "$TD" && bin/rename.sh MyApp com.acme.myapp "My App" \
+  --email=test@acme.com --slug=test/myapp --force 2>&1)
+FB_EXIT=$?
+set -e
+echo "$FB_OUT" | grep -qF -- "--force bypass enabled" || \
+  fail "REQ-10 (MEDIUM-4): --force did not announce bypass; got: $FB_OUT"
+# Bypass-announced is the falsifiable signal — the downstream behavior
+# (whether mv succeeds) depends on which file we moved. The SPEC says
+# --force "bypasses the on-main-branch gate AND the partial-rename
+# detection gate" — that's the contract under test.
+ok "--force bypassed partial-rename gate (downstream exit $FB_EXIT — bypass announced)"
+
+# ── REQ-10 (MEDIUM-4): --force bypasses on-main-branch gate ──────────────
+#
+# Per SPEC REQ-5 / MEDIUM-4: --force bypasses the on-main gate (so power
+# users on a feature branch can run the rename). Falsifiable via clean
+# clone on a non-main branch.
+
+step "REQ-10 (MEDIUM-4): --force bypasses on-main-branch gate"
+TD=$(fresh_clone)
+( cd "$TD" && git checkout --quiet -b feature/probe HEAD )
+
+# Without --force: should fail at on-main gate.
+set +e
+NB_OUT=$(cd "$TD" && bin/rename.sh MyApp com.acme.myapp "My App" \
+  --email=test@acme.com --slug=test/myapp 2>&1)
+NB_EXIT=$?
+set -e
+test "$NB_EXIT" -ne 0 || \
+  fail "REQ-5: feature branch without --force should exit non-zero (got $NB_EXIT)"
+echo "$NB_OUT" | grep -q "not on main branch" || \
+  fail "REQ-5: stderr missing 'not on main branch'; got: $NB_OUT"
+ok "feature branch without --force rejected (exit $NB_EXIT)"
+
+# With --force: should succeed (rename completes; xcodegen runs).
+set +e
+FB_OUT=$(cd "$TD" && bin/rename.sh MyApp com.acme.myapp "My App" \
+  --email=test@acme.com --slug=test/myapp --force 2>&1)
+FB_EXIT=$?
+set -e
+test "$FB_EXIT" -eq 0 || \
+  fail "MEDIUM-4: feature branch + --force should succeed (got $FB_EXIT); output: $FB_OUT"
+test -d "$TD/app/MyApp.xcodeproj" || \
+  fail "MEDIUM-4: --force rename completed but app/MyApp.xcodeproj missing"
+ok "feature branch + --force succeeded (exit $FB_EXIT, xcodegen regen confirmed)"
+
+# ── HelloAppApp scrub: G-01 closure verification (substring not whole-word) ─
+#
+# G-01 closure changed Step F from `git grep -lw` to `git grep -l` so
+# `HelloApp` matches inside `HelloAppApp` (the SwiftUI @main struct).
+# This is the textbook "test rubber-stamped a defect" gap from
+# 01-VERIFICATION.md. Falsifiable: post-rename app/Shared/MyApp.swift
+# must NOT contain HelloAppApp; the SwiftUI @main struct should be
+# MyAppApp.
+
+step "G-01: HelloAppApp scrub (substring match in Step F broad sweep)"
+TD=$(fresh_clone)
+( cd "$TD" && bin/rename.sh MyApp com.acme.myapp "My App" \
+    --email=test@acme.com --slug=test/myapp >/dev/null 2>&1 ) || \
+  fail "G-01 setup: rename failed"
+# Falsifiable assertion: HelloAppApp must NOT be in MyApp.swift.
+if grep -qF "HelloAppApp" "$TD/app/Shared/MyApp.swift"; then
+  fail "G-01: app/Shared/MyApp.swift still contains 'HelloAppApp' — Step F broad sweep regression"
+fi
+# Positive assertion: MyAppApp must be in MyApp.swift (the @main struct).
+grep -qF "MyAppApp" "$TD/app/Shared/MyApp.swift" || \
+  fail "G-01: app/Shared/MyApp.swift missing 'MyAppApp' — substitution did not occur"
+# Repo-wide: zero HelloApp substring matches outside the standard exclusions.
+HITS=$(cd "$TD" && git grep -c -e HelloApp -- . \
+        ':!.planning' ':!LICENSE' ':!app/HelloApp.xcodeproj' \
+        ':!bin/rename.sh' ':!ci/test-rename.sh' ':!ci/test-rename-gates.sh' \
+        2>/dev/null \
+        | awk -F: 'BEGIN{s=0} $2>0{s+=$2} END{print s}' || true)
+test "$HITS" = "0" || \
+  fail "G-01: $HITS HelloApp substring matches remain post-rename (substring form, no -w)"
+ok "HelloAppApp scrubbed; MyAppApp present; 0 HelloApp substring hits repo-wide"
+
+# ── Done ──────────────────────────────────────────────────────────────────
+
+step "ci/test-rename-gates.sh: all gate-coverage assertions passed"
+ok "tmpdir cleanup will run via EXIT trap"

--- a/ci/test-rename.sh
+++ b/ci/test-rename.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# ci/test-rename.sh — end-to-end integration test for bin/rename.sh.
+#
+# Clones the live repo to a tmpdir, runs bin/rename.sh with test args,
+# asserts the substitution surfaces are all scrubbed, exercises
+# idempotent re-run and the AC-19 forced-failure rollback, and runs
+# 'make check' in the tmpdir to confirm the renamed app builds green.
+#
+# Usage:
+#   ci/test-rename.sh                # run from repo root
+#
+# Exit 0 = green; non-zero = a substitution / build failed.
+#
+# Iter-4 cross-AI fixes:
+#   - HIGH-2: check_zero includes :!bin/rename.sh :!ci/test-rename.sh
+#     so post-rename grep doesn't false-positive on the running scripts'
+#     literal references
+#   - HIGH-4: idempotency uses standard `set +e; OUT=$(...); EXIT=$?;
+#     set -e` exit-capture (NOT `OUT=$(... || true); EXIT=$?` which
+#     always returns 0 from command substitution)
+#   - HIGH-5: idempotency asserts STATUS_BEFORE == STATUS_AFTER
+#     (script doesn't commit so post-rename tree is dirty by design;
+#     comparing pre/post status detects whether the second run produced
+#     ANY new changes — that's the falsifiable idempotency signal)
+#   - MEDIUM-1: check_zero uses git grep -F for fixed-literal patterns
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMPDIR=""
+
+step() { printf '\n==> %s\n' "$*"; }
+ok()   { printf '    ✓ %s\n' "$*"; }
+fail() { printf '    ✗ %s\n' "$*" >&2; exit 1; }
+
+cleanup() {
+  if [ -n "$TMPDIR" ] && [ -d "$TMPDIR" ]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap 'cleanup' EXIT INT TERM
+
+# ── Pre-flight ────────────────────────────────────────────────────────────
+
+step "Pre-flight"
+cd "$REPO_ROOT"
+test -x bin/rename.sh || fail "bin/rename.sh not executable in $REPO_ROOT"
+command -v git >/dev/null || fail "git not on PATH"
+command -v make >/dev/null || fail "make not on PATH"
+command -v xcodegen >/dev/null || fail "xcodegen not on PATH — run 'make bootstrap' first"
+ok "tools present"
+
+# ── Clone to tmpdir ───────────────────────────────────────────────────────
+
+step "Clone to tmpdir"
+TMPDIR="$(mktemp -d -t test-rename-XXXXXX)"
+ok "tmpdir: $TMPDIR"
+
+git clone --no-hardlinks --quiet "$REPO_ROOT" "$TMPDIR"
+ok "cloned $REPO_ROOT -> $TMPDIR"
+
+cd "$TMPDIR"
+
+# Force-set main to cloned HEAD so bin/rename.sh's on-main pre-flight
+# gate passes AND both shell scripts (bin/rename.sh + ci/test-rename.sh)
+# remain present.
+git checkout --quiet -B main HEAD || \
+  fail "failed to set main to current HEAD in clone"
+test -x bin/rename.sh || \
+  fail "post-checkout: bin/rename.sh missing or not executable in clone"
+ok "on main branch in clone (force-set to cloned HEAD)"
+
+# ── Run bin/rename.sh in the tmpdir ───────────────────────────────────────
+
+step "Run bin/rename.sh in tmpdir"
+TEST_APP="MyApp"
+TEST_BUNDLE="com.test.myapp"
+TEST_DISPLAY="My Test App"
+TEST_EMAIL="test@example.com"
+TEST_SLUG="test/myapp"
+
+bin/rename.sh "$TEST_APP" "$TEST_BUNDLE" "$TEST_DISPLAY" \
+  --email="$TEST_EMAIL" --slug="$TEST_SLUG" \
+  || fail "bin/rename.sh failed in tmpdir"
+ok "rename complete"
+
+# ── Post-rename grep assertions ───────────────────────────────────────────
+
+step "Post-rename assertions"
+
+# HIGH-2 closure: include :!bin/rename.sh and :!ci/test-rename.sh in
+# exclusions so post-rename grep doesn't false-positive on the running
+# scripts' literal references (e.g. error messages mentioning HelloApp).
+# MEDIUM-1: -F applied to fixed-literal patterns containing '.'
+#
+# Signature: check_zero PATTERN [F]
+#   F  → use git grep -F (fixed-string)
+check_zero() {
+  local pat="$1"
+  local fflag="${2:-}"
+  local hits
+  if [ "$fflag" = "F" ]; then
+    hits=$(git grep -cw -F -e "$pat" -- . \
+            ':!.planning' ':!LICENSE' ':!app/HelloApp.xcodeproj' \
+            ':!bin/rename.sh' ':!ci/test-rename.sh' 2>/dev/null \
+            | awk -F: 'BEGIN{s=0} $2>0{s+=$2} END{print s}' || true)
+  else
+    hits=$(git grep -cw -e "$pat" -- . \
+            ':!.planning' ':!LICENSE' ':!app/HelloApp.xcodeproj' \
+            ':!bin/rename.sh' ':!ci/test-rename.sh' 2>/dev/null \
+            | awk -F: 'BEGIN{s=0} $2>0{s+=$2} END{print s}' || true)
+  fi
+  test "$hits" = "0" || fail "post-rename: '$pat' still has $hits matches"
+  ok "'$pat' == 0 matches"
+}
+
+check_zero "HelloApp"
+check_zero "com.example.helloapp" F
+check_zero "maintainers@indiagram.com" F
+check_zero "<year>"
+check_zero "indiagrams/ios-macos-template" F
+
+# Positive assertions: new identifiers present
+test "$(git grep -cw -e "$TEST_APP" -- . ':!.planning' ':!LICENSE' \
+      ':!bin/rename.sh' ':!ci/test-rename.sh' 2>/dev/null \
+      | awk -F: 'BEGIN{s=0} $2>0{s+=$2} END{print s}' || true)" -gt 0 \
+  || fail "post-rename: '$TEST_APP' not present"
+ok "'$TEST_APP' has matches"
+
+test "$(git grep -cw -F -e "$TEST_BUNDLE" -- . ':!.planning' ':!LICENSE' \
+      ':!bin/rename.sh' ':!ci/test-rename.sh' 2>/dev/null \
+      | awk -F: 'BEGIN{s=0} $2>0{s+=$2} END{print s}' || true)" -gt 0 \
+  || fail "post-rename: '$TEST_BUNDLE' not present"
+ok "'$TEST_BUNDLE' has matches"
+
+# File-path renames complete
+test -f "app/Shared/$TEST_APP.swift" || fail "app/Shared/$TEST_APP.swift missing"
+test -f "app/iOS/$TEST_APP.entitlements" || fail "app/iOS/$TEST_APP.entitlements missing"
+test -f "app/macOS/$TEST_APP.entitlements" || fail "app/macOS/$TEST_APP.entitlements missing"
+test ! -f "app/Shared/HelloApp.swift" || fail "old app/Shared/HelloApp.swift still present"
+test ! -f "app/iOS/HelloApp.entitlements" || fail "old app/iOS/HelloApp.entitlements still present"
+test ! -f "app/macOS/HelloApp.entitlements" || fail "old app/macOS/HelloApp.entitlements still present"
+ok "file-path renames complete"
+
+# xcodegen regenerated
+test -d "app/$TEST_APP.xcodeproj" || fail "app/$TEST_APP.xcodeproj missing"
+test ! -d "app/HelloApp.xcodeproj" || fail "old app/HelloApp.xcodeproj still present"
+test -f "app/$TEST_APP.xcodeproj/project.pbxproj" || fail "project.pbxproj missing"
+grep -q "$TEST_BUNDLE" "app/$TEST_APP.xcodeproj/project.pbxproj" || \
+  fail "PRODUCT_BUNDLE_IDENTIFIER '$TEST_BUNDLE' missing from pbxproj"
+ok "xcodegen regen complete"
+
+# LICENSE Copyright preserved
+grep -q "^Copyright (c) 2026 Indiagram LLC" LICENSE || \
+  fail "LICENSE Copyright (c) 2026 Indiagram LLC was modified — MIT requirement violated"
+ok "LICENSE Copyright preserved"
+
+# <year> -> current year
+test "$(grep -c "$(date +%Y)" fastlane/metadata/copyright.txt)" -gt 0 || \
+  fail "current year ($(date +%Y)) not present in fastlane/metadata/copyright.txt"
+ok "<year> -> $(date +%Y) substituted"
+
+# ── Idempotency: re-run with same args (HIGH-3 + HIGH-4 + HIGH-5) ─────────
+#
+# HIGH-3 closure: check_idempotency in bin/rename.sh now runs BEFORE
+# the clean-tree gate, so a second invocation on a dirty post-first-
+# rename tree returns case 0 = silent exit 0.
+#
+# HIGH-4 closure: standard exit-capture pattern. The PRIOR plan used
+# `OUT=$(cmd 2>&1 || true); EXIT=$?` which ALWAYS sets $? to 0 because
+# `|| true` is INSIDE the command substitution — a failing rename
+# would have been silently reported as success. Standard pattern:
+#
+#   set +e
+#   OUT=$(cmd 2>&1)
+#   EXIT=$?
+#   set -e
+#
+# HIGH-5 closure: assert STATUS_BEFORE == STATUS_AFTER instead of
+# asserting clean tree. The script doesn't commit, so post-first-rename
+# the tree is dirty (sed mods + git mv staging uncommitted). A truly
+# idempotent re-run produces NO new changes — STATUS_BEFORE (sorted
+# git status --short) must equal STATUS_AFTER (sorted).
+
+step "Idempotency check (re-run with same args)"
+
+STATUS_BEFORE=$(git status --short | sort)
+
+set +e
+OUT=$(bin/rename.sh "$TEST_APP" "$TEST_BUNDLE" "$TEST_DISPLAY" \
+        --email="$TEST_EMAIL" --slug="$TEST_SLUG" 2>&1)
+EXIT=$?
+set -e
+
+STATUS_AFTER=$(git status --short | sort)
+
+test "$EXIT" = "0" || fail "second rename exit $EXIT (expected 0 for idempotent silent no-op); output: $OUT"
+test "$STATUS_BEFORE" = "$STATUS_AFTER" || fail "second rename modified the tree (idempotency violated):
+BEFORE:
+$STATUS_BEFORE
+AFTER:
+$STATUS_AFTER"
+ok "second rename was silent no-op (exit 0; status unchanged)"
+
+# ── make check: build green on the renamed app ────────────────────────────
+
+step "make check (build the renamed app)"
+bash -euo pipefail <<'BASH'
+set +e
+make check 2>&1 | tee .test-rename-make-check.log
+EXIT=${PIPESTATUS[0]}
+set -e
+test "$EXIT" -eq 0 || { echo "ERROR: make check failed with exit $EXIT"; exit 1; }
+BASH
+ok "make check exit 0"
+
+# ── Forced-failure rollback exercise (SPEC AC-19; HIGH-1 reset-hard) ──────
+#
+# Per SPEC AC-19: forced failure (chmod -w on target file) triggers
+# rollback; `git status --short` empty after script exit 1.
+#
+# HIGH-1 update: rollback now uses reset-hard mechanism (NOT git stash);
+# the contract is unchanged from the test's perspective — pre-rename
+# state is restored, working tree is clean.
+
+step "Forced-failure rollback exercise (SPEC AC-19; HIGH-1 reset-hard)"
+
+# Reset clone to pre-rename state.
+git reset --hard --quiet HEAD
+git clean -fdx --quiet  # -x is fine here because TMPDIR is fully owned by us
+
+test -f app/Shared/HelloApp.swift || \
+  fail "AC-19 setup: expected app/Shared/HelloApp.swift to be present pre-rename after reset"
+test -x bin/rename.sh || \
+  fail "AC-19 setup: bin/rename.sh missing or not executable after reset"
+
+# Force a failure on a substitution target by removing write permission.
+chmod 000 app/Shared/HelloApp.swift
+
+set +e
+bin/rename.sh "$TEST_APP" "$TEST_BUNDLE" "$TEST_DISPLAY" \
+  --email="$TEST_EMAIL" --slug="$TEST_SLUG" >/dev/null 2>&1
+RENAME_EXIT=$?
+set -e
+
+# Restore permissions BEFORE the assertions
+chmod 644 app/Shared/HelloApp.swift 2>/dev/null || true
+
+# AC-19 (a): non-zero exit
+test "$RENAME_EXIT" -ne 0 || \
+  fail "AC-19: expected non-zero exit on forced failure, got $RENAME_EXIT"
+ok "AC-19 (a): forced-failure rename returned non-zero ($RENAME_EXIT)"
+
+# AC-19 (b): `git status --short` empty after rollback
+DIRTY=$(git status --short | wc -l | tr -d ' ')
+test "$DIRTY" = "0" || \
+  fail "AC-19 (b): working tree not clean after rollback (got $DIRTY entries):
+$(git status --short)"
+ok "AC-19 (b): working tree clean after rollback"
+
+# AC-19 (c): pre-rename files restored
+test -f app/Shared/HelloApp.swift || \
+  fail "AC-19 (c): app/Shared/HelloApp.swift missing after rollback"
+test -f app/iOS/HelloApp.entitlements || \
+  fail "AC-19 (c): app/iOS/HelloApp.entitlements missing after rollback"
+test -f app/macOS/HelloApp.entitlements || \
+  fail "AC-19 (c): app/macOS/HelloApp.entitlements missing after rollback"
+ok "AC-19 (c): pre-rename file paths restored"
+
+step "AC-19 forced-failure rollback exercise: PASSED"
+
+# ── Done ──────────────────────────────────────────────────────────────────
+
+step "ci/test-rename.sh: all assertions passed"
+ok "tmpdir cleanup will run via EXIT trap"

--- a/ci/test-rename.sh
+++ b/ci/test-rename.sh
@@ -93,28 +93,40 @@ step "Post-rename assertions"
 # scripts' literal references (e.g. error messages mentioning HelloApp).
 # MEDIUM-1: -F applied to fixed-literal patterns containing '.'
 #
-# Signature: check_zero PATTERN [F]
-#   F  → use git grep -F (fixed-string)
+# Signature: check_zero PATTERN [F|NW]
+#   F   → use git grep -F (fixed-string)
+#   NW  → drop -w word-boundary (substring match — required for HelloApp
+#         per goal-backward gap-closure G-01: HelloAppApp contains
+#         HelloApp as a substring; -w would mask it from the scrub check)
 check_zero() {
   local pat="$1"
-  local fflag="${2:-}"
+  local mode="${2:-}"
   local hits
-  if [ "$fflag" = "F" ]; then
-    hits=$(git grep -cw -F -e "$pat" -- . \
-            ':!.planning' ':!LICENSE' ':!app/HelloApp.xcodeproj' \
-            ':!bin/rename.sh' ':!ci/test-rename.sh' 2>/dev/null \
-            | awk -F: 'BEGIN{s=0} $2>0{s+=$2} END{print s}' || true)
-  else
-    hits=$(git grep -cw -e "$pat" -- . \
-            ':!.planning' ':!LICENSE' ':!app/HelloApp.xcodeproj' \
-            ':!bin/rename.sh' ':!ci/test-rename.sh' 2>/dev/null \
-            | awk -F: 'BEGIN{s=0} $2>0{s+=$2} END{print s}' || true)
-  fi
+  case "$mode" in
+    F)
+      hits=$(git grep -cw -F -e "$pat" -- . \
+              ':!.planning' ':!LICENSE' ':!app/HelloApp.xcodeproj' \
+              ':!bin/rename.sh' ':!ci/test-rename.sh' 2>/dev/null \
+              | awk -F: 'BEGIN{s=0} $2>0{s+=$2} END{print s}' || true)
+      ;;
+    NW)
+      hits=$(git grep -c -e "$pat" -- . \
+              ':!.planning' ':!LICENSE' ':!app/HelloApp.xcodeproj' \
+              ':!bin/rename.sh' ':!ci/test-rename.sh' 2>/dev/null \
+              | awk -F: 'BEGIN{s=0} $2>0{s+=$2} END{print s}' || true)
+      ;;
+    *)
+      hits=$(git grep -cw -e "$pat" -- . \
+              ':!.planning' ':!LICENSE' ':!app/HelloApp.xcodeproj' \
+              ':!bin/rename.sh' ':!ci/test-rename.sh' 2>/dev/null \
+              | awk -F: 'BEGIN{s=0} $2>0{s+=$2} END{print s}' || true)
+      ;;
+  esac
   test "$hits" = "0" || fail "post-rename: '$pat' still has $hits matches"
   ok "'$pat' == 0 matches"
 }
 
-check_zero "HelloApp"
+check_zero "HelloApp" NW
 check_zero "com.example.helloapp" F
 check_zero "maintainers@indiagram.com" F
 check_zero "<year>"
@@ -200,11 +212,25 @@ BEFORE:
 $STATUS_BEFORE
 AFTER:
 $STATUS_AFTER"
-ok "second rename was silent no-op (exit 0; status unchanged)"
+
+# Goal-backward gap-closure G-02: SPEC REQ-6 / AC-13 require the
+# already-renamed re-run to produce NO stdout. The prior form
+# asserted only EXIT==0 + tree-equality, so a stray
+# "==> Pre-flight gates (args validation)" line from validate_args
+# slipped through silently. We now assert OUT is empty.
+test -z "$OUT" || fail "second rename was not silent (expected empty stdout, got):
+$OUT"
+ok "second rename was silent no-op (exit 0; status unchanged; stdout empty)"
 
 # ── make check: build green on the renamed app ────────────────────────────
+#
+# Goal-backward gap-closure G-03: SPEC AC-12 requires verification that
+# the renamed app builds green across all 3 platform targets. The prior
+# form ran only `make check` (iOS device) and assumed the other targets
+# would follow. We now run all three explicitly: iOS device + iOS Sim
+# + macOS, each as a separate gate.
 
-step "make check (build the renamed app)"
+step "make check (iOS device build of the renamed app — AC-11)"
 bash -euo pipefail <<'BASH'
 set +e
 make check 2>&1 | tee .test-rename-make-check.log
@@ -213,6 +239,26 @@ set -e
 test "$EXIT" -eq 0 || { echo "ERROR: make check failed with exit $EXIT"; exit 1; }
 BASH
 ok "make check exit 0"
+
+step "make check-sim (iOS Simulator build of the renamed app — AC-12 part 1)"
+bash -euo pipefail <<'BASH'
+set +e
+make check-sim 2>&1 | tee .test-rename-make-check-sim.log
+EXIT=${PIPESTATUS[0]}
+set -e
+test "$EXIT" -eq 0 || { echo "ERROR: make check-sim failed with exit $EXIT"; exit 1; }
+BASH
+ok "make check-sim exit 0"
+
+step "make check-macos (macOS build of the renamed app — AC-12 part 2)"
+bash -euo pipefail <<'BASH'
+set +e
+make check-macos 2>&1 | tee .test-rename-make-check-macos.log
+EXIT=${PIPESTATUS[0]}
+set -e
+test "$EXIT" -eq 0 || { echo "ERROR: make check-macos failed with exit $EXIT"; exit 1; }
+BASH
+ok "make check-macos exit 0"
 
 # ── Forced-failure rollback exercise (SPEC AC-19; HIGH-1 reset-hard) ──────
 #


### PR DESCRIPTION
## Summary

**M3 P1: `bin/rename.sh` fork-rename script** — first phase of M3 (Renamer + first-run polish), establishing the primary fork-onboarding path. A forker can run a single command from a fresh clone and arrive at a fully renamed, buildable iOS+macOS app with preserved git history.

**Goal:** make `gh repo create --template` → green build flow take ≤5 minutes for a stranger.

**Status:** Verified ✓ (21/21 SPEC ACs after gap-closure; security audit PASS; code review 0 critical / 0 warning / 1 info)

## Changes

Two new files (purely additive — no existing tracked file modified):

- **`bin/rename.sh`** (mode 0755, ~750 LOC) — single executable bash script implementing fork-rename:
  - 5 identity-surface substitutions: `HelloApp` → `APP_NAME` (broad sweep with placeholder approach for DISPLAY_NAME safety), `com.example.helloapp` → `BUNDLE_ID`, `maintainers@indiagram.com` → `EMAIL`, `indiagrams/ios-macos-template` → `SLUG`, `<year>` → current year
  - 3 file-path renames via `git mv` (preserves history): `HelloApp.swift`, iOS `.entitlements`, macOS `.entitlements`
  - `xcodegen generate` regenerates `app/$APP_NAME.xcodeproj/`
  - Idempotent silent re-run via structural file-path signal counting
  - `--dry-run` preview with per-file substitution counts
  - `--force` override for branch + partial-rename gates
  - Reset-hard rollback on any failure (replaces broken `git stash` mechanism)

- **`ci/test-rename.sh`** (mode 0755, ~315 LOC) — end-to-end integration test: clone-tmpdir + rename + post-rename grep assertions + idempotency + AC-19 forced-failure rollback + 3-platform `make check*` (iOS device + iOS Simulator + macOS).

- **`ci/test-rename-gates.sh`** (mode 0755, ~483 LOC) — fast Nyquist coverage test (~5s, 26 assertions): pre-flight gates, `--dry-run`, `--slug` auto-derive, special-character DISPLAY_NAME, `--force` scenarios, partial-rename detection, G-01 substring scrub.

## Usage

```bash
bin/rename.sh APP_NAME BUNDLE_ID DISPLAY_NAME --email=EMAIL [--slug=OWNER/REPO] [--dry-run] [--force]
bin/rename.sh -h    # print usage
```

Pre-flight gates fire in canonical order: args parsing → idempotency check → args validation → xcodegen presence → clean tree → on main → mutations.

## Requirements Addressed

- **REQ-1** to **REQ-10** — all 10 SPEC requirements satisfied
- **AC-1** through **AC-21** — all 21 acceptance criteria verified

## Verification

- ✓ **Code review:** 0 critical, 0 warning, 1 info (out-of-scope polish item)
- ✓ **Goal-backward verification:** 21/21 ACs after gap-closure (initially 17/21; 3 gaps G-01/G-02/G-03 closed via 2 fix commits)
- ✓ **Security audit:** PASS — 21/21 STRIDE threats closed
- ✓ **Validation:** 21/21 AC + 10/10 REQ Nyquist coverage; falsifiability spot-checked
- ✓ **Live integration test:** ci/test-rename.sh exit 0 end-to-end (canonical rename + idempotency + AC-19 forced-failure rollback + 3-platform builds green via xcbeautify)

## Plan Iteration History

7 plan iterations: 3 in-house plan-check + 4 cross-AI iterations (Gemini + Codex). Cross-AI review caught 11 HIGH/MEDIUM defects in-house process missed across the first 3 iterations. Goal-backward verification then caught 3 more gaps the cross-AI review and the integration test rubber-stamped — closed via fix commits `0fea8ac` and `7b1e091`.

This continues the M2 P2-P5 pattern (cross-AI catching HIGHs on substitution-style phases) and extends it: M3 P1 demonstrates that goal-backward verification is a complementary verification stage that catches direct-inspection-against-SPEC defects neither in-house nor cross-AI sees.

## Key Decisions

- **Function-only architecture** (iter-5 BLOCKER-3 closure): file scope = helpers + globals + function defs + traps + `main "$@"` only. Eliminates forward-reference exit-127 risk during incremental T1-T9 commits.
- **Reset-hard rollback** (HIGH-1 closure): replaces broken `git stash` (which is a no-op on clean trees that Gate 7 requires).
- **MUTATION_STARTED guard** (iter-6 BLOCKER-iter5-1): file-scope flag flipped to 1 immediately before first mutation, with rollback() early-out. Prevents trap data-loss on pre-mutation gate failures.
- **DISPLAY_PLACEHOLDER approach** (HIGH-6 closure): 7-step ordering with `__GSD_DISPLAY_PLACEHOLDER__` indirection so DISPLAY_NAME values containing `HelloApp` substring (e.g. "HelloApp Pro") survive the broad sweep.
- **Idempotency check before clean-tree gate** (HIGH-3 + G-02 closure): silent re-run produces NO stdout per AC-13.
- **Step F drops `-w` from broad HelloApp sweep** (G-01 closure): catches the `HelloApp` substring inside `HelloAppApp` (the SwiftUI `@main` struct).

## Test plan

- [x] `bash -n bin/rename.sh` exits 0
- [x] `bin/rename.sh -h` exits 0 and emits usage with all 5 args
- [x] `ci/test-rename-gates.sh` ~5s — 26 assertions pass
- [x] `ci/test-rename.sh` end-to-end pass (clone + rename + 3-platform `make check*` + AC-19 rollback)
- [x] Pre-flight failure modes exercised (invalid APP_NAME / BUNDLE_ID / split-flag / `|` rejection / missing --email)
- [x] Idempotency: silent exit 0 + stdout-empty + STATUS_BEFORE == STATUS_AFTER
- [x] AC-19 forced-failure rollback restores tree to pre-rename state
- [x] Live repo unchanged after T10 build gate (only the cloned tmpdir was mutated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
