### PR TITLE
M5 P2: bin/setup-github.sh cross-org verification + SMOKE-TEST.md

### DIFF
--- a/docs/SMOKE-TEST.md
+++ b/docs/SMOKE-TEST.md
@@ -150,6 +150,147 @@ rm -rf "../ios-macos-smoke-test"
 rm -f ../bootstrap.log ../check.log ../setup-github.log ../smoke-cleanup.log
 ```
 
+## Cross-org verification
+
+The smoke test above validates the same-org template-fork path
+(`indiagrams/ios-macos-template` → `indiagrams/ios-macos-smoke-test`).
+The cross-org verification adds two coverage axes — a different org
+(`prakashrj/`) and the no-arg auto-detect form of `bin/setup-github.sh` —
+to confirm the script has no hardcoded org assumptions. Run this before
+any major release that affects forker onboarding (e.g., before flipping
+the template public).
+
+### When to run
+
+- Before flipping the template public (M5 P3): confirms any forker in any
+  org can run `bin/setup-github.sh` against their fork.
+- After non-trivial edits to `bin/setup-github.sh` (rename of CI check
+  names; addition/removal of branch-protection fields; merge-mode tweaks).
+- As a periodic regression check at major release boundaries.
+
+### Procedure
+
+```bash
+# 0. Pre-flight: confirm both throwaway repos do not exist; gh has
+#    repo + delete_repo + admin:repo_hook scopes; both orgs admin-accessible.
+gh auth status
+gh repo view indiagrams/ios-macos-smoke-test 2>&1 | grep -q 'Could not resolve'
+gh repo view prakashrj/ios-macos-cross-org-test 2>&1 | grep -q 'Could not resolve'
+
+# 1. Same-org: re-create indiagrams/ios-macos-smoke-test from template +
+#    apply HIGH-1.1 settle pattern.
+cd ..
+INDIAGRAMS_DIR_ABS="$(pwd)/ios-macos-smoke-test"
+gh repo create indiagrams/ios-macos-smoke-test \
+  --template indiagrams/ios-macos-template \
+  --public --clone
+sleep 5
+( cd "$INDIAGRAMS_DIR_ABS" && git checkout HEAD -- . 2>/dev/null || true )
+
+# 2. Run setup-github.sh (explicit form, same-org). Verify protection.
+cd ios-macos-template
+bin/setup-github.sh indiagrams/ios-macos-smoke-test
+sleep 2
+gh api repos/indiagrams/ios-macos-smoke-test/branches/main/protection \
+  --jq '.required_status_checks.contexts[]' | sort
+# Expected exactly:
+#   app (iOS Simulator)
+#   app (iOS device)
+#   app (macOS)
+
+# 3. Idempotency: run setup-github.sh AGAIN. Capture full protection JSON
+#    before + after; assert byte-identical.
+PROTECTION_BEFORE=$(gh api repos/indiagrams/ios-macos-smoke-test/branches/main/protection --jq '.')
+bin/setup-github.sh indiagrams/ios-macos-smoke-test
+sleep 2
+PROTECTION_AFTER=$(gh api repos/indiagrams/ios-macos-smoke-test/branches/main/protection --jq '.')
+[ "$PROTECTION_BEFORE" = "$PROTECTION_AFTER" ] || echo "FAIL: protection drifted on re-run"
+
+# 4. Cross-org: create prakashrj/ios-macos-cross-org-test with --add-readme
+#    (creates main + initial README commit immediately; no template race).
+cd ..
+CROSS_ORG_DIR_ABS="$(pwd)/ios-macos-cross-org-test"
+gh repo create prakashrj/ios-macos-cross-org-test \
+  --public --clone --add-readme
+sleep 2
+
+# 5. Run setup-github.sh (explicit form, cross-org). Verify protection +
+#    state-vector.
+cd ios-macos-template
+bin/setup-github.sh prakashrj/ios-macos-cross-org-test
+sleep 2
+gh api repos/prakashrj/ios-macos-cross-org-test/branches/main/protection \
+  --jq '.required_status_checks.contexts[]' | sort
+gh api repos/prakashrj/ios-macos-cross-org-test \
+  --jq '[.allow_squash_merge, .allow_merge_commit, .allow_rebase_merge, .allow_auto_merge, .delete_branch_on_merge]'
+# Expected: [true,false,false,true,true]
+
+# 6. No-arg auto-detect form: run setup-github.sh from inside the
+#    cross-org clone with no arguments.
+cd "$CROSS_ORG_DIR_ABS"
+"$(pwd)/../ios-macos-template/bin/setup-github.sh"   # no args
+cd -
+
+# 7. Cleanup (trap-on-EXIT in the orchestration; this is the manual form):
+gh repo delete indiagrams/ios-macos-smoke-test --yes
+gh repo delete prakashrj/ios-macos-cross-org-test --yes
+rm -rf "$INDIAGRAMS_DIR_ABS" "$CROSS_ORG_DIR_ABS"
+```
+
+### Expected outcomes
+
+- All 4 `bin/setup-github.sh` invocations exit 0 (1 same-org explicit +
+  1 same-org idempotent re-run + 1 cross-org explicit + 1 cross-org no-arg).
+- Both repos' `main` branch protection has exactly the 3 required CI
+  check names: `app (iOS Simulator)`, `app (iOS device)`, `app (macOS)`.
+- Both repos' merge-mode + auto-delete state-vector returns
+  `[true,false,false,true,true]`.
+- Idempotent re-run on `indiagrams/ios-macos-smoke-test` produces
+  byte-identical protection JSON between the two invocations.
+- Both throwaway repos return 404 from `gh repo view` post-cleanup.
+
+### Cleanup
+
+The orchestration runs a trap-on-EXIT chain that deletes both throwaway
+repos and removes both local clones automatically (whether the run
+succeeded or failed). On failure, the cleanup chain preserves the
+invocation logs for diagnosis.
+
+If the trap does not fire (e.g., `kill -9`), manually:
+
+```bash
+gh repo delete indiagrams/ios-macos-smoke-test --yes 2>/dev/null
+gh repo delete prakashrj/ios-macos-cross-org-test --yes 2>/dev/null
+rm -rf ../ios-macos-smoke-test ../ios-macos-cross-org-test
+rm -f ../indiagrams-*.log ../prakashrj-*.log ../cleanup-*.log
+```
+
+### This run (2026-05-01)
+
+The procedure was executed during M5 P2 against:
+
+- `indiagrams/ios-macos-smoke-test` — created at 2026-05-01T03:06:18Z;
+  re-created via template fork; deleted in cleanup
+- `prakashrj/ios-macos-cross-org-test` — created at 2026-05-01T03:06:41Z;
+  created via `--add-readme`; deleted in cleanup
+
+Timings (wall time, all 4 setup-github invocations):
+
+| Step | Wall time |
+|---|---|
+| `bin/setup-github.sh indiagrams/...` (explicit) | 0m1.555s |
+| `bin/setup-github.sh indiagrams/...` (idempotent re-run) | 0m1.632s |
+| `bin/setup-github.sh prakashrj/...` (explicit) | 0m1.332s |
+| `bin/setup-github.sh` (no-arg, cross-org) | 0m1.271s |
+
+Both repos reached protection-converged state on the first invocation;
+idempotent re-run on the indiagrams repo produced byte-identical
+protection JSON; the no-arg auto-detect form on the prakashrj clone
+correctly resolved `prakashrj/ios-macos-cross-org-test` from origin.
+`bin/setup-github.sh` has zero hardcoded `indiagrams`/`prakashrj`
+references — confirmed via execute-time grep audit
+(per REVIEWS MEDIUM-8 + gemini-LOW-1 closure).
+
 ## Re-running
 
 The smoke test can be re-run anytime — typically before each major release:


### PR DESCRIPTION
## Summary

M5 P2 — verifies `bin/setup-github.sh` works in any org, with both invocation forms. Closes the cross-org portability gate before M5 P3's public flip.

**Change shipped:** `docs/SMOKE-TEST.md` (+141 lines) — adds `## Cross-org verification` section between `## Cleanup` and `## Re-running`. Documents the procedure + this run's empirical results.

**No script changes** — `bin/setup-github.sh` is already cross-org-portable; M5 P2 only verifies + documents.

## What was verified (empirically, this run)

Created 2 throwaway public repos in 2 different orgs, ran `bin/setup-github.sh` 4 times, verified branch protection lands on both, deleted both repos:

| Invocation | Repo | Form | Wall time |
|---|---|---|---|
| STEP B | `indiagrams/ios-macos-smoke-test` | explicit `owner/repo` arg | 1.555s |
| STEP C | `indiagrams/ios-macos-smoke-test` | explicit (idempotent re-run) | 1.632s |
| STEP E | `prakashrj/ios-macos-cross-org-test` | explicit cross-org | 1.332s |
| STEP F | `prakashrj/ios-macos-cross-org-test` | NO-arg auto-detect | 1.271s |

All 4 exit 0; branch protection lands with the exact 3 required CI check names; idempotent re-run produces byte-equal protection JSON; both repos 404 post-cleanup.

## Cross-AI codex+gemini review (load-bearing)

Codex 9-for-9 across M3+M4+M5: caught **4 HIGH defects** that gemini missed entirely:
- **HIGH-1 (structural):** original plan had Edit-tool-in-bash anti-pattern. Replaced with shell-heredoc + awk getline-from-tempfile insertion (BSD-portable, single bash heredoc retained).
- **HIGH-2:** `gh repo create --add-readme --clone` race orphaning remote on clone failure. Fixed via `if/elif/else` recovery.
- **HIGH-3:** Step D fallback didn't recover missing `.git`. Fixed via `rm -rf` + direct `git clone`.
- **HIGH-4:** `grep -Fq '--add-readme'` parses `--add-readme` as option flag. Fixed via `grep -Fq -- '--add-readme'`.

Plus 5 MEDIUM + 2 LOW closures.

12th defect caught by planner during mental-test: BSD awk rejects multi-line `-v var=` values. Replaced with getline-from-tempfile.

## Test plan

- [x] 12+ verify gates at execute time (action gates 0-8 + verify gates A-L)
- [x] Both throwaway repos created + 4 setup-github invocations succeed + both repos deleted
- [x] Branch protection exact-name comparison (HIGH-4 carryforward from M4 P4)
- [x] Idempotent JSON byte-equality between 2 indiagrams runs
- [x] Cross-org no-arg auto-detect form works (verified `Target: prakashrj/ios-macos-cross-org-test` from origin)
- [x] Code review (gsd-code-review): 0 H/M/L
- [x] Security audit (gsd-secure-phase): 24/24 threats closed (21 mitigated + 3 accepted)
- [x] Goal-backward verification (gsd-verifier): goal achieved
- [x] Nyquist coverage (gsd-validate-phase): 17/18 COVERED + 1 HUMAN_NEEDED
- [ ] Manual UAT (AC-02-12): view this PR's "Files changed" tab on github.com — confirm `docs/SMOKE-TEST.md` cross-org section renders inline

## Carries forward to M5 P3

Cross-org portability is now empirically verified. M5 P3 (visibility flip) is unblocked from setup-github concern. The runbook in `docs/SMOKE-TEST.md` becomes the standing pre-release verification for cross-org template-fork flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)