### PR TITLE
chore: SCOPE.md — contribution principle (around the project, not inside)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,9 @@ Before opening a PR, ask:
 - Does this fix a sharp edge a stranger would hit?
 - Does it preserve the "5-minute clone-to-first-build" promise?
 - Does it generalize, or is it specific to your project?
+- For enhancements: does it pass the [SCOPE.md](SCOPE.md) test? (Stuff *around* the project — XcodeGen, fastlane, CI, signing, release tooling — is in scope. Stuff *inside* the project — networking libs, persistence, auth, UI framework opinions — is deliberately out of scope.)
 
-If the answer to all three is yes, open a PR. If you're unsure, open an issue first.
+If the answer to all is yes, open a PR. If you're unsure, open an issue first.
 
 ## Quickstart
 

--- a/SCOPE.md
+++ b/SCOPE.md
@@ -1,0 +1,77 @@
+# Scope
+
+This template ships **infrastructure around iOS + macOS apps**, not application code.
+
+The framing was crystallized by an early forker on r/iOSProgramming: *"stuff around the project, not inside the project."* That's the contribution principle.
+
+## The test
+
+Before opening an enhancement issue or PR, ask:
+
+> **Does this addition require modifying Swift source files in `app/HelloApp/` to use it?**
+
+- **No** → around the project; in scope. PRs welcome.
+- **Yes** → inside the project; deliberately out of scope.
+
+That's the whole rule. It's tight on purpose: it gives every contributor and reviewer a single test to run, and it keeps the maintenance surface focused.
+
+## In scope (around the project)
+
+Anything in these categories typically passes the test:
+
+| Category | Examples |
+|----------|----------|
+| **Build / project tooling** | XcodeGen, Tuist, custom scripts that regenerate `.xcodeproj` |
+| **CI providers** | GitHub Actions (current), Bitrise, CircleCI, GitLab CI alternatives |
+| **Release pipelines** | fastlane (current), Apple-native (`xcodebuild` + `xcrun notarytool` + ASC API direct), TestFlight upload helpers |
+| **Signing helpers** | `fastlane match`, manual cert/profile management scripts, expiry notifiers |
+| **Linting + formatting** | SwiftLint, SwiftFormat, `swift-format` |
+| **Test scaffolding** | XCTest setup, XCUITest harness, snapshot testing config (e.g., `swift-snapshot-testing`), `.xctestplan` files |
+| **Documentation tooling** | DocC scaffold, README structure templates |
+| **Security / audit tooling** | CodeQL workflow, secret scanners (gitleaks, truffleHog), pre-release audit runbooks |
+| **Developer-experience helpers** | preflight installers, fork-rename scripts, version-bump scripts, lefthook / git hooks |
+| **App Store / metadata tooling** | Screenshot automation, App Store Connect API key bootstrap, App Store metadata templates |
+| **Distribution (Mac)** | Notarization scripts, DMG packaging, Sparkle config (config-only — no app code) |
+
+## Out of scope (inside the project) — and why
+
+These are **deliberately** not in the template, and PRs adding them will be politely declined with a pointer back to this doc:
+
+| Category | Why it's out |
+|----------|--------------|
+| **Networking libraries** (Alamofire, Moya, Apollo) | Every team has a strong opinion; shipping any choice is wrong for someone |
+| **Persistence** (Core Data, SwiftData, Realm, GRDB) | Same |
+| **Auth providers** (Sign in with Apple, Auth0, Firebase Auth, OAuth wrappers) | Same |
+| **UI framework opinions** (UIKit-first, SwiftUI-first, hybrid scaffolding) | Same |
+| **State management** (TCA, Redux, custom architectures) | Same |
+| **Crash reporters / analytics SDKs** (Sentry, Bugsnag, Crashlytics, Firebase, Mixpanel) | Require `import X` + SDK init in `App.swift` — modify app source files |
+| **Subscription / paywall libraries** (RevenueCat, Glassfy) | Same — modify app source files; lock in a vendor |
+| **Push-notification SDKs** (OneSignal, etc.) | Same |
+| **Logging frameworks** (CocoaLumberjack) | Replace `print` calls in app source — `os_log` is Apple-native and stays in scope |
+| **Auto-update frameworks** (Sparkle runtime integration) | Sparkle *config* is in scope; the runtime initialization in `App.swift` is not |
+
+The pattern: **app-layer dependencies that get force-fed onto every forker are out**, regardless of how popular the library is. The forker can add what they need; the template should not subtract what they don't.
+
+## How to propose an enhancement
+
+1. **Run the test** above on your proposed addition.
+2. **File an issue** stating: (a) what you'd add, (b) the answer to the test, (c) the specific value it adds, (d) any references (Reddit thread, prior art, related tools).
+3. **For in-scope items:** PRs accepted. If you're proposing a parallel maintained implementation (e.g., a Tuist variant alongside XcodeGen), note the maintenance trade-off — documentation-only paths are usually preferred over parallel implementations.
+4. **For out-of-scope items:** the issue gets closed with a reference to this doc. No hard feelings — this is what predictable scope looks like.
+
+## Worked examples
+
+Two recent classifications from r/iOSProgramming feedback (v1.0.0 launch):
+
+| Request | Test answer | Verdict |
+|---------|-------------|---------|
+| **Tuist variant or migration documentation** | No — replaces `project.yml` (XcodeGen) with `Project.swift` (Tuist) at the project-config layer; app source untouched | In scope; tracked in [#TBD] |
+| **Apple-native release pipeline** (`xcodebuild` + `notarytool` + ASC API direct) | No — lives in `Makefile` + `ci/` scripts + GitHub Actions workflows; app source untouched | In scope; tracked in [#TBD] |
+
+If a hypothetical request came in for, say, *"add Sentry for crash reporting"* — the test answer would be **yes** (it requires `import Sentry` + `SentrySDK.start(...)` in `App.swift`), so it would be declined as out of scope.
+
+## Why this discipline matters
+
+Every accepted enhancement carries an *ongoing* maintenance cost: CI keeps running it, dependencies need updating, breaking changes need handling, edge cases need debugging. The "around the project" framing keeps that cost focused on a coherent surface (build, test, sign, ship, distribute) rather than ballooning into "every iOS dev tool ever."
+
+The lower the cognitive load on first-time forkers, the more likely they finish the rename and ship something. Aggressive scope discipline serves that goal.


### PR DESCRIPTION
## Summary

Captures the "stuff around the project, not inside the project" framing as a durable contribution principle. Surfaced organically via r/iOSProgramming feedback on the v1.0.0 launch (u/Vybo: *"I'm glad you focused on the stuff around the project, not inside the project"*) — this PR makes the principle explicit so future enhancement requests have a clear test to run.

**`SCOPE.md` (new)** — articulates:

- The single test: *"Does this addition require modifying Swift source files in `app/HelloApp/` to use it?"*
- In-scope categories with examples (build tooling, CI, release pipelines, signing, linting, tests, docs, security tooling, dev-experience helpers, App Store tooling, Mac distribution)
- Out-of-scope categories with reasons (networking, persistence, auth, UI opinions, state management, crash reporters, paywalls, push SDKs, logging frameworks, auto-update runtimes)
- How to propose an enhancement (file an issue, run the test, document the answer)
- Worked examples from current Reddit feedback (Tuist variant, Apple-native release pipeline — both classified as in scope)
- Why the discipline matters (sublinear maintenance cost; cognitive load on first-time forkers)

**`CONTRIBUTING.md` (modified)** — adds one bullet to the "Before opening a PR" checklist linking to SCOPE.md.

## Test plan

- [x] `SCOPE.md` exists with substantive content (>= 50 lines)
- [x] `CONTRIBUTING.md` links to SCOPE.md
- [x] Atomic commit on 2 files only
- [ ] (PR review) SCOPE.md renders correctly on github.com (table formatting + code blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)