### PR TITLE
M5 P3: visibility flipped to public + CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Visibility flipped from private to public on 2026-05-01 (M5 P3)
+
 ### Added
 - _Nothing yet — track in-flight work here._
 


### PR DESCRIPTION
## Summary

Flips `indiagrams/ios-macos-template` from private to public. Source repo is now publicly readable; "Use this template" button is active. CHANGELOG.md `[Unreleased]` records the flip.

This is the milestone-defining phase: M5 P3 takes the project from private development to public template.

## What changed

- **CHANGELOG.md** — `[Unreleased]` gains a `### Changed` subsection: `- Visibility flipped from private to public on 2026-05-01 (M5 P3)`
- **GitHub-side state** — `indiagrams/ios-macos-template` visibility flipped from PRIVATE → PUBLIC via `gh repo edit ... --visibility public --accept-visibility-change-consequences` (commit `a2ef86e`)

## Closure ritual

| Step | Result |
|------|--------|
| Cross-AI review (codex + gemini) | codex caught 2 HIGH + 4 MED + 2 LOW; gemini found nothing — pattern continues at codex 11-for-11 |
| Replan with REVIEWS.md | All 8 codex closures applied; SPEC AC-03-1 + VALIDATION + PLAN updated |
| Execute | 6/6 tasks PASS; flip exit 0; verify-triple PASS (REST visibility + state-vector + HTTP 200 first attempt) |
| Code review | 0 Critical / 0 Warning / 0 Info on +3-line CHANGELOG insertion |
| Security audit | 11/11 STRIDE threats mitigated; M5 P1 (PR #25) audit clearance still holds at HEAD |
| Nyquist validation | 8/9 ACs COVERED auto; 1 HUMAN_NEEDED (AC-03-9 manual UAT — see Test plan) |
| Verifier (goal-backward) | PASS — `[true,"public"]` state-vector + HTTP 200 + commit `a2ef86e` |

## Acceptance Criteria

- [x] AC-03-1: `gh api repos/indiagrams/ios-macos-template --jq '.visibility'` returns `"public"` (REST endpoint, lowercase — codex HIGH-1 closure)
- [x] AC-03-2: `gh api repos/indiagrams/ios-macos-template --jq '[.is_template, .visibility]'` returns `[true,"public"]`
- [x] AC-03-3: `curl -sI -H 'Authorization:' -H 'Cookie:' https://github.com/indiagrams/ios-macos-template -o /dev/null -w '%{http_code}'` returns `200`
- [x] AC-03-4: exactly 1 `## [Unreleased]` heading in CHANGELOG.md
- [x] AC-03-5: flip-record line present within `[Unreleased]` span
- [x] AC-03-6: post-commit tree clean modulo session-ephemeral allowlist
- [x] AC-03-7: no scope creep — `git diff HEAD~1 HEAD -- README.md docs/ bin/ ci/ app/ fastlane/ Gemfile .gitignore` empty
- [x] AC-03-8: byte-identical-outside-section invariant on CHANGELOG.md
- [ ] AC-03-9 (manual UAT, this PR review): visit https://github.com/indiagrams/ios-macos-template in an incognito browser; confirm green "Use this template" button is visible

## Test plan

- [ ] Open https://github.com/indiagrams/ios-macos-template in an incognito browser (no GitHub session)
- [ ] Confirm the green "Use this template" button is visible at top-right of repo header
- [ ] Confirm the repo is publicly browsable (no auth wall)
- [ ] Confirm CHANGELOG.md `[Unreleased]` `### Changed` line reads: `Visibility flipped from private to public on 2026-05-01 (M5 P3)`

## Manual rollback (documented for emergency, NOT used)

```bash
gh repo edit indiagrams/ios-macos-template --visibility private --accept-visibility-change-consequences
```

Note: search-engine indexing has begun as of ~2026-05-01T04:00Z; rollback would not undo crawl-cache entries.

## Next

M5 P4 (final phase) — tag v1.0.0 + announce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)