### PR TITLE
docs: Apple-native release pipeline alternative (closes #35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- _Nothing yet — track in-flight work here._
+- `docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md` — alternative release path using `xcodebuild` + `xcrun altool` + `xcrun notarytool` + App Store Connect API direct, for forkers who prefer to avoid the Ruby/fastlane dependency surface (#35)
 
 ## [1.0.0] - 2026-05-01
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ set -a; source .env.local; set +a
 fastlane release tag:v0.1.0
 ```
 
+Prefer Apple-native tooling (no Ruby/fastlane)? See [`docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md`](docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md) — same archive/export flow, replaces fastlane with `xcrun altool` + `xcrun notarytool` + ASC API direct.
+
 **Submit to App Review (one-shot, sync versions)**
 ```bash
 ci/bump-asc-version.sh v0.1.0   # bump ASC version + attach TestFlight build + re-upload metadata

--- a/docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md
+++ b/docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md
@@ -1,0 +1,507 @@
+# Releasing with Apple-native tools (no fastlane)
+
+An alternative release path using only Apple-shipped tooling: `xcodebuild`,
+`xcrun altool`, `xcrun notarytool`, and the App Store Connect API direct.
+For forkers who want to drop the Ruby + fastlane dependency surface and
+ship with what `xcode-select --install` already provides.
+
+> **Status:** documentation only. The template's default release pipeline
+> remains [fastlane](../fastlane/Fastfile) (`fastlane release tag:vX.Y.Z`).
+> This doc shows the equivalent commands you'd run if you replaced
+> fastlane with Apple's own tools — useful as a recipe, a reference, or a
+> migration plan. Tracked in [#35](https://github.com/indiagrams/ios-macos-template/issues/35).
+
+## Why this exists
+
+Two-of-two r/iOSProgramming commenters on the v1.0.0 launch post asked
+about an Apple-native (ASC CLI) path instead of fastlane. Real signal.
+The trade-off is genuine:
+
+| Aspect | fastlane | Apple-native |
+|---|---|---|
+| Dependencies | Ruby + fastlane gem + plugins | None beyond Xcode |
+| Cold-run startup | ~3–5 s | <1 s |
+| Integrated metadata + screenshots + signing | ✓ (`deliver`, `snapshot`, `match`) | Manual (separate ASC API calls) |
+| macOS notarization (outside App Store) | via plugin or shell-out | `xcrun notarytool` (Apple-supported) |
+| Community + plugins | Mature, large | Apple-only |
+| Best for | Full release pipeline in one tool | "Build + upload" only; minimal-deps shops |
+
+Pick fastlane if you want one tool that does build + upload + screenshots
++ metadata + signing-management (`match`). Pick Apple-native if you'd
+rather not depend on a Ruby gem and you're comfortable wiring the pieces
+together yourself.
+
+## What this doc covers
+
+- iOS App Store: `xcodebuild` archive → export → upload via `xcrun altool`
+- macOS App Store: archive → export → app-sandbox re-sign hack → `productbuild` → upload
+- macOS outside the App Store: notarization with `xcrun notarytool` + `xcrun stapler staple`
+- Metadata: minimal sync to App Store Connect via the ASC API directly (curl + JWT)
+- Alternative upload path: ASC API `/v1/buildUploads` (new in WWDC 2025) for
+  forkers who want the most future-proof option
+
+## What this doc does not cover
+
+- **`fastlane match` replacement.** Manual cert + profile management is
+  documented in [`docs/APPLE-PREREQS.md`](APPLE-PREREQS.md). Apple does
+  not ship a `match`-equivalent; if you leave fastlane, you take on cert
+  rotation manually (or use a third-party tool like
+  [`apple-actions/upload-testflight-build`](https://github.com/apple-actions)
+  or roll your own).
+- **`fastlane snapshot` / `MacSnapfile` replacement.** Screenshot
+  automation is genuinely fastlane-strong territory — there is no
+  drop-in Apple-native equivalent. The template's
+  [`ci/take-screenshots.sh`](../ci/take-screenshots.sh) +
+  [`ci/extract-mac-screenshots.sh`](../ci/extract-mac-screenshots.sh)
+  already drive iOS via `xcodebuild test` + `XCUIScreenshot` and macOS
+  via `XCTAttachment` extracted from the `xcresult` — neither requires
+  fastlane to capture, only to upload. You can keep the capture scripts
+  and replace the upload step with the metadata flow below.
+
+## Prerequisites
+
+Same as the fastlane path — see [`docs/APPLE-PREREQS.md`](APPLE-PREREQS.md):
+
+- Paid Apple Developer Program membership ($99/yr).
+- **Apple Distribution** cert in your login Keychain.
+- **Mac Installer Distribution** cert in your login Keychain (macOS .pkg signing).
+- **App Store Connect API key** with App Manager role:
+  - The `.p8` private key file (downloaded once from ASC → Users and
+    Access → Integrations → Team Keys).
+  - The **Key ID** (10-character alphanumeric).
+  - The **Issuer ID** (UUID).
+- For macOS notarization (non-App-Store distribution only): an
+  app-specific password OR a `notarytool` keychain profile. See
+  [`xcrun notarytool store-credentials`](#one-time-setup-notarytool-keychain-profile)
+  below.
+
+Apple announced that **starting in 2026, builds uploaded to App Store
+Connect must be created with Xcode 14 or later** ([upload-builds
+help](https://developer.apple.com/help/app-store-connect/manage-builds/upload-builds/)).
+This template uses Xcode 15+; you're already covered.
+
+The conventions below assume:
+
+- Bundle ID: `com.example.helloapp` (substitute yours)
+- Scheme: `HelloApp-iOS` / `HelloApp-macOS`
+- Team ID: read from `.env.local` as `FASTLANE_TEAM_ID` (the existing convention)
+- Build artifacts: `build/HelloApp-<version>.ipa`, `build/HelloApp-<version>.pkg`
+- ASC API key path: `~/.appstoreconnect/AuthKey_<KEYID>.p8` (per
+  [`docs/APPLE-PREREQS.md`](APPLE-PREREQS.md))
+
+`xcrun altool` requires API key files to live in
+`~/.appstoreconnect/private_keys/` OR
+`~/.private_keys/AuthKey_<KEYID>.p8`. Symlink or copy if you keep the
+canonical copy elsewhere.
+
+## iOS App Store flow
+
+The template's existing
+[`ci/local-release-check.sh`](../ci/local-release-check.sh) already drives
+the archive + export half of this; the only thing fastlane adds in the
+default pipeline is the upload step (`pilot`). Replacing `pilot` with
+`altool` is mechanical.
+
+### 1. Archive
+
+```bash
+TAG=v0.1.0
+VERSION="${TAG#v}"
+TEAM_ID="$FASTLANE_TEAM_ID"
+
+# Regenerate xcodeproj from project.yml (XcodeGen).
+( cd app && xcodegen generate )
+
+WORK_DIR="$(mktemp -d)"
+IOS_ARCHIVE="$WORK_DIR/HelloApp-iOS.xcarchive"
+
+xcodebuild archive \
+  -project app/HelloApp.xcodeproj \
+  -scheme HelloApp-iOS \
+  -configuration Release \
+  -destination 'generic/platform=iOS' \
+  -archivePath "$IOS_ARCHIVE" \
+  -allowProvisioningUpdates \
+  DEVELOPMENT_TEAM="$TEAM_ID" \
+  MARKETING_VERSION="$VERSION" \
+  CURRENT_PROJECT_VERSION="0"
+```
+
+`-allowProvisioningUpdates` lets Xcode auto-create the App Store
+provisioning profile on first run if one doesn't already exist. Subsequent
+runs reuse the cached profile.
+
+### 2. Export the .ipa
+
+The template ships [`ci/ExportOptions-iOS.plist`](../ci/ExportOptions-iOS.plist)
+with `method=app-store-connect` and `signingStyle=automatic`. Re-use it
+verbatim — the only substitution is `TEAM_ID_PLACEHOLDER`:
+
+```bash
+EXPORT_OPTS="$WORK_DIR/ExportOptions-iOS.plist"
+cp ci/ExportOptions-iOS.plist "$EXPORT_OPTS"
+sed -i '' "s/TEAM_ID_PLACEHOLDER/$TEAM_ID/g" "$EXPORT_OPTS"
+
+IOS_EXPORT="$WORK_DIR/export-ios"
+xcodebuild -exportArchive \
+  -archivePath "$IOS_ARCHIVE" \
+  -exportOptionsPlist "$EXPORT_OPTS" \
+  -exportPath "$IOS_EXPORT" \
+  -allowProvisioningUpdates
+
+IPA_SRC=$(find "$IOS_EXPORT" -maxdepth 2 -name "*.ipa" | head -1)
+IPA_DEST="build/HelloApp-${VERSION}.ipa"
+cp "$IPA_SRC" "$IPA_DEST"
+shasum -a 256 "$IPA_DEST" | tee "$IPA_DEST.sha256"
+```
+
+### 3. Upload to TestFlight / App Store
+
+`xcrun altool --upload-package` is the simplest Apple-native upload path.
+Apple deprecated altool's *notarization* subcommands in November 2023, but
+the App Store upload subcommands remain supported (see [TN3147 — Migrating
+to the latest notarization tool](https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool)
+and the [fastlane TN3147 discussion](https://github.com/fastlane/fastlane/discussions/21347)
+for confirmation of the scope).
+
+```bash
+# Place AuthKey_<KEYID>.p8 in ~/.appstoreconnect/private_keys/ first.
+# (altool searches there; symlink from your canonical location if needed.)
+mkdir -p ~/.appstoreconnect/private_keys
+ln -sf ~/.appstoreconnect/AuthKey_${ASC_API_KEY_ID}.p8 \
+       ~/.appstoreconnect/private_keys/AuthKey_${ASC_API_KEY_ID}.p8
+
+xcrun altool --upload-package "$IPA_DEST" \
+  --type ios \
+  --apple-id "com.example.helloapp" \
+  --bundle-version "$VERSION" \
+  --bundle-short-version-string "$VERSION" \
+  --bundle-id "com.example.helloapp" \
+  --apiKey "$ASC_API_KEY_ID" \
+  --apiIssuer "$ASC_API_KEY_ISSUER_ID"
+```
+
+The build appears in App Store Connect under TestFlight after the
+"Processing" step (typically 5–30 min). You'll receive an Apple email
+when it's ready or if it failed (e.g. ITMS-90296 sandbox issues, missing
+icons, etc.).
+
+### Alternative: ASC API direct (`POST /v1/buildUploads`)
+
+WWDC 2025 introduced first-class build upload support in the App Store
+Connect API ([Build uploads
+docs](https://developer.apple.com/documentation/appstoreconnectapi/build-uploads)).
+The flow is multi-step:
+
+1. `POST /v1/buildUploads` to create the upload reservation (returns an ID).
+2. `POST /v1/buildUploadFiles` per file (the .ipa is one file plus
+   metadata) — returns chunked-upload reservation URLs.
+3. `PUT` the file bytes to each reservation URL.
+4. `PATCH /v1/buildUploadFiles/<id>` with `uploaded: true` to commit.
+5. Poll the build state via the
+   [`BUILD_UPLOAD_STATE_UPDATED` webhook](https://developer.apple.com/documentation/appstoreconnectapi/webhookeventtype)
+   or poll `GET /v1/buildUploads/<id>`.
+
+Use this path if you want the most future-proof, scriptable, no-binary-
+dependency option (just `curl` + a JWT generator). Apple positions it as
+the "ideal for CI/CD" path. The implementation is straightforward but
+has more moving parts than `altool`; for a one-page recipe `altool`
+remains simpler.
+
+## macOS App Store flow
+
+Identical to iOS through the export step, then a re-sign hack, then
+`productbuild`, then upload. The re-sign hack is the same one fastlane
+runs (the template embeds it in
+[`ci/local-release-check.sh`](../ci/local-release-check.sh) lines 181–225)
+and it is **independent of fastlane vs. Apple-native** — it happens
+between export and upload.
+
+### 1. Archive
+
+```bash
+MACOS_ARCHIVE="$WORK_DIR/HelloApp-macOS.xcarchive"
+
+xcodebuild archive \
+  -project app/HelloApp.xcodeproj \
+  -scheme HelloApp-macOS \
+  -configuration Release \
+  -destination 'generic/platform=macOS' \
+  -archivePath "$MACOS_ARCHIVE" \
+  -allowProvisioningUpdates \
+  CODE_SIGN_STYLE=Automatic \
+  DEVELOPMENT_TEAM="$TEAM_ID" \
+  MARKETING_VERSION="$VERSION" \
+  CURRENT_PROJECT_VERSION="0"
+```
+
+### 2. Export
+
+```bash
+EXPORT_OPTS_MACOS="$WORK_DIR/ExportOptions-macOS-AppStore.plist"
+cp ci/ExportOptions-macOS-AppStore.plist "$EXPORT_OPTS_MACOS"
+sed -i '' "s/TEAM_ID_PLACEHOLDER/$TEAM_ID/g" "$EXPORT_OPTS_MACOS"
+
+MACOS_EXPORT="$WORK_DIR/export-macos"
+xcodebuild -exportArchive \
+  -archivePath "$MACOS_ARCHIVE" \
+  -exportPath "$MACOS_EXPORT" \
+  -exportOptionsPlist "$EXPORT_OPTS_MACOS" \
+  -allowProvisioningUpdates
+
+EXPORTED_PKG=$(find "$MACOS_EXPORT" -maxdepth 2 -name "*.pkg" | head -1)
+```
+
+### 3. App-sandbox re-sign hack (mandatory before upload)
+
+> **Why this exists.** Xcode's auto-managed Mac App Store provisioning
+> profile does *not* list `app-sandbox` as a capability. The signed `.app`
+> from `-exportArchive` strips `com.apple.security.app-sandbox` from
+> entitlements, and TestFlight then rejects with
+> [ITMS-90296](https://developer.apple.com/help/app-store-connect/reference/error-codes-and-messages/).
+> The fix is to expand the .pkg, force-add app-sandbox back into the
+> embedded entitlements, re-sign, and repack.
+>
+> See [`ci/local-release-check.sh`](../ci/local-release-check.sh#L181) —
+> this exact hack is documented there and runs in the template's signed
+> release path. Reuse the script as-is, or transcribe the lines into your
+> own pipeline. The hack is the same regardless of whether you upload
+> with fastlane or `altool`.
+
+The entitlements re-sign uses the existing helper
+[`ci/lib/resolve-dist-cert-sha.sh`](../ci/lib/resolve-dist-cert-sha.sh) to
+disambiguate the Apple Distribution cert SHA-1 from the .app's embedded
+provisioning profile (necessary when one team has multiple distribution
+certs).
+
+### 4. productbuild
+
+```bash
+INSTALLER_CERT=$(security find-identity -v -p basic 2>/dev/null \
+  | grep -E "3rd Party Mac Developer Installer|Mac Installer Distribution" \
+  | head -1 | grep -oE '"[^"]+"' | tr -d '"')
+
+PKG_DEST="build/HelloApp-${VERSION}.pkg"
+productbuild --component "$EXPANDED_APP" /Applications \
+  --sign "$INSTALLER_CERT" \
+  --timestamp \
+  "$PKG_DEST"
+shasum -a 256 "$PKG_DEST" | tee "$PKG_DEST.sha256"
+```
+
+### 5. Upload
+
+Same `xcrun altool` flow as iOS, but `--type macos` and the .pkg path:
+
+```bash
+xcrun altool --upload-package "$PKG_DEST" \
+  --type macos \
+  --apple-id "com.example.helloapp" \
+  --bundle-version "$VERSION" \
+  --bundle-short-version-string "$VERSION" \
+  --bundle-id "com.example.helloapp" \
+  --apiKey "$ASC_API_KEY_ID" \
+  --apiIssuer "$ASC_API_KEY_ISSUER_ID"
+```
+
+## macOS notarization (non-App-Store distribution)
+
+If you're shipping a Mac app via your own website or a DMG (not the Mac
+App Store), you need to notarize it. `notarytool` is the supported tool
+since November 2023; `altool`'s notarization subcommands were
+[decommissioned](https://developer.apple.com/news/upcoming-requirements/?id=11012023a).
+Reference: [Customizing the notarization workflow](https://developer.apple.com/documentation/security/customizing-the-notarization-workflow).
+
+### One-time setup (`notarytool` keychain profile)
+
+```bash
+xcrun notarytool store-credentials "AC_PASSWORD" \
+  --apple-id "you@example.com" \
+  --team-id "$TEAM_ID" \
+  --password "abcd-efgh-ijkl-mnop"   # app-specific password from appleid.apple.com
+```
+
+Or use the ASC API key directly without storing in keychain (recommended
+for CI):
+
+```bash
+xcrun notarytool submit "$PKG_DEST" \
+  --key ~/.appstoreconnect/AuthKey_${ASC_API_KEY_ID}.p8 \
+  --key-id "$ASC_API_KEY_ID" \
+  --issuer "$ASC_API_KEY_ISSUER_ID" \
+  --wait
+```
+
+### Submit and staple
+
+```bash
+# Using the keychain profile from above:
+xcrun notarytool submit "$PKG_DEST" \
+  --keychain-profile "AC_PASSWORD" \
+  --wait
+
+# After notarization succeeds, staple the ticket so the app validates offline:
+xcrun stapler staple "$PKG_DEST"
+
+# Verify:
+xcrun stapler validate "$PKG_DEST"
+spctl --assess --type install --verbose "$PKG_DEST"
+```
+
+The `--wait` flag blocks until the notary service finishes (typically
+1–5 min). Without `--wait`, you get a submission ID and have to poll
+with `xcrun notarytool log <id>`.
+
+### When notarization is *not* needed
+
+- App Store distribution (TestFlight + App Store) does **not** require
+  notarization. App Review serves the same purpose.
+- Mac App Store .pkgs uploaded via `altool --upload-package --type macos`
+  go through App Review, not notarization.
+
+Notarization is only for the developer-distributed-installer path
+(direct download, DMG, custom updater).
+
+## Metadata via App Store Connect API direct
+
+Replacing `fastlane deliver` with raw ASC API calls. The template's
+[fastlane `do_upload_metadata`](../fastlane/Fastfile) workaround for
+`deliver`'s silently-dropped fields (the
+[`do_upload_metadata`](../fastlane/Fastfile#L60) helper that reads
+every metadata file directly and passes explicit hashes) becomes
+unnecessary on the Apple-native path because you're not going through
+`deliver` at all — you're calling the API directly with the values you
+want.
+
+### 1. Generate a JWT
+
+The ASC API uses ES256 JWTs. Apple's
+[official guide](https://developer.apple.com/documentation/appstoreconnectapi/generating-tokens-for-api-requests)
+covers the algorithm. A minimal Python helper (works with the standard
+library + `cryptography`):
+
+```python
+#!/usr/bin/env python3
+# bin/asc-jwt.py — emit a 20-min JWT for the App Store Connect API
+import os, sys, time, json, base64
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
+
+KEY_ID    = os.environ["ASC_API_KEY_ID"]
+ISSUER_ID = os.environ["ASC_API_KEY_ISSUER_ID"]
+KEY_PATH  = os.path.expanduser(f"~/.appstoreconnect/AuthKey_{KEY_ID}.p8")
+
+def b64url(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+header  = b64url(json.dumps({"alg": "ES256", "kid": KEY_ID, "typ": "JWT"}).encode())
+payload = b64url(json.dumps({
+    "iss": ISSUER_ID,
+    "iat": int(time.time()),
+    "exp": int(time.time()) + 20 * 60,
+    "aud": "appstoreconnect-v1",
+}).encode())
+signing_input = f"{header}.{payload}".encode()
+
+with open(KEY_PATH, "rb") as f:
+    key = load_pem_private_key(f.read(), password=None)
+der_sig = key.sign(signing_input, __import__("cryptography.hazmat.primitives.asymmetric.ec",
+                                              fromlist=["ECDSA"]).ECDSA(hashes.SHA256()))
+r, s = decode_dss_signature(der_sig)
+sig = b64url(r.to_bytes(32, "big") + s.to_bytes(32, "big"))
+print(f"{header}.{payload}.{sig}")
+```
+
+```bash
+TOKEN="$(python3 bin/asc-jwt.py)"
+```
+
+(For a Ruby or Swift JWT generator, see Apple's `appstoreconnect-swift-sdk`
+or roll your own — JWT is a 5-line operation in any language.)
+
+### 2. Update the description for the current iOS version
+
+```bash
+APP_ID="1234567890"   # numeric app ID from ASC URL
+LOCALE="en-US"
+
+# Find the current "Prepare for Submission" version localization:
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.appstoreconnect.apple.com/v1/apps/$APP_ID/appStoreVersions?filter[platform]=IOS&limit=1" \
+  | jq -r '.data[0].id'   # → APP_STORE_VERSION_ID
+
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.appstoreconnect.apple.com/v1/appStoreVersions/$APP_STORE_VERSION_ID/appStoreVersionLocalizations?filter[locale]=$LOCALE" \
+  | jq -r '.data[0].id'   # → LOCALIZATION_ID
+
+# Patch the description (and other fields) in one shot:
+curl -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  "https://api.appstoreconnect.apple.com/v1/appStoreVersionLocalizations/$LOCALIZATION_ID" \
+  -d "$(jq -n \
+    --arg id "$LOCALIZATION_ID" \
+    --rawfile desc fastlane/metadata/en-US/description.txt \
+    '{data: {type: "appStoreVersionLocalizations", id: $id, attributes: {description: $desc}}}')"
+```
+
+The same pattern works for `keywords`, `marketingUrl`, `supportUrl`,
+`promotionalText`, `whatsNew`, etc. The full attribute list is in
+[`AppStoreVersionLocalization`](https://developer.apple.com/documentation/appstoreconnectapi/appstoreversionlocalization).
+
+### 3. Upload screenshots
+
+`POST /v1/appScreenshotSets` to reserve, then `PUT` the bytes per Apple's
+chunked-upload protocol. Significantly more code than the metadata
+PATCH; if you need this, vendoring [`appstoreconnect-swift-sdk`](https://github.com/AvdLee/appstoreconnect-swift-sdk)
+or writing a small wrapper is reasonable. Otherwise: keep
+`ci/take-screenshots.sh` for capture and use the ASC web UI for upload —
+that's a defensible trade-off if releases are infrequent.
+
+## Limitations vs. fastlane
+
+What you give up by leaving fastlane:
+
+- **No `match`.** Cert + provisioning profile sync across machines is
+  manual. You can install certs in the login Keychain by hand,
+  re-download profiles from `developer.apple.com` when they expire, or
+  rely on `-allowProvisioningUpdates` to auto-create on first run.
+- **No `precheck`.** Fastlane's pre-flight ASC linting (broken URLs,
+  metadata length limits, prohibited keywords) is gone. You'll find
+  these issues at App Review time instead. Run `Validate App` in
+  Xcode's Organizer first if you want a similar local check.
+- **No automated screenshot capture story.** The capture itself
+  ([`ci/take-screenshots.sh`](../ci/take-screenshots.sh) +
+  [`ci/extract-mac-screenshots.sh`](../ci/extract-mac-screenshots.sh))
+  doesn't depend on fastlane — keep it. The *upload* step
+  (`fastlane ios upload_screenshots` / `fastlane mac upload_screenshots`)
+  is the part you replace, and the ASC API equivalent is non-trivial
+  enough that doing screenshots from the ASC web UI is the pragmatic
+  default for low-frequency releases.
+- **No integrated TestFlight tester management.** Fastlane's `pilot`
+  manages tester groups; on the API path you'd call
+  [`/v1/betaGroups`](https://developer.apple.com/documentation/appstoreconnectapi/betagroups)
+  and friends manually.
+
+What you gain:
+
+- Zero non-Apple dependencies. `xcode-select --install` is the only
+  prerequisite.
+- Faster cold starts (no Ruby + gem load).
+- Full visibility into what each command does — every step is one
+  `xcrun ...` or one `curl ...`. No magic.
+- Future-proof against fastlane's own evolution (Apple is
+  [deprecating Transporter's `-f` flag in 2026](https://github.com/fastlane/fastlane/issues/29608),
+  and fastlane's plugins shell out to the same Apple tools you'd be
+  calling directly).
+
+## References
+
+- Apple — [App Store Connect API: Build uploads](https://developer.apple.com/documentation/appstoreconnectapi/build-uploads) (WWDC 2025)
+- Apple — [Generating tokens for API requests](https://developer.apple.com/documentation/appstoreconnectapi/generating-tokens-for-api-requests)
+- Apple — [TN3147: Migrating to the latest notarization tool](https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool)
+- Apple — [Customizing the notarization workflow](https://developer.apple.com/documentation/security/customizing-the-notarization-workflow)
+- Apple — [Upload builds (App Store Connect Help)](https://developer.apple.com/help/app-store-connect/manage-builds/upload-builds/)
+- Apple — [App Store Connect API key setup](https://developer.apple.com/documentation/appstoreconnectapi/creating-api-keys-for-app-store-connect-api)
+- `man xcodebuild`, `man notarytool`, `man stapler`, `man codesign`, `man productbuild`
+- altool man (community-mirrored, 2019 baseline; flags unchanged): <https://keith.github.io/xcode-man-pages/altool.1.html>
+- This template — [`docs/APPLE-PREREQS.md`](APPLE-PREREQS.md), [`SCOPE.md`](../SCOPE.md), [`ci/local-release-check.sh`](../ci/local-release-check.sh), [`ci/ExportOptions-iOS.plist`](../ci/ExportOptions-iOS.plist), [`ci/ExportOptions-macOS-AppStore.plist`](../ci/ExportOptions-macOS-AppStore.plist)


### PR DESCRIPTION
Closes #35.

## Summary

Adds [`docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md`](https://github.com/indiagrams/ios-macos-template/blob/docs/apple-native-release-pipeline/docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md) — a forker-targeted recipe for replacing the fastlane release pipeline with Apple's own tooling (`xcodebuild` + `xcrun altool` + `xcrun notarytool` + ASC API direct).

This implements **Option A (documentation only)** from issue #35 — the explicitly recommended path. Template default stays fastlane; this is for forkers who'd rather not depend on a Ruby gem.

## What's covered

- **iOS App Store flow** — archive → export → upload via `xcrun altool --upload-package` (the App-Store-supported subcommand; only altool's *notarization* subcommands were deprecated in Nov 2023, per [TN3147](https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool)).
- **macOS App Store flow** — same archive/export, plus the existing app-sandbox re-sign hack (the doc points back at `ci/local-release-check.sh` which already implements it; the hack is independent of fastlane vs. Apple-native).
- **macOS notarization (non-App-Store)** — `xcrun notarytool submit` + `xcrun stapler staple`, with both keychain-profile and direct-`.p8` invocations.
- **Metadata via ASC API direct** — minimal Python ES256 JWT generator + `curl` PATCH against `/v1/appStoreVersionLocalizations`. Replaces `fastlane deliver` (and obviates the dropped-fields workaround in `do_upload_metadata`).
- **Reference to ASC API `/v1/buildUploads`** — the new WWDC 2025 build-upload API as a future-proof alternative to `altool`.
- **Limitations** — explicit on what you give up (`match`, `precheck`, screenshot upload story).
- **Trade-off matrix** lifted from the issue.

## What's *not* covered

Per the issue's out-of-scope section, and matching the template's existing scope discipline:
- No `match` replacement (manual cert/profile management; pointer to `docs/APPLE-PREREQS.md`).
- No `snapshot` / `MacSnapfile` replacement (genuinely fastlane-strong territory; capture scripts in `ci/` already work without fastlane, only upload would change).
- No parallel `make release-asc` Makefile target (Option B/C from issue, explicitly rejected).

## Files changed

- `docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md` — new (507 lines)
- `CHANGELOG.md` — bullet under `[Unreleased] → ### Added`
- `README.md` — one-line pointer in the "Cut a release" workflow block

## SCOPE.md test

No Swift source under `app/HelloApp/` modified. `git diff --name-only main` is `CHANGELOG.md`, `README.md`, `docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md` only. ✅

## Test plan

- [x] `make check` green locally (iOS device build).
- [x] Cross-referenced every documented command against current Apple docs:
  - [Upload builds (App Store Connect Help)](https://developer.apple.com/help/app-store-connect/manage-builds/upload-builds/) — confirmed `altool --upload-package` still supported; 2026 requires Xcode 14+ for ASC uploads (we use 15+, covered).
  - [TN3147 — Migrating to the latest notarization tool](https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool) — confirmed the deprecation scope is notarization only.
  - [Customizing the notarization workflow](https://developer.apple.com/documentation/security/customizing-the-notarization-workflow) — `notarytool` flow.
  - [ASC API: Build uploads](https://developer.apple.com/documentation/appstoreconnectapi/build-uploads) — WWDC 2025 endpoint shape.
- [x] Rendered the `.md` (will verify GitHub render in PR view).
- [ ] 3 CI checks green on the PR (`app (iOS device)`, `app (iOS Simulator)`, `app (macOS)`).
