### PR TITLE
M4 P2: README leads with "Quickstart in 5 minutes" — 4-command on-ramp

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,18 @@ The template ships with a working `HelloApp` stub that builds green on both iOS 
 
 ![HelloApp template running natively on macOS — same hammer icon, title, and rename instruction](docs/screenshots/macos-home.png)
 
-## Quickstart
+## Quickstart in 5 minutes
+
+5 minutes from `gh repo create` to a green build:
 
 ```bash
-git clone https://github.com/indiagrams/ios-macos-template.git my-app
-cd my-app
-make bootstrap          # brew bundle, lefthook install, xcodegen, bundle install
-make check              # iOS device build (primary signal)
-make check-macos        # macOS build
-open app/HelloApp.xcodeproj
+gh repo create my-app --template indiagrams/ios-macos-template --public --clone && cd my-app   # ~30s — fork from template + clone
+bin/rename.sh YourApp com.your-org.yourapp 'Your App' --email=you@example.com   # ~30s — substitute identity surfaces
+make bootstrap   # ~3min — brew bundle + lefthook + xcodegen + bundle install (warm Homebrew cache)
+make check   # ~1.5min — iOS device build (primary signal)
 ```
+
+Want branch protection + push to a fresh remote? See [Renaming the stub](#renaming-the-stub) for the full 5-command flow.
 
 ## Renaming the stub
 


### PR DESCRIPTION
## Summary

Replaces the existing `## Quickstart` section in README.md with `## Quickstart in 5 minutes` — a single copy-pasteable bash block that takes a forker from `gh repo create --template` through `make check` (green build) in ≤5 minutes total, with per-command time-budget comments.

```bash
gh repo create my-app --template indiagrams/ios-macos-template --public --clone && cd my-app   # ~30s — fork from template + clone
bin/rename.sh YourApp com.your-org.yourapp 'Your App' --email=you@example.com                  # ~30s — substitute identity surfaces
make bootstrap                                                                                  # ~3min — brew bundle + lefthook + xcodegen + bundle install (warm Homebrew cache)
make check                                                                                      # ~1.5min — iOS device build (primary signal)
```

Footer pointer routes forkers to `## Renaming the stub` for the full 5-command publish-and-protect flow (verify-rename, commit, push, setup-github).

## Why

After M4 P1 inserted the `## What you get` screenshots section, the existing `## Quickstart` was a `git clone`-shape walkthrough — not the canonical template-fork on-ramp a forker landing from a "Use this template" button needs. M4 P2 consolidates the on-ramp into a single 4-command block matching the ROADMAP-mandated shape.

## Cross-AI codex review (load-bearing per M3+M4 pattern)

In-house plan-checker → PASS. Cross-AI codex caught:
- **HIGH-1:** AC-01-4 exclusion-list false-pass risk → replaced with whitelist + exact-count + ordered-prefix gate
- **MEDIUM-1:** Time-budget regex too loose → tightened to anchor at `#` boundary
- **MEDIUM-2:** Stale snapshot reuse → always overwrite via `cp -f` + integrity assertion
- **MEDIUM-3:** SUMMARY.md sequencing vs allowlist → resolved via `.gitignore` rationale (`.planning/` is line 28)
- **LOW-1:** "5 minutes" only in heading → digit form in BOTH heading and intro
- **LOW-2:** Cold-cache time-budget honesty → `(warm Homebrew cache)` qualifier

Gemini hallucinated an email-typo HIGH (`--email=you @example.com`) — verified absent in all files via grep. Dismissed. (Codex 5-for-5 across M3+M4; gemini false-positive 4-for-4.)

## Test plan

- [x] 9 automated SPEC ACs (heading present, old heading absent, 4-command whitelist + count + order, time-budget anchored to `#`, "5 minutes" literal, byte-identical-outside-section, fastlane/ci/app untouched, changed-path allowlist) — all green at execute and verify time
- [x] Code review (gsd-code-review): 0 HIGH, 0 MEDIUM, 0 LOW
- [x] Security audit (gsd-secure-phase): 13/13 threats mitigated/accepted, verdict PASS
- [x] Goal-backward verification (gsd-verifier): goal achieved, 5/5 must-haves verified
- [x] Nyquist coverage (gsd-validate-phase): 15/16 COVERED + 1 HUMAN_NEEDED, 14/14 decisions COVERED, status PASS
- [ ] Manual UAT (AC-01-10): view this PR's "Files changed" tab — confirm:
  - the new `## Quickstart in 5 minutes` section renders inline with valid bash syntax highlighting
  - the `[Renaming the stub](#renaming-the-stub)` anchor link resolves on click
  - the em-dash glyph in `# ~30s — …` comments renders correctly
  - the section visually sits between `## What you get` and `## Renaming the stub`

🤖 Generated with [Claude Code](https://claude.com/claude-code)