### PR TITLE
M6 P3: 5 M3 in-house review INFO closures (workflow + tests + README)

### DIFF
--- a/.github/workflows/verify-rename.yml
+++ b/.github/workflows/verify-rename.yml
@@ -14,10 +14,15 @@ on:
       - bin/rename.sh
       - bin/verify-rename.sh
       - ci/test-verify-rename.sh
+      - .github/workflows/verify-rename.yml
+
+# Least-privilege token (M6 P3 IN-01 closure).
+permissions:
+  contents: read
 
 # D-07: mirror pr.yml concurrency — cancel stale verify runs on new push.
 concurrency:
-  group: verify-rename-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The template ships with a working `HelloApp` stub that builds green on both iOS 
 
 ```bash
 gh repo create my-app --template indiagrams/ios-macos-template --public --clone && cd my-app   # ~30s — fork from template + clone
-bin/rename.sh YourApp com.your-org.yourapp 'Your App' --email=you@example.com   # ~30s — substitute identity surfaces
+bin/rename.sh YourApp com.your-org.yourapp 'Your App' --email=you@example.com   # ~30s — substitute identity surfaces (app name, bundle ID, display, maintainer email; repo slug auto-derived from git remote)
 make bootstrap   # ~3min — brew bundle + lefthook + xcodegen + bundle install (warm Homebrew cache)
 make check   # ~1.5min — iOS device build (primary signal)
 ```

--- a/ci/test-rename.sh
+++ b/ci/test-rename.sh
@@ -27,15 +27,15 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-TMPDIR=""
+WORK_DIR=""
 
 step() { printf '\n==> %s\n' "$*"; }
 ok()   { printf '    ✓ %s\n' "$*"; }
 fail() { printf '    ✗ %s\n' "$*" >&2; exit 1; }
 
 cleanup() {
-  if [ -n "$TMPDIR" ] && [ -d "$TMPDIR" ]; then
-    rm -rf "$TMPDIR"
+  if [ -n "$WORK_DIR" ] && [ -d "$WORK_DIR" ]; then
+    rm -rf "$WORK_DIR"
   fi
 }
 trap 'cleanup' EXIT INT TERM
@@ -53,13 +53,13 @@ ok "tools present"
 # ── Clone to tmpdir ───────────────────────────────────────────────────────
 
 step "Clone to tmpdir"
-TMPDIR="$(mktemp -d -t test-rename-XXXXXX)"
-ok "tmpdir: $TMPDIR"
+WORK_DIR="$(mktemp -d -t test-rename-XXXXXX)"
+ok "tmpdir: $WORK_DIR"
 
-git clone --no-hardlinks --quiet "$REPO_ROOT" "$TMPDIR"
-ok "cloned $REPO_ROOT -> $TMPDIR"
+git clone --no-hardlinks --quiet "$REPO_ROOT" "$WORK_DIR"
+ok "cloned $REPO_ROOT -> $WORK_DIR"
 
-cd "$TMPDIR"
+cd "$WORK_DIR"
 
 # Force-set main to cloned HEAD so bin/rename.sh's on-main pre-flight
 # gate passes AND both shell scripts (bin/rename.sh + ci/test-rename.sh)
@@ -292,7 +292,7 @@ step "Forced-failure rollback exercise (SPEC AC-19; HIGH-1 reset-hard)"
 
 # Reset clone to pre-rename state.
 git reset --hard --quiet HEAD
-git clean -fdx --quiet  # -x is fine here because TMPDIR is fully owned by us
+git clean -fdx --quiet  # -x is fine here because WORK_DIR is fully owned by us
 
 test -f app/Shared/HelloApp.swift || \
   fail "AC-19 setup: expected app/Shared/HelloApp.swift to be present pre-rename after reset"

--- a/ci/test-verify-rename.sh
+++ b/ci/test-verify-rename.sh
@@ -11,7 +11,7 @@
 # test that catches drift if the exclusion list ever expands or contracts.
 #
 # Cross-AI review closures (see 03-REVIEWS.md):
-#   HIGH-Plan2-1 — restore README.md via `cp $TMPDIR/README.md.post-rename`
+#   HIGH-Plan2-1 — restore README.md via `cp $WORK_DIR/README.md.post-rename`
 #                  snapshot, NOT a git-based file restore (resetting the
 #                  file to HEAD). HEAD is pre-rename in the tmpdir because
 #                  rename.sh leaves changes uncommitted; restoring to it
@@ -32,15 +32,15 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-TMPDIR=""
+WORK_DIR=""
 
 step() { printf '\n==> %s\n' "$*"; }
 ok()   { printf '    ✓ %s\n' "$*"; }
 fail() { printf '    ✗ %s\n' "$*" >&2; exit 1; }
 
 cleanup() {
-  if [ -n "$TMPDIR" ] && [ -d "$TMPDIR" ]; then
-    rm -rf "$TMPDIR"
+  if [ -n "$WORK_DIR" ] && [ -d "$WORK_DIR" ]; then
+    rm -rf "$WORK_DIR"
   fi
 }
 trap 'cleanup' EXIT INT TERM
@@ -54,13 +54,13 @@ command -v xcodegen  >/dev/null || fail "xcodegen not on PATH — run 'make boot
 ok "tools present"
 
 step "Clone to tmpdir"
-TMPDIR="$(mktemp -d -t test-verify-rename-XXXXXX)"
-ok "tmpdir: $TMPDIR"
+WORK_DIR="$(mktemp -d -t test-verify-rename-XXXXXX)"
+ok "tmpdir: $WORK_DIR"
 
-git clone --no-hardlinks --quiet "$REPO_ROOT" "$TMPDIR"
-ok "cloned $REPO_ROOT -> $TMPDIR"
+git clone --no-hardlinks --quiet "$REPO_ROOT" "$WORK_DIR"
+ok "cloned $REPO_ROOT -> $WORK_DIR"
 
-cd "$TMPDIR"
+cd "$WORK_DIR"
 
 git checkout --quiet -B main HEAD \
   || fail "failed to set main to current HEAD in clone"
@@ -103,9 +103,9 @@ step "Mutate-and-fail: snapshot README, reintroduce HelloApp, assert byte-exact 
 # because rename.sh leaves changes uncommitted in the tmpdir — that
 # would restore to pre-rename, with all 5 surface literals re-leaked,
 # invalidating the D-05 test entirely. Use a file snapshot via cp.
-cp README.md "$TMPDIR/README.md.post-rename" \
-  || fail "could not snapshot README.md to $TMPDIR/README.md.post-rename"
-ok "README.md snapshotted to $TMPDIR/README.md.post-rename"
+cp README.md "$WORK_DIR/README.md.post-rename" \
+  || fail "could not snapshot README.md to $WORK_DIR/README.md.post-rename"
+ok "README.md snapshotted to $WORK_DIR/README.md.post-rename"
 
 # Append the literal HelloApp to README.md. This is in the post-rename
 # tmpdir, so any HelloApp marker is a leak (the rename swept the file
@@ -145,7 +145,7 @@ test -z "$VERIFY_STDOUT" || fail "mutate-and-fail: stdout not empty on exit 1"
 ok "mutate-and-fail: exit $VERIFY_EXIT + byte-exact APP_NAME header + README mention + summary + stdout empty"
 
 # Cross-AI HIGH-Plan2-1: restore README from snapshot, NOT git checkout.
-cp "$TMPDIR/README.md.post-rename" README.md \
+cp "$WORK_DIR/README.md.post-rename" README.md \
   || fail "could not restore README.md from snapshot"
 ok "README.md restored to post-rename state via snapshot (NOT git checkout)"
 


### PR DESCRIPTION
## Summary

Bundles 5 INFO items deferred from M3 P3 + P4 in-house code reviews:
- **M3-P3-IN-01:** verify-rename.yml adds `permissions: contents: read` (least-privilege token)
- **M3-P3-IN-02:** workflow file added to its own `paths:` filter
- **M3-P3-IN-03:** drop redundant `${{ github.workflow }}` from concurrency group prefix
- **M3-P3-IN-04:** rename `TMPDIR` → `WORK_DIR` in `ci/test-verify-rename.sh` + `ci/test-rename.sh`
- **M3-P4-IN-01:** README Quickstart comment clarifies slug auto-derive

All 5 are pure defense-in-depth + clarity polish.

## Test plan

- [x] permissions block present
- [x] Workflow file in own paths filter
- [x] Concurrency group reduced
- [x] Zero TMPDIR; bash -n syntax intact
- [x] README slug-comment tightened
- [x] Atomic commit on 4 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)