### PR TITLE
M5 P4: tag v1.0.0 + GitHub release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ vendor/bundle/
 # OS
 Thumbs.db
 ehthumbs.db
+
+# Generated artifacts (regenerable from CHANGELOG.md)
+release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- Visibility flipped from private to public on 2026-05-01 (M5 P3)
-
 ### Added
 - _Nothing yet — track in-flight work here._
+
+## [1.0.0] - 2026-05-01
+
+### Changed
+- Visibility flipped from private to public on 2026-05-01 (M5 P3)
 
 ## [0.x] - 2026-04-30
 


### PR DESCRIPTION
Phase 4 of M5 (Pre-public audit + go public) — milestone-defining v1.0.0 release.

Changes (squashed into single commit on main):
- CHANGELOG.md: move [Unreleased] → [1.0.0] - 2026-05-01; reset [Unreleased] placeholder
- .gitignore: ignore release-notes.md (ephemeral artifact; regenerable from CHANGELOG.md via M4 P3 awk procedure)

Post-merge automation (executed by /gsd-execute-phase 4 after squash):
- Generate release-notes.md from merged-main CHANGELOG.md
- Create annotated tag v1.0.0 -F release-notes.md at origin/main HEAD
- Push tag (explicit ref; pre-filter-repo-backup excluded)
- gh release create v1.0.0 --notes-from-tag --verify-tag --title "v1.0.0"

Goal-backward invariant: git rev-parse v1.0.0^{commit} == git rev-parse origin/main (codex review HIGH-1 closure).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>