### PR TITLE
chore: bin/preflight.sh + docs/APPLE-PREREQS.md for first-time forkers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,19 @@ The template ships with a working `HelloApp` stub that builds green on both iOS 
 
 ## Quickstart in 5 minutes
 
-5 minutes from `gh repo create` to a green build:
+**Prereqs:** macOS with Xcode (the full app, not just Command Line Tools), Homebrew, and `gh` authenticated.
+
+**Don't have all of those?** Run `bin/preflight.sh` first — it checks every prereq and walks you through installing the missing ones (Homebrew, gh CLI, gh auth, bundler). One-time setup, then you're ready:
+
+```bash
+git clone https://github.com/indiagrams/ios-macos-template.git /tmp/preflight \
+  && bash /tmp/preflight/bin/preflight.sh \
+  && rm -rf /tmp/preflight
+```
+
+**Apple Developer account?** See [`docs/APPLE-PREREQS.md`](docs/APPLE-PREREQS.md) — a free Apple ID is enough to build and run on Simulator; the paid Developer Program ($99/yr) is required for TestFlight + App Store. The doc covers Team ID, App Store Connect API keys, and code-signing artifacts to keep out of git.
+
+**5 minutes from `gh repo create` to a green build:**
 
 ```bash
 gh repo create my-app --template indiagrams/ios-macos-template --public --clone && cd my-app   # ~30s — fork from template + clone

--- a/bin/preflight.sh
+++ b/bin/preflight.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# bin/preflight.sh — verify + auto-install prereqs for ios-macos-template forks.
+#
+# Idempotent. Run repeatedly; only acts on what's missing.
+#
+# Auto-installs (with confirmation): Homebrew, gh CLI, bundler.
+# Auto-fixes (with confirmation): xcode-select dev dir, Xcode license.
+# Cannot auto-install: Xcode (Mac App Store), Apple Developer membership.
+#
+# Usage:
+#   bin/preflight.sh                # interactive; prompts before each install
+#   bin/preflight.sh --yes          # auto-confirm all install/fix prompts
+#
+# Exit codes:
+#   0 — all prereqs satisfied
+#   1 — one or more prereqs missing AND user declined to fix
+#   2 — Xcode not installed (manual install required from Mac App Store)
+
+set -euo pipefail
+
+YES=0
+[ "${1:-}" = "--yes" ] && YES=1
+
+step()  { printf '\n==> %s\n' "$*"; }
+ok()    { printf '    ✓ %s\n' "$*"; }
+warn()  { printf '    ⚠ %s\n' "$*" >&2; }
+fail()  { printf '    ✗ %s\n' "$*" >&2; exit 1; }
+
+ask() {
+  local q="$1"
+  [ "$YES" = "1" ] && return 0
+  printf '    > %s [y/N] ' "$q"
+  read -r ans
+  [[ "$ans" =~ ^[Yy]$ ]]
+}
+
+# ── 1. macOS check ──────────────────────────────────────────────
+step "1/8: macOS"
+if [ "$(uname -s)" != "Darwin" ]; then
+  fail "macOS required (got $(uname -s)). Xcode only runs on macOS."
+fi
+ok "macOS $(sw_vers -productVersion)"
+
+# ── 2. Xcode app installed ──────────────────────────────────────
+step "2/8: Xcode (full app)"
+if [ ! -d /Applications/Xcode.app ]; then
+  warn "Xcode not found at /Applications/Xcode.app"
+  echo "    Install Xcode from the Mac App Store (~10-15 GB, 30-60 min download)."
+  echo "    https://apps.apple.com/us/app/xcode/id497799835"
+  echo "    Then: open Xcode once to accept the launch dialog, and re-run this script."
+  exit 2
+fi
+XCODE_VER=$(defaults read /Applications/Xcode.app/Contents/Info CFBundleShortVersionString 2>/dev/null || echo "unknown")
+ok "Xcode $XCODE_VER at /Applications/Xcode.app"
+
+# ── 3. xcode-select pointing at Xcode ──────────────────────────
+step "3/8: xcode-select active developer directory"
+ACTIVE=$(xcode-select -p 2>/dev/null || echo "")
+if [[ "$ACTIVE" == */CommandLineTools ]] || [ -z "$ACTIVE" ]; then
+  warn "xcode-select points at: ${ACTIVE:-<unset>}"
+  echo "    Need: /Applications/Xcode.app/Contents/Developer"
+  if ask "Run sudo xcode-select -s now?"; then
+    sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+    ok "xcode-select switched"
+  else
+    fail "xcode-select must point at Xcode. Run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer"
+  fi
+fi
+ok "xcode-select: $(xcode-select -p)"
+
+# ── 4. Xcode license accepted ──────────────────────────────────
+step "4/8: Xcode license"
+if ! /usr/bin/xcrun --find xcodebuild >/dev/null 2>&1 || ! xcodebuild -version >/dev/null 2>&1; then
+  warn "Xcode license not accepted (xcodebuild can't run)"
+  if ask "Run sudo xcodebuild -license accept now?"; then
+    sudo xcodebuild -license accept
+    ok "Xcode license accepted"
+  else
+    fail "Xcode license must be accepted. Run: sudo xcodebuild -license accept"
+  fi
+fi
+ok "Xcode license accepted"
+
+# ── 5. Homebrew ────────────────────────────────────────────────
+step "5/8: Homebrew"
+if ! command -v brew >/dev/null 2>&1; then
+  warn "Homebrew not installed"
+  echo "    Required for: make bootstrap (xcodegen, fastlane, lefthook from Brewfile)"
+  if ask "Install Homebrew now? (downloads + runs official install script from brew.sh)"; then
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    # Try common Homebrew paths so brew is on PATH this session
+    if [ -x /opt/homebrew/bin/brew ]; then
+      eval "$(/opt/homebrew/bin/brew shellenv)"
+    elif [ -x /usr/local/bin/brew ]; then
+      eval "$(/usr/local/bin/brew shellenv)"
+    fi
+    ok "Homebrew installed"
+  else
+    fail "Homebrew required. See https://brew.sh"
+  fi
+fi
+ok "Homebrew $(brew --version | head -1 | awk '{print $2}')"
+
+# ── 6. gh CLI installed ────────────────────────────────────────
+step "6/8: gh CLI installed"
+if ! command -v gh >/dev/null 2>&1; then
+  warn "gh CLI not installed"
+  if ask "Install via brew install gh?"; then
+    brew install gh
+    ok "gh installed"
+  else
+    fail "gh required for gh repo create + bin/setup-github.sh"
+  fi
+fi
+ok "gh $(gh --version | head -1 | awk '{print $3}')"
+
+# ── 7. gh authenticated ────────────────────────────────────────
+step "7/8: gh authenticated"
+if ! gh auth status >/dev/null 2>&1; then
+  warn "gh not authenticated"
+  echo "    gh auth login walks you through browser-based or token-based login"
+  if ask "Run gh auth login now?"; then
+    gh auth login
+    ok "gh authenticated"
+  else
+    fail "gh must be authenticated. Run: gh auth login"
+  fi
+fi
+GH_USER=$(gh api user --jq .login 2>/dev/null || echo "?")
+ok "gh authenticated as $GH_USER"
+
+# ── 8. Bundler (for fastlane Ruby gems) ───────────────────────
+step "8/8: Bundler (for fastlane)"
+if ! command -v bundle >/dev/null 2>&1; then
+  warn "Bundler not installed"
+  if ask "Install via gem install bundler? (uses macOS system Ruby)"; then
+    sudo gem install bundler
+    ok "Bundler installed"
+  else
+    warn "Bundler is required for make bootstrap (Ruby gems for fastlane)"
+    fail "Install bundler manually: sudo gem install bundler"
+  fi
+fi
+ok "Bundler $(bundle --version | awk '{print $3}')"
+
+# ── Summary ────────────────────────────────────────────────────
+step "All preflight checks passed"
+cat <<'EOF'
+
+  Next steps:
+
+    1. (Optional) Read docs/APPLE-PREREQS.md if you plan to ship to TestFlight or
+       the App Store — covers what tier of Apple Developer account you need.
+
+    2. Quickstart from a fresh fork:
+
+         gh repo create my-app --template indiagrams/ios-macos-template --public --clone && cd my-app
+         bin/rename.sh YourApp com.your-org.yourapp 'Your App' --email=you@example.com
+         make bootstrap
+         make check
+
+EOF

--- a/docs/APPLE-PREREQS.md
+++ b/docs/APPLE-PREREQS.md
@@ -1,0 +1,82 @@
+# Apple Account Prerequisites
+
+What you need from Apple to use this template, broken down by what you actually plan to do.
+
+## Three tiers of Apple account
+
+### 1. Apple ID (free, required to download Xcode)
+
+- Sign up: <https://appleid.apple.com>
+- Used to download Xcode from the Mac App Store and to sign into Xcode for personal-team development signing.
+
+### 2. Free Apple Developer account (free, optional)
+
+- Sign in to Xcode (Xcode → Settings → Accounts → "+" → Apple ID) with your Apple ID and Xcode automatically enrolls you in the free developer tier.
+- Lets you sideload your app to your own physical iPhone/iPad for testing.
+- Provisioning profiles expire every 7 days (you re-build to refresh).
+- No paid subscription required.
+
+### 3. Apple Developer Program ($99 USD/year, required to ship)
+
+- Enroll: <https://developer.apple.com/programs/>
+- Required for:
+  - App Store distribution
+  - TestFlight builds
+  - Push notifications, iCloud, Sign in with Apple, certain entitlements
+  - Long-lived (1-year) provisioning profiles
+- Individual or Organization tier — Organization needs a D-U-N-S number (free; takes a few business days).
+
+## What this template specifically needs
+
+| Capability | Apple ID | Free dev | Paid program |
+|------------|----------|----------|--------------|
+| Open the project in Xcode | ✓ | — | — |
+| Build for iOS Simulator | ✓ | — | — |
+| Build for macOS | ✓ | — | — |
+| Run on a physical iPhone | — | ✓ | — |
+| Submit to TestFlight | — | — | ✓ |
+| Submit to App Store | — | — | ✓ |
+| Use the fastlane release pipeline (`fastlane release`) | — | — | ✓ |
+| Push notifications, iCloud, etc. | — | — | ✓ |
+
+If you're just exploring the template, an Apple ID + free developer signing is enough. The paid program is only needed when you're ready to publish.
+
+## Apple-side setup checklist (when ready to ship)
+
+Once you've enrolled in the Apple Developer Program:
+
+- [ ] Note your **Team ID** — visible at <https://developer.apple.com/account/> under Membership Details. 10-character alphanumeric string like `ABCDE12345`. Substitute it for `TEAM_ID_PLACEHOLDER` in `app/project.yml`.
+- [ ] Create the app record on App Store Connect — <https://appstoreconnect.apple.com> → My Apps → "+". Use the bundle ID you set via `bin/rename.sh`.
+- [ ] Generate an **App Store Connect API key** (recommended for fastlane non-interactive uploads):
+  - <https://appstoreconnect.apple.com/access/integrations/api> → Team Keys → "+"
+  - Role: App Manager (or higher)
+  - Download the `.p8` private key — **download is one-time only**, save it carefully.
+  - Note the **Key ID** and **Issuer ID** shown alongside.
+- [ ] Place the `.p8` file **outside the repo** (e.g., `~/.appstoreconnect/`). The template's `.gitignore` blocks `*.p8`, but accidents happen.
+- [ ] Configure fastlane to read the API key from your local secrets path. See `fastlane/Fastfile` for the expected env vars.
+
+## Code-signing artifacts — DO NOT commit
+
+The `.gitignore` already blocks the common ones, but be aware:
+
+| File | Why it matters | Where to keep it |
+|------|---------------|------------------|
+| `*.p8` | App Store Connect API private key | `~/.appstoreconnect/` |
+| `*.mobileprovision` | Provisioning profiles (manual signing) | `~/Library/MobileDevice/Provisioning Profiles/` (Xcode manages) |
+| `*.cer`, `*.p12` | Distribution certificates | macOS Keychain |
+| `.env.local` | Local secrets (API keys, paths) | repo root, gitignored |
+
+If you accidentally commit any of these, treat it as a credential leak: revoke the key/cert immediately on Apple's side, then `git rm --cached` + force-rotate.
+
+## Common gotchas
+
+- **Free tier won't notarize.** macOS apps distributed outside the App Store need notarization, which requires the paid program.
+- **Team membership ≠ ownership.** If you're added to someone else's Apple Developer team as a member, you can sign builds but may not have App Store Connect access. Coordinate with your team's Account Holder.
+- **D-U-N-S number lookup is free.** If Apple says you need to "obtain" one for an Organization enrollment, use the free Apple lookup tool — don't pay D&B for one.
+- **Apple ID without 2FA can't be added to a developer team** (Apple requirement). Enable 2FA before enrollment.
+
+## Reference
+
+- Apple Developer Program enrollment FAQ: <https://developer.apple.com/support/enrollment/>
+- App Store Connect API: <https://developer.apple.com/documentation/appstoreconnectapi>
+- fastlane App Store Connect API docs: <https://docs.fastlane.tools/app-store-connect-api/>


### PR DESCRIPTION
## Summary

Surfaced via real first-time-forker friction (a tester hit `xcode-select: tool 'xcodebuild' requires Xcode` because xcode-select pointed at Command Line Tools, not Xcode). Two new files + a README update so the next forker doesn't hit the same wall.

**`bin/preflight.sh`** — interactive prereq check + auto-installer:

- 8 checks: macOS, Xcode app, xcode-select dev dir, Xcode license, Homebrew, gh CLI, gh auth, Bundler
- Auto-installs (with confirmation): Homebrew, gh CLI, Bundler
- Auto-fixes (with confirmation): xcode-select dev dir, Xcode license
- Cannot auto-install: Xcode itself (Mac App Store) — exits 2 with link
- `--yes` flag for non-interactive mode
- Idempotent — running twice is a no-op when everything's set

**`docs/APPLE-PREREQS.md`** — what forkers need from Apple, with three account tiers explained (Apple ID free → free dev account → $99 Developer Program), capability matrix (build / sideload / TestFlight / App Store), Team ID + App Store Connect API key setup checklist, code-signing artifacts to keep out of git, common gotchas (notarization needs paid program, 2FA required, free D-U-N-S lookup, etc.).

**`README.md`** — Quickstart now points at `bin/preflight.sh` for forkers without all prereqs and links to `docs/APPLE-PREREQS.md` for the Apple-side setup.

## Test plan

- [x] `bash -n bin/preflight.sh` syntax-clean
- [x] `bin/preflight.sh` is executable
- [x] `docs/APPLE-PREREQS.md` exists and has substantive content
- [x] README links to both new artifacts
- [ ] (PR review) Run `bin/preflight.sh` on a clean macOS without Homebrew/gh and confirm it walks the user through install
- [ ] (PR review) Verify the bootstrap clone-detour command works: `git clone ... /tmp/preflight && bash /tmp/preflight/bin/preflight.sh && rm -rf /tmp/preflight`

🤖 Generated with [Claude Code](https://claude.com/claude-code)