### PR TITLE
feat: Tuist 4 manifests alongside XcodeGen (refs #38)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,11 @@ app/iOS/Generated-Info.plist
 app/macOS/Generated-Info.plist
 
 # XcodeGen-generated project (regenerated from project.yml)
+# Tuist-generated project + workspace + cache (regenerated from app/Project.swift)
 app/HelloApp.xcodeproj
+app/HelloApp.xcworkspace
+app/Derived/
+.tuist/
 
 # Editor
 .vscode/

--- a/Brewfile
+++ b/Brewfile
@@ -3,6 +3,7 @@
 
 # Build / project generation
 brew "xcodegen"        # app/project.yml → HelloApp.xcodeproj
+cask "tuist"          # app/Project.swift → HelloApp.xcodeproj (Tuist alternative; see #38)
 brew "swiftlint"       # Swift lint
 brew "xcbeautify"      # nicer xcodebuild logs
 brew "xcresultparser"  # parse .xcresult bundles in CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md` — alternative release path using `xcodebuild` + `xcrun altool` + `xcrun notarytool` + App Store Connect API direct, for forkers who prefer to avoid the Ruby/fastlane dependency surface (#35)
 - `docs/MIGRATING-TO-TUIST.md` — step-by-step migration guide for forkers who prefer Tuist (`Project.swift`) over XcodeGen (`project.yml`); template default remains XcodeGen (#34)
+- `Tuist.swift` + `app/Project.swift` — Tuist 4 manifests committed alongside `app/project.yml`. XcodeGen remains the default; Tuist users can `cd app && tuist generate --no-open` and build directly. Forker-time selection arrives in a follow-up PR (Refs #38)
 
 ## [1.0.0] - 2026-05-01
 

--- a/Tuist.swift
+++ b/Tuist.swift
@@ -1,0 +1,23 @@
+// Tuist.swift — top-level Tuist 4 configuration for the ios-macos-template.
+//
+// Lives at repo root (Tuist 4 default; pre-4.0 used Tuist/Config.swift).
+// Companion to app/Project.swift; both ship alongside app/project.yml so
+// forkers can pick their generator at fork time via
+//   bin/rename.sh ... --generator=tuist|xcodegen
+// Default remains XcodeGen — see docs/MIGRATING-TO-TUIST.md and #38.
+//
+// compatibleXcodeVersions: .all is intentional. .upToNextMajor("15.0")
+// rejects Xcode 16+ at generate time, which is a foot-gun for forkers
+// upgrading Xcode mid-project. Forkers wanting a strict pin can edit
+// here once they've taken ownership of their fork.
+
+import ProjectDescription
+
+let config = Config(
+    compatibleXcodeVersions: .all,
+    swiftVersion: "5.9",
+    generationOptions: .options(
+        resolveDependenciesWithSystemScm: false,
+        disablePackageVersionLocking: false
+    )
+)

--- a/app/Project.swift
+++ b/app/Project.swift
@@ -1,0 +1,208 @@
+// app/Project.swift — Tuist 4 manifest for the HelloApp template stub.
+//
+// 1:1 equivalent of app/project.yml. Both ship on `main`; bin/rename.sh's
+// `--generator=tuist|xcodegen` flag (see #38) selects which one a fresh
+// fork keeps post-rename. CI runs both via .github/workflows/pr.yml's
+// 6-job matrix so any drift between the two manifests fails fast.
+//
+// When editing this file, also update app/project.yml (and vice versa).
+// The CI matrix is the source of truth — both must produce a
+// build-green HelloApp.xcodeproj.
+
+import ProjectDescription
+
+// MARK: - Shared settings
+
+let baseSettings: SettingsDictionary = [
+    "SWIFT_VERSION": "5.9",
+    "SWIFT_STRICT_CONCURRENCY": "complete",
+    "ENABLE_USER_SCRIPT_SANDBOXING": "YES",
+    "MARKETING_VERSION": "0.0.1",
+    "CURRENT_PROJECT_VERSION": "1",
+    "DEVELOPMENT_TEAM": "TEAM_ID_PLACEHOLDER",   // override via .env.local FASTLANE_TEAM_ID
+    "CODE_SIGN_STYLE": "Automatic",
+    "SWIFT_TREAT_WARNINGS_AS_ERRORS": "NO",
+    "GCC_TREAT_WARNINGS_AS_ERRORS": "NO",
+]
+
+// MARK: - iOS app
+
+let iosInfoPlist: [String: Plist.Value] = [
+    "CFBundleDisplayName": "HelloApp",
+    "CFBundleShortVersionString": "$(MARKETING_VERSION)",
+    "CFBundleVersion": "$(CURRENT_PROJECT_VERSION)",
+    "UILaunchScreen": .dictionary([:]),
+    "UIApplicationSceneManifest": .dictionary([
+        "UIApplicationSupportsMultipleScenes": false,
+    ]),
+    "UISupportedInterfaceOrientations": .array([
+        "UIInterfaceOrientationPortrait",
+        "UIInterfaceOrientationLandscapeLeft",
+        "UIInterfaceOrientationLandscapeRight",
+    ]),
+    "UISupportedInterfaceOrientations~ipad": .array([
+        "UIInterfaceOrientationPortrait",
+        "UIInterfaceOrientationPortraitUpsideDown",
+        "UIInterfaceOrientationLandscapeLeft",
+        "UIInterfaceOrientationLandscapeRight",
+    ]),
+    "ITSAppUsesNonExemptEncryption": false,
+]
+
+let iosTarget = Target.target(
+    name: "HelloApp-iOS",
+    destinations: [.iPhone, .iPad],
+    product: .app,
+    bundleId: "com.example.helloapp",
+    deploymentTargets: .iOS("17.0"),
+    infoPlist: .extendingDefault(with: iosInfoPlist),
+    sources: ["Shared/**", "iOS/**"],
+    resources: [
+        "iOS/Assets.xcassets",
+    ],
+    entitlements: .file(path: "iOS/HelloApp.entitlements"),
+    settings: .settings(base: [
+        "PRODUCT_BUNDLE_IDENTIFIER": "com.example.helloapp",
+        "TARGETED_DEVICE_FAMILY": "1,2",
+        "SUPPORTS_MACCATALYST": "NO",
+        "INFOPLIST_KEY_LSApplicationCategoryType": "public.app-category.utilities",
+        "INFOPLIST_KEY_NSHumanReadableCopyright": "TODO Copyright © <year> <Your Org>. All rights reserved.",
+    ])
+)
+
+// MARK: - macOS app
+
+let macInfoPlist: [String: Plist.Value] = [
+    "CFBundleDisplayName": "HelloApp",
+    "CFBundleShortVersionString": "$(MARKETING_VERSION)",
+    "CFBundleVersion": "$(CURRENT_PROJECT_VERSION)",
+    "LSMinimumSystemVersion": "$(MACOSX_DEPLOYMENT_TARGET)",
+    "LSApplicationCategoryType": "public.app-category.utilities",
+    "NSHumanReadableCopyright": "TODO Copyright © <year> <Your Org>. All rights reserved.",
+    "NSPrincipalClass": "NSApplication",
+    // CFBundleIconName intentionally NOT set — its presence makes Sonoma+
+    // prefer Assets.car AppIcon (which has actool's broken 4-size set).
+    // The post-build script below installs the hand-rolled .icns instead.
+    "CFBundleIconFile": "AppIcon",
+    "ITSAppUsesNonExemptEncryption": false,
+]
+
+// Overwrites actool's broken 4-size .icns with the hand-rolled 10-size
+// version. Tuist places `.post` scripts at the END of buildPhases (after
+// Resources / Frameworks / Embed Frameworks) but before Code Sign — so
+// the .icns gets overwritten *after* actool emits its broken version,
+// and the signed bundle ships with the hand-rolled 10-size set.
+let macIconScript: TargetScript = .post(
+    script: """
+    set -euo pipefail
+    /bin/cp "$SCRIPT_INPUT_FILE_0" "$SCRIPT_OUTPUT_FILE_0"
+    echo "Overwrote $SCRIPT_OUTPUT_FILE_0 with hand-rolled 10-size .icns"
+    """,
+    name: "Overwrite actool's broken AppIcon.icns with hand-rolled 10-size version",
+    inputPaths: ["$(SRCROOT)/macOS/Resources/AppIcon.icns"],
+    outputPaths: ["$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/AppIcon.icns"]
+)
+
+let macTarget = Target.target(
+    name: "HelloApp-macOS",
+    destinations: [.mac],
+    product: .app,
+    bundleId: "com.example.helloapp",
+    deploymentTargets: .macOS("14.0"),
+    infoPlist: .extendingDefault(with: macInfoPlist),
+    sources: [
+        "Shared/**",
+        // macOS/Resources/ holds the hand-rolled AppIcon.icns + source 1024 PNG.
+        // Excluded here because the post-build script copies the .icns into
+        // the .app over actool's broken 4-size version.
+        .glob("macOS/**", excluding: ["macOS/Resources/**"]),
+    ],
+    resources: [
+        "macOS/Assets.xcassets",
+    ],
+    entitlements: .file(path: "macOS/HelloApp.entitlements"),
+    scripts: [macIconScript],
+    settings: .settings(base: [
+        "PRODUCT_BUNDLE_IDENTIFIER": "com.example.helloapp",
+        // Suppress actool's auto-injection of CFBundleIconName=AppIcon.
+        // Empty value = actool emits Assets.car as before but does not set
+        // the key, so macOS reads CFBundleIconFile → our hand-rolled .icns.
+        "ASSETCATALOG_COMPILER_APPICON_NAME": "",
+    ])
+)
+
+// MARK: - UI test targets
+
+let iosUITestTarget = Target.target(
+    name: "HelloAppUITests",
+    destinations: [.iPhone, .iPad],
+    product: .uiTests,
+    bundleId: "com.example.helloapp.uitests",
+    deploymentTargets: .iOS("17.0"),
+    infoPlist: .default,
+    sources: ["UITests/**"],
+    dependencies: [.target(name: "HelloApp-iOS")],
+    settings: .settings(base: [
+        "TEST_TARGET_NAME": "HelloApp-iOS",
+        // SnapshotHelper.swift uses raw NSURLConnection patterns that warn
+        // under strict concurrency — relax for the test target only.
+        "SWIFT_STRICT_CONCURRENCY": "minimal",
+    ])
+)
+
+let macUITestTarget = Target.target(
+    name: "HelloAppMacOSUITests",
+    destinations: [.mac],
+    product: .uiTests,
+    bundleId: "com.example.helloapp.macuitests",
+    deploymentTargets: .macOS("14.0"),
+    infoPlist: .default,
+    sources: ["MacOSUITests/**"],
+    dependencies: [.target(name: "HelloApp-macOS")],
+    settings: .settings(base: [
+        "TEST_TARGET_NAME": "HelloApp-macOS",
+    ])
+)
+
+// MARK: - Schemes
+
+let iosScheme: Scheme = .scheme(
+    name: "HelloApp-iOS",
+    shared: true,
+    // NB: only the main app target — UI tests live in testAction only.
+    // Including HelloAppUITests here would compile it during plain
+    // `xcodebuild build` and trip strict-concurrency errors that the
+    // per-target SWIFT_STRICT_CONCURRENCY=minimal override can't suppress.
+    buildAction: .buildAction(targets: ["HelloApp-iOS"]),
+    testAction: .targets(
+        ["HelloAppUITests"],
+        configuration: .debug
+    ),
+    runAction: .runAction(configuration: .debug, executable: "HelloApp-iOS"),
+    archiveAction: .archiveAction(configuration: .release)
+)
+
+let macScheme: Scheme = .scheme(
+    name: "HelloApp-macOS",
+    shared: true,
+    buildAction: .buildAction(targets: ["HelloApp-macOS"]),
+    testAction: .targets(
+        ["HelloAppMacOSUITests"],
+        configuration: .debug
+    ),
+    runAction: .runAction(configuration: .debug, executable: "HelloApp-macOS"),
+    archiveAction: .archiveAction(configuration: .release)
+)
+
+// MARK: - Project
+
+let project = Project(
+    name: "HelloApp",
+    options: .options(
+        defaultKnownRegions: ["en"],
+        developmentRegion: "en"
+    ),
+    settings: .settings(base: baseSettings, defaultSettings: .recommended),
+    targets: [iosTarget, macTarget, iosUITestTarget, macUITestTarget],
+    schemes: [iosScheme, macScheme]
+)


### PR DESCRIPTION
First PR in the multi-PR series for first-class Tuist support — Refs #38.

## What

Add `Tuist.swift` + `app/Project.swift` to `main` alongside `app/project.yml`. Brewfile installs both `xcodegen` (brew) and `tuist` (cask). `.gitignore` covers Tuist-generated artifacts. Default behavior is unchanged — `make check`, `make bootstrap`, and `bin/rename.sh` all still drive XcodeGen.

The follow-on PRs add `bin/switch-to-tuist.sh` (PR 2), the CI matrix that builds both generators (PR 3), the `bin/rename.sh --generator=tuist|xcodegen` flag (PR 4 — closes #38), and the README/docs polish (PR 5).

## Files

- New: `Tuist.swift` (top-level Tuist 4 config)
- New: `app/Project.swift` (1:1 of `app/project.yml`)
- Modified: `Brewfile` — `cask "tuist"` alongside `brew "xcodegen"`
- Modified: `.gitignore` — Tuist artifacts (`app/HelloApp.xcworkspace`, `app/Derived/`, `.tuist/`)
- Modified: `CHANGELOG.md` — Unreleased / Added bullet

No Swift source under `app/HelloApp/` modified — passes the [SCOPE.md](../blob/main/SCOPE.md) test.

## Test plan

1. `make check` green locally (XcodeGen path unchanged).
2. Manual end-to-end against the new Tuist manifest: `cd app && tuist generate --no-open` succeeds; the same iOS device / iOS Simulator / macOS unsigned `xcodebuild build` commands CI runs all green against the Tuist-generated `HelloApp.xcodeproj`.
3. SCOPE.md test: diff is `Brewfile`, `.gitignore`, `CHANGELOG.md`, `Tuist.swift`, `app/Project.swift` only.
4. 3 existing CI checks green on this PR (the new Tuist parity jobs land in PR 3).

## References

- Refs #38 (the umbrella issue with the chosen approach + acceptance criteria + 5-PR sequence)
- Predecessor: #34 (Tuist migration doc, closed by #37) — that doc's reference `Project.swift` skeleton is the validated starting content for `app/Project.swift`
- [PRINCIPLES.md](../blob/main/docs/PRINCIPLES.md) #9 (CHANGELOG in same PR), #10 (semver — additive forker-facing change → MINOR; defaults preserved)
- [SCOPE.md](../blob/main/SCOPE.md) (in scope: project-config layer, app source untouched)
