### PR TITLE
M6 P2: bin/rename.sh --year flag + bin/verify-rename.sh <year> check

### DIFF
--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -6,7 +6,7 @@
 # idempotent (silent no-op on re-run with same args), pre-flight-gated.
 #
 # Usage:
-#   bin/rename.sh APP_NAME BUNDLE_ID DISPLAY_NAME --email=EMAIL [--slug=OWNER/REPO] [--dry-run] [--force]
+#   bin/rename.sh APP_NAME BUNDLE_ID DISPLAY_NAME --email=EMAIL [--slug=OWNER/REPO] [--year=YYYY] [--dry-run] [--force]
 #   bin/rename.sh -h                                # print this usage
 #   bin/rename.sh --help                            # alias for -h
 #
@@ -29,6 +29,7 @@
 #                       CONTRIBUTING.md. If omitted, auto-derives from
 #                       `git remote get-url origin`. MUST NOT contain
 #                       newline or '|'.
+#   --year=YYYY         Override copyright year (default: current year via date +%Y).
 #   --dry-run           Preview substitutions without applying.
 #   --force             Override the on-main-branch gate AND the partial-
 #                       rename detection gate. Other gates (args validation,
@@ -107,6 +108,7 @@ BUNDLE_ID=""
 DISPLAY_NAME=""
 EMAIL=""
 SLUG=""
+YEAR_ARG=""
 DRY_RUN=0
 FORCE=0
 
@@ -135,6 +137,12 @@ parse_args() {
         [ $# -ge 2 ] || fail "--slug requires a value (e.g. --slug=acme/myapp)"
         case "$2" in -*) fail "--slug value cannot start with '-' (got '$2')";; esac
         SLUG="$2"; shift 2 ;;
+      --year=*)
+        YEAR_ARG="${1#--year=}"; shift ;;
+      --year)
+        [ $# -ge 2 ] || fail "--year requires a value (e.g. --year=2026)"
+        case "$2" in -*) fail "--year value cannot start with '-' (got '$2')";; esac
+        YEAR_ARG="$2"; shift 2 ;;
       -*)
         fail "unknown flag '$1' — run with -h for usage" ;;
       *)
@@ -357,7 +365,7 @@ DISPLAY_PLACEHOLDER='__GSD_DISPLAY_PLACEHOLDER__'
 
 apply_substitutions() {
   local year escaped_email escaped_slug escaped_display
-  year=$(date +%Y)
+  year="${YEAR_ARG:-$(date +%Y)}"
   escaped_email=$(sed_escape_replacement "$EMAIL")
   escaped_slug=$(sed_escape_replacement "$SLUG")
   escaped_display=$(sed_escape_replacement "$DISPLAY_NAME")

--- a/bin/verify-rename.sh
+++ b/bin/verify-rename.sh
@@ -78,6 +78,7 @@ APP_NAME_ORIG="HelloApp"
 BUNDLE_ID_ORIG="com.example.helloapp"
 EMAIL_ORIG="maintainers@indiagram.com"
 SLUG_ORIG="indiagrams/ios-macos-template"
+YEAR_ORIG="<year>"
 
 # check_surface LABEL LITERAL
 # Greps tracked files for LITERAL excluding the 5 self-reference paths.
@@ -136,13 +137,14 @@ check_surface() {
   echo "$count"
 }
 
-# ── Main: 4 surface checks + summary on failure ───────────────────────
+# ── Main: 5 surface checks + summary on failure ───────────────────────
 APP_NAME_HITS=$(check_surface "APP_NAME" "$APP_NAME_ORIG")
 BUNDLE_ID_HITS=$(check_surface "BUNDLE_ID" "$BUNDLE_ID_ORIG")
 EMAIL_HITS=$(check_surface "EMAIL" "$EMAIL_ORIG")
 SLUG_HITS=$(check_surface "SLUG" "$SLUG_ORIG")
+YEAR_HITS=$(check_surface "YEAR" "$YEAR_ORIG")
 
-TOTAL=$((APP_NAME_HITS + BUNDLE_ID_HITS + EMAIL_HITS + SLUG_HITS))
+TOTAL=$((APP_NAME_HITS + BUNDLE_ID_HITS + EMAIL_HITS + SLUG_HITS + YEAR_HITS))
 
 # Count surfaces with non-zero matches.
 SURFACES_LEAKED=0
@@ -150,6 +152,7 @@ SURFACES_LEAKED=0
 [ "$BUNDLE_ID_HITS" -gt 0 ] && SURFACES_LEAKED=$((SURFACES_LEAKED + 1))
 [ "$EMAIL_HITS"     -gt 0 ] && SURFACES_LEAKED=$((SURFACES_LEAKED + 1))
 [ "$SLUG_HITS"      -gt 0 ] && SURFACES_LEAKED=$((SURFACES_LEAKED + 1))
+[ "$YEAR_HITS"      -gt 0 ] && SURFACES_LEAKED=$((SURFACES_LEAKED + 1))
 
 if [ "$TOTAL" -gt 0 ]; then
   printf 'Verify failed: %d total matches across %d surfaces.\n' \


### PR DESCRIPTION
## Summary

Two small post-1.0 polish fixes completing the M3-carried `<year>` placeholder work:
- **`bin/rename.sh`** — adds `--year YYYY` override flag (default: `date +%Y`, behavior unchanged when omitted). Mirrors `--email` / `--slug` parse pattern.
- **`bin/verify-rename.sh`** — adds 5th surface check via existing `check_surface()` helper for residual `<year>` placeholders post-rename.

## Test plan

- [x] `grep -Fc -- '--year' bin/rename.sh` returns ≥4
- [x] `apply_substitutions()` resolves `year="${YEAR_ARG:-$(date +%Y)}"`
- [x] `bin/verify-rename.sh` has `YEAR_ORIG="<year>"` + `YEAR_HITS=$(check_surface "YEAR" "$YEAR_ORIG")` + integrated TOTAL/SURFACES_LEAKED accumulators
- [x] AC-02-2 runtime check: residual `<year>` in test fixture causes verify-rename.sh exit 1
- [x] Atomic commit on bin/rename.sh + bin/verify-rename.sh only

🤖 Generated with [Claude Code](https://claude.com/claude-code)