### PR TITLE
M3 P4: README ## Renaming the stub leads with bin/rename.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ open app/HelloApp.xcodeproj
 
 ## Renaming the stub
 
+Run these five commands from the cloned repo:
+
+```bash
+bin/rename.sh YourApp com.your-org.yourapp 'Your App' --email=you@example.com    # substitute identity surfaces (app name, bundle ID, display, maintainer email, repo slug)
+bin/verify-rename.sh                                                              # assert no leftover originals (run BEFORE commit so a bad rename never lands in git history)
+git add -A && git commit -m "Rename app stub"                                    # record the rename (rename.sh mutates the tree but does not commit)
+git push -u origin main                                                          # publish your renamed fork BEFORE branch protection is enabled
+bin/setup-github.sh                                                              # branch protection + auto-merge + squash-only (runs LAST so it doesn't gate the initial publish)
+```
+
+That's it — your fork is renamed, verified, committed, pushed, and locked down with branch protection.
+
+<details>
+<summary>If you prefer manual sed</summary>
+
 The stub uses these names:
 
 | Token | Value |
@@ -88,7 +103,12 @@ mv app/Shared/HelloApp.swift            app/Shared/MyApp.swift
 make generate
 ```
 
-You'll also want to:
+</details>
+
+### After rename: still-manual steps
+
+These steps `bin/rename.sh` cannot automate — they need your real assets:
+
 - Replace `app/iOS/Assets.xcassets/AppIcon.appiconset/Icon-1024.png` with your real 1024×1024 icon.
 - Run `make icons` to regenerate the macOS iconset + `.icns` from the new 1024 source.
 - Fill in `fastlane/metadata/en-US/*.txt` (replace TODO markers).


### PR DESCRIPTION
## Summary

**Phase 4 (M3 P4): Update README to lead with bin/rename.sh** — rewrites the `## Renaming the stub` section so a forker reading top-to-bottom hits a 5-command operationally-correct workflow before encountering the demoted manual-sed flow. Manual sed + token table preserved verbatim inside a closed-by-default `<details>` footnote. Tail items (icon / `make icons` / fastlane metadata / copyright TODOs) reframed as `### After rename: still-manual steps` subsection.

**Status:** Verified ✓ (11/12 SPEC ACs PASS empirically; 1 deferred to manual smoke test on disposable fork; 8/8 STRIDE threats SECURED; 0 critical/warning post code-review)

## Changes

### `README.md` (only file modified, +21/-1 lines net; section grew 43 → 64 lines)

The new lead block:

```bash
bin/rename.sh YourApp com.your-org.yourapp 'Your App' --email=you@example.com    # substitute identity surfaces
bin/verify-rename.sh                                                              # assert no leftover originals (BEFORE commit)
git add -A && git commit -m "Rename app stub"                                    # record the rename
git push -u origin main                                                          # publish BEFORE protection enabled
bin/setup-github.sh                                                              # branch protection + auto-merge (LAST)
```

Each command has a 1-line `# WHY` comment per PRINCIPLES.md #6.

The manual sed flow + token table are preserved inside a closed-by-default `<details>` block with summary `If you prefer manual sed`. Tail items live under a new `### After rename: still-manual steps` subsection.

## Why 5 commands not 3 (the original ROADMAP text)

The original ROADMAP entry said "3 lines (rename, setup-github, ship)". Cross-AI codex review caught this as **operationally broken**:

1. `bin/rename.sh` mutates files but does NOT commit — bare `git push` after rename publishes nothing
2. `bin/setup-github.sh` enables branch protection that BLOCKS direct pushes — running it before the first push leaves you stuck

The 5-command flow resolves both: verify before commit (catch bad renames pre-commit), commit before push, push before setup-github. setup-github runs LAST so its branch protection takes effect after the rename has already landed on main.

This makes the new lead block consistent with the existing README:246 prose ("After creating your repo and pushing the first commit, run `make setup-github`") — no internal contradiction.

## Requirements Addressed

- **SPEC-REQ-1** Tool-led 5-command block at top of `## Renaming the stub`
- **SPEC-REQ-2** Manual sed block + token table demoted to closed `<details>` footnote
- **SPEC-REQ-3** "After rename: still-manual steps" subsection at section end
- **SPEC-REQ-4** No changes outside `## Renaming the stub` section heading boundaries
- **SPEC-REQ-5** No changes to CONTRIBUTING.md / SECURITY.md / CODE_OF_CONDUCT.md / docs/PRINCIPLES.md / `.github/*`

## Verification

- [x] `awk` extraction confirms 5 command-invocation lines in correct order at README:60-64
- [x] `grep -rl "HelloApp"` literal preserved inside `<details>` footnote (post lead block)
- [x] All 6 token table headers present inside footnote
- [x] `### After rename: still-manual steps` heading + 4 required items at section end
- [x] `diff -q` of awk-extracted outside-section content is byte-identical pre/post
- [x] `git diff HEAD~1 -- CONTRIBUTING.md SECURITY.md CODE_OF_CONDUCT.md docs/PRINCIPLES.md '.github/**'` returns 0 lines
- [x] README:246 cross-reference anchor intact (line shifted from 226 → 246 due to section growth; content byte-identical)
- [x] gsd-verifier: 6/7 must-haves PASS (AC-04-7 manual smoke test deferred to closure ritual — requires disposable fork + admin gh auth)
- [x] gsd-security-auditor: 8/8 threats SECURED (3 mitigated via implementation; 5 accepted — public-doc info disclosure, fallback DoS, etc.)
- [x] gsd-nyquist-auditor: 11/12 COVERED + 1 HUMAN_NEEDED (AC-04-7)
- [x] In-house code review: 0 critical, 0 warning, 1 INFO (slug-comment clarity nit; deferred)
- [x] Cross-AI review (codex + gemini): 2 HIGH closures landed (operational correctness + SPEC drift); 1 MEDIUM closure (cross-ref consistency); 1 gemini false-positive rejected with verification

## Cross-AI Review Closures

| Tag | Severity | Resolution |
|-----|----------|------------|
| HIGH-1 | HIGH | 5-command operationally-correct flow (commit + push BEFORE setup-github) |
| HIGH-2 | HIGH | SPEC.md updated 2026-04-30 to mandate 5 commands; PLAN matches |
| MEDIUM-1 | MEDIUM | setup-github at position 5 → consistent with README:246 prose |
| Gemini email-typo claim | MEDIUM (claimed) | REJECTED — verified false positive (PLAN.md:199 has correct `--email=you@example.com`) |

## Test plan

- [ ] **Manual smoke test on disposable fork** (AC-04-7): create a fresh repo from this template; clone it; run the 5-command sequence verbatim with real placeholder values; confirm rename + push + protection apply correctly. Cannot be automated (requires admin `gh` auth + disposable repo to avoid mutating production settings).
- [x] CI passes — pr.yml's 3 build checks run on every PR; verify-rename.yml does NOT trigger (paths-filter excludes README.md changes by design — verified D-06 lock).
- [x] github.com renders the new section correctly — `<details>` collapsibility, table inside footnote, nested fenced code blocks all preview cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)