### PR TITLE
M6 P1: docs/TAGGING --cleanup=verbatim + README v1.0.0 banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ When cutting a release:
 ```bash
 # After moving Unreleased → [X.Y.Z] in CHANGELOG.md, committing,
 # and writing release-notes.md (the new section's body):
-git tag -a vX.Y.Z -F release-notes.md   # annotated tag; -F reads notes from file
+git tag -a vX.Y.Z --cleanup=verbatim -F release-notes.md   # annotated tag; --cleanup=verbatim preserves Markdown headings (default --cleanup=strip eats #-prefixed lines); -F reads notes from file
 git push origin vX.Y.Z
 gh release create vX.Y.Z --notes-from-tag --title "vX.Y.Z" --verify-tag
 ```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Swift 5.9](https://img.shields.io/badge/Swift-5.9-orange.svg)](https://swift.org)
 
+> **v1.0.0 released** — [release notes](https://github.com/indiagrams/ios-macos-template/releases/tag/v1.0.0). The "Use this template" button is live; fork it and ship.
+
 Opinionated boilerplate for iOS + macOS apps.
 Distilled from production iOS + macOS apps shipping on the App Store —
 same XcodeGen layout, same fastlane release pipeline, same App Store


### PR DESCRIPTION
## Summary

Two small post-1.0 polish fixes:
- **CHANGELOG.md `## Tagging` example** — adds `--cleanup=verbatim` flag (M5 P4 LEARNINGS surprise: default `--cleanup=strip` ate Markdown headings from tag annotation; tag had to be rebuilt at execute time)
- **README.md v1.0.0 banner** — points visitors to the release page (M5 P4 D-11 deferral)

## Test plan

- [x] grep -Fc 'git tag -a vX.Y.Z --cleanup=verbatim' CHANGELOG.md returns 1
- [x] grep -Fc 'v1.0.0' README.md returns >=1 with release URL
- [x] Atomic commit on CHANGELOG.md + README.md only
- [ ] (PR review) Visual check of README banner rendering on github.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)