### PR TITLE
M4 P3: CHANGELOG.md + tagging strategy + README pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- _Nothing yet — track in-flight work here._
+
+## [0.x] - 2026-04-30
+
+### Added
+- MIT license + Code of Conduct (Contributor Covenant 2.1) + SECURITY.md + CONTRIBUTING.md + PR/issue templates (M1, M2)
+- `bin/rename.sh` — substitution script for forking the template (app name, bundle ID, display, email, repo slug) (M3 P1)
+- `bin/verify-rename.sh` + paths-filtered CI workflow — one-command verdict that rename completed cleanly (M3 P3)
+- `bin/setup-github.sh` — branch protection + auto-merge + squash-only configuration (M2)
+- README `## Renaming the stub` — 5-command operationally-correct flow leading forkers from rename through publish-and-protect (M3 P4)
+- README `## What you get` — iOS + macOS screenshots showing the HelloApp template stub (M4 P1)
+- README `## Quickstart in 5 minutes` — 4-command on-ramp from `gh repo create --template` to green build (M4 P2)
+
+## Versioning
+
+This CHANGELOG tracks **template versions** — releases of the `ios-macos-template` repo itself, not the forker apps that consume it. Forker apps maintain their own CHANGELOG and version policy independently.
+
+Pre-1.0 (`0.x`) is the development phase: breaking changes are allowed without bumping a major version. The `0.x` retrospective entry above summarizes what shipped during M1–M4 milestones; further pre-1.0 work lands under `[Unreleased]` until the public flip.
+
+`v1.0.0` will be cut at the public-visibility flip (ROADMAP M5 P4) — first public release. From `v1.0.0` onward this project follows strict [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `MAJOR.MINOR.PATCH` where MAJOR is incremented for breaking forker-facing changes (renamed `bin/` scripts, removed Make targets, restructured README sections that forkers cite), MINOR for new forker-facing features (new scripts, new sections), and PATCH for fixes that don't change the forker contract.
+
+Forkers tracking template upgrades should read the CHANGELOG before pulling template changes into their fork. Template-fork creation always uses the default branch (`main`); to base a fork on a specific template version, use `git fetch` to pull a specific tag and rebase manually.
+
+## Tagging
+
+When cutting a release:
+
+1. Move the `[Unreleased]` entries into a new `[X.Y.Z] - YYYY-MM-DD` section in `CHANGELOG.md` and commit.
+2. Extract the new section to a release-notes file (e.g. `awk '/^## \[X\.Y\.Z\]/,/^## /' CHANGELOG.md > release-notes.md`, then trim the trailing next-section line).
+3. Create an annotated tag with the release notes as its message, push, and create the GitHub release.
+
+```bash
+# After moving Unreleased → [X.Y.Z] in CHANGELOG.md, committing,
+# and writing release-notes.md (the new section's body):
+git tag -a vX.Y.Z -F release-notes.md   # annotated tag; -F reads notes from file
+git push origin vX.Y.Z
+gh release create vX.Y.Z --notes-from-tag --title "vX.Y.Z" --verify-tag
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Forkers tracking template upgrades should read the CHANGELOG before pulling temp
 When cutting a release:
 
 1. Move the `[Unreleased]` entries into a new `[X.Y.Z] - YYYY-MM-DD` section in `CHANGELOG.md` and commit.
-2. Extract the new section to a release-notes file (e.g. `awk '/^## \[X\.Y\.Z\]/,/^## /' CHANGELOG.md > release-notes.md`, then trim the trailing next-section line).
+2. Extract the new section to a release-notes file: `awk '/^## \[X\.Y\.Z\]/{flag=1; print; next} flag && /^## /{exit} flag' CHANGELOG.md > release-notes.md`.
 3. Create an annotated tag with the release notes as its message, push, and create the GitHub release.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -285,3 +285,5 @@ to match — the names must match the job `name:` attribute exactly.
 ## License
 
 MIT — see [LICENSE](LICENSE).
+
+See [CHANGELOG.md](CHANGELOG.md) for version history and the [Versioning](CHANGELOG.md#versioning) policy.


### PR DESCRIPTION
## Summary

Creates `CHANGELOG.md` at repo root following [keep-a-changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format with:
- `[Unreleased]` section (placeholder for in-flight work)
- `[0.x] - 2026-04-30` retrospective entry summarizing M1-M4 net deliverables (7 bullets)
- `## Versioning` policy section — distinguishes *template versions* (this repo) from *forker app versions*; defines pre-1.0 (`0.x`) phase + post-1.0 strict SemVer rules
- `## Tagging` procedure — annotated `git tag -a vX.Y.Z -F release-notes.md` + `gh release create --notes-from-tag --verify-tag`

Plus a one-line README pointer at end of `## License` section.

## Why

ROADMAP M5 P4 plans the first public tag (`v1.0.0`) at the public-flip milestone. To tag responsibly, we need a CHANGELOG documenting what's *in* v1.0.0 + the development arc that led there. M4 P3 lays that foundation. The `## Tagging` section gives M5 P4 (and forkers) an operationally-correct release procedure.

## Cross-AI codex+gemini review (load-bearing)

In-house plan-checker → PASS. Cross-AI codex+gemini → 1 HIGH consensus + 2 codex-only HIGH + 2 MEDIUM + 1 LOW caught after PASS. Plus in-house gsd-code-reviewer caught a 7th HIGH post-execute. All closed:

- **HIGH-1 (codex):** EOF byte-identical gate could false-pass via command-substitution awk strip → replaced with exact-file `diff -q EXPECTED README.md` + tail-line anchor
- **HIGH-2 (codex+gemini consensus):** Lightweight `git tag` + `--notes-from-tag` falls back to commit message → annotated `git tag -a -F release-notes.md` (verified via `gh release create --help`)
- **HIGH-3 (codex):** Workspace state violated changed-path gate → pre-flight allowlist + ephemeral path filter for `.planning/` + `.claude/scheduled_tasks.lock`
- **MEDIUM-4 (codex):** Bash fence gate too loose → two-stage flag-form awk extracts fence body before literal checks
- **MEDIUM-5 (codex):** SPEC AC-03-12 wording vs `\n` + pointer mechanism mismatch → SPEC updated
- **LOW-6 (codex):** `gh repo create --template @vX.Y.Z` not valid → replaced with `git fetch` + rebase forker advice
- **HIGH-1 (in-house code review post-execute):** BSD awk range recipe `/^## \[X\.Y\.Z\]/,/^## /` self-terminated (start matches end pattern; output = 1-line heading) → replaced with flag-state form, empirically validated on `awk version 20200816`

Codex 6-for-6, gemini 1 TRUE positive (confirms tagging issue). 7 total closures verified in shipped state.

## Test plan

- [x] 16 automated SPEC ACs (heading whitelists + count, fence body extract + literal checks, byte-identical-outside-pointer via exact-file diff, changed-path allowlist with ephemeral filter, fastlane/ci/app/docs untouched) — all green at execute, post-fix, and verify time
- [x] Code review (gsd-code-review): HIGH-1 caught + closed via `gsd-code-review-fix` (commit `6396e00`)
- [x] Security audit (gsd-secure-phase): 15/15 threats mitigated/accepted, verdict PASS
- [x] Goal-backward verification (gsd-verifier): 11/11 truths VERIFIED empirically (including BSD awk recipe yields 9-line body)
- [x] Nyquist coverage (gsd-validate-phase): 20/21 COVERED + 1 HUMAN_NEEDED, 13/13 decisions COVERED, status PASS
- [ ] Manual UAT (AC-03-15): view this PR's "Files changed" tab on github.com — confirm:
  - CHANGELOG.md renders inline with proper markdown formatting
  - The README pointer's `[Versioning](CHANGELOG.md#versioning)` anchor link resolves on click
  - The `## Tagging` section's bash fence highlights correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)