### PR TITLE
feat: bin/switch-to-tuist.sh + harness (refs #38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md` — alternative release path using `xcodebuild` + `xcrun altool` + `xcrun notarytool` + App Store Connect API direct, for forkers who prefer to avoid the Ruby/fastlane dependency surface (#35)
 - `docs/MIGRATING-TO-TUIST.md` — step-by-step migration guide for forkers who prefer Tuist (`Project.swift`) over XcodeGen (`project.yml`); template default remains XcodeGen (#34)
 - `Tuist.swift` + `app/Project.swift` — Tuist 4 manifests committed alongside `app/project.yml`. XcodeGen remains the default; Tuist users can `cd app && tuist generate --no-open` and build directly. Forker-time selection arrives in a follow-up PR (Refs #38)
+- `bin/switch-to-tuist.sh` — convert a fork from XcodeGen to Tuist via a single command. Idempotent + atomic-rollback (parity with `bin/rename.sh`'s contract). Edits Brewfile, Makefile, ci/local-check.sh, ci/local-release-check.sh, .github/workflows/pr.yml; removes `app/project.yml`. Exercised by `ci/test-switch-to-tuist.sh` and reused by the `bin/rename.sh --generator=tuist` flag in a follow-up PR. (Refs #38)
 
 ## [1.0.0] - 2026-05-01
 

--- a/bin/switch-to-tuist.sh
+++ b/bin/switch-to-tuist.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+# bin/switch-to-tuist.sh — convert a fork from XcodeGen to Tuist.
+#
+# Why this exists:
+#   `main` ships both XcodeGen (`app/project.yml`) and Tuist
+#   (`Tuist.swift` + `app/Project.swift`) manifests so forkers can pick
+#   their generator (#38). This script flips a fork to Tuist-only by:
+#   removing `app/project.yml`, dropping `brew "xcodegen"` from
+#   Brewfile, and replacing every `xcodegen generate` invocation in
+#   Makefile / ci/local-check.sh / ci/local-release-check.sh /
+#   .github/workflows/pr.yml with `tuist generate --no-open`.
+#
+#   Two callers:
+#     1. `bin/rename.sh ... --generator=tuist` calls this script
+#        (with --force, since rename.sh's tree is mid-mutation).
+#     2. The 3 Tuist parity jobs in .github/workflows/pr.yml call this
+#        script before building, so CI verifies the Tuist manifest
+#        stays compatible with the XcodeGen one on every PR.
+#
+#   Factoring the surgery out of bin/rename.sh into a standalone script
+#   keeps both call-sites testable in isolation. The
+#   `--generator=xcodegen` direction (the default) does nothing — no
+#   matching switch-to-xcodegen.sh exists yet because no audience for
+#   that direction has surfaced.
+#
+# Usage:
+#   bin/switch-to-tuist.sh                       # apply the switch
+#   bin/switch-to-tuist.sh --dry-run             # preview without modifying
+#   bin/switch-to-tuist.sh --force               # bypass clean-tree + on-main gates
+#   bin/switch-to-tuist.sh -h | --help           # print this header
+#
+# Pre-flight gates (canonical order):
+#   1. `tuist` on PATH (fail with install hint)
+#   2. `app/Project.swift` present (else: PR #1 not landed in this fork)
+#   3. Idempotency dispatch:
+#        case 0 = already-switched (silent exit 0)
+#        case 1 = partial state (fail unless --force)
+#        case 2 = pre-switch state (proceed)
+#   4. Working tree clean (override via --force)
+#   5. On `main` branch (override via --force)
+#
+# Atomic rollback (parity with bin/rename.sh):
+#   Pre-flight Gate 4 (clean tree) ensures HEAD == working tree
+#   pre-mutation. Any failure during the mutation phase triggers an
+#   ERR/EXIT/INT/TERM trap that runs `git reset --hard HEAD` +
+#   `git clean -fd` (NOT -fdx — forker's .env.local is precious).
+#   MUTATION_STARTED guards the destructive-op path so a pre-mutation
+#   gate failure does not destroy a forker's dirty working tree.
+#
+# Idempotency:
+#   Re-running on an already-switched tree (project.yml absent +
+#   Project.swift present + Brewfile lacks `brew "xcodegen"`) is a
+#   silent exit 0 — no stdout, no rollback, no side effects.
+#
+# Constraints (parity with bin/rename.sh):
+#   - bash 3.2+ (macOS default); no bash 4+ features
+#   - BSD-portable sed (sed -i '', | delimiter)
+#   - No new external dependencies (git, bash, sed, awk, find)
+
+set -euo pipefail
+
+step() { printf '\n==> %s\n' "$*"; }
+ok()   { printf '    ✓ %s\n' "$*"; }
+fail() { printf '    ✗ %s\n' "$*" >&2; exit 1; }
+
+print_usage() {
+  sed -n '2,/^set -euo pipefail$/{ /^set -euo pipefail$/!p; }' "$0" | sed 's/^# \{0,1\}//'
+}
+
+# ── Argument parsing ──────────────────────────────────────────────────────
+DRY_RUN=0
+FORCE=0
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help) print_usage; exit 0 ;;
+    --dry-run) DRY_RUN=1 ;;
+    --force)   FORCE=1 ;;
+    *) fail "unknown flag '$arg' — run with -h for usage" ;;
+  esac
+done
+
+# ── Resolve repo root ─────────────────────────────────────────────────────
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT" || fail "could not cd to repo root ($REPO_ROOT)"
+
+# ── Mutation guard for the rollback trap (mirrors bin/rename.sh) ─────────
+ROLLBACK_DONE=0
+MUTATION_STARTED=0
+
+rollback() {
+  [ "$ROLLBACK_DONE" = "1" ] && return 0
+  ROLLBACK_DONE=1
+
+  # Pre-mutation early-out: nothing to roll back if we never started
+  # mutating. Without this guard, a pre-flight gate failure on a dirty
+  # working tree would trigger the EXIT trap and `git reset --hard`
+  # would destroy the forker's uncommitted work.
+  [ "$MUTATION_STARTED" = "1" ] || return 0
+
+  printf '    ✗ rolling back to pre-switch state...\n' >&2
+  if git reset --hard HEAD --quiet 2>/dev/null; then
+    git clean -fd --quiet 2>/dev/null || true
+    printf '    ✗ rolled back to pre-switch state.\n' >&2
+  else
+    printf '    ✗ git reset --hard HEAD failed; manual recovery required.\n' >&2
+    printf '    ✗ inspect: git status; git log --oneline -5\n' >&2
+  fi
+}
+
+trap 'rollback' ERR
+trap 'rollback' INT TERM
+trap 'rollback' EXIT
+
+# ── Idempotency dispatch (HIGH-3 parity with bin/rename.sh) ──────────────
+# Returns:
+#   0 = already-switched (caller silent-exits 0)
+#   1 = partial state (caller fails unless --force)
+#   2 = pre-switch state (caller proceeds)
+check_idempotency() {
+  local has_yml=0 has_swift=0 brewfile_has_xcodegen=0
+  [ -f "app/project.yml" ] && has_yml=1
+  [ -f "app/Project.swift" ] && has_swift=1
+  if [ -f "Brewfile" ] && grep -q '^brew "xcodegen"' Brewfile 2>/dev/null; then
+    brewfile_has_xcodegen=1
+  fi
+
+  # Already-switched: project.yml gone, Project.swift present, Brewfile
+  # has no brew "xcodegen" line. All three together — any one of them
+  # alone is partial state.
+  if [ "$has_yml" = "0" ] && [ "$has_swift" = "1" ] && [ "$brewfile_has_xcodegen" = "0" ]; then
+    return 0
+  fi
+
+  # Pre-switch: project.yml present, Project.swift present (PR 1 landed),
+  # Brewfile has brew "xcodegen". The expected `main` shape.
+  if [ "$has_yml" = "1" ] && [ "$has_swift" = "1" ] && [ "$brewfile_has_xcodegen" = "1" ]; then
+    return 2
+  fi
+
+  # Anything else is partial state (e.g. Project.swift missing entirely
+  # — PR 1 not landed in this fork).
+  return 1
+}
+
+# ── Pre-flight gate functions ─────────────────────────────────────────────
+gate_tuist_present() {
+  command -v tuist >/dev/null 2>&1 || \
+    fail "tuist not found — install with 'brew install --cask tuist' (or run 'make bootstrap' after PR-1 landed)"
+  ok "tuist on PATH ($(tuist version 2>/dev/null | head -1))"
+}
+
+gate_project_swift_present() {
+  [ -f "app/Project.swift" ] || \
+    fail "app/Project.swift missing — PR #1 (refs #38) not landed in this fork; pull main first"
+  [ -f "Tuist.swift" ] || \
+    fail "Tuist.swift missing — PR #1 (refs #38) not landed in this fork; pull main first"
+  ok "Tuist manifests present (Tuist.swift + app/Project.swift)"
+}
+
+gate_clean_tree() {
+  if [ "$FORCE" = "1" ]; then
+    ok "working-tree gate skipped (--force)"
+    return 0
+  fi
+  if [ "$(git status --short | wc -l | tr -d ' ')" != "0" ]; then
+    fail "working tree not clean — commit, stash, or remove untracked files (or pass --force)"
+  fi
+  ok "working tree clean"
+}
+
+gate_on_main() {
+  local BRANCH
+  BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  if [ "$BRANCH" != "main" ] && [ "$FORCE" != "1" ]; then
+    fail "not on main branch (currently: $BRANCH) — pass --force to override"
+  fi
+  ok "branch check: $BRANCH (force=$FORCE)"
+}
+
+# ── Mutations ─────────────────────────────────────────────────────────────
+# Each step is independently idempotent (file may already be in target
+# state). The ordered set of steps brings any pre-switch tree to the
+# switched state; running again on the switched tree is a no-op.
+
+mutate_remove_project_yml() {
+  step "Removing app/project.yml"
+  if [ -f "app/project.yml" ]; then
+    git rm --quiet app/project.yml
+    ok "app/project.yml removed (git rm)"
+  else
+    ok "app/project.yml already absent"
+  fi
+}
+
+mutate_brewfile() {
+  step "Editing Brewfile (drop brew \"xcodegen\")"
+  if [ -f "Brewfile" ] && grep -q '^brew "xcodegen"' Brewfile; then
+    sed -i '' '/^brew "xcodegen"/d' Brewfile
+    ok "Brewfile: brew \"xcodegen\" line removed"
+  else
+    ok "Brewfile: no brew \"xcodegen\" line (already removed or absent)"
+  fi
+}
+
+mutate_makefile() {
+  step "Editing Makefile (xcodegen generate → tuist generate --no-open)"
+  if [ ! -f "Makefile" ]; then
+    fail "Makefile missing — unexpected repo state"
+  fi
+  # 2 occurrences: bootstrap target + generate target.
+  # `cd app && xcodegen generate` → `cd app && tuist generate --no-open`
+  sed -i '' 's|cd app && xcodegen generate|cd app \&\& tuist generate --no-open|g' Makefile
+  # Help line: "Regenerate HelloApp.xcodeproj from app/project.yml"
+  sed -i '' 's|Regenerate HelloApp.xcodeproj from app/project.yml|Regenerate HelloApp.xcodeproj from app/Project.swift|g' Makefile
+  ok "Makefile: xcodegen generate → tuist generate --no-open"
+}
+
+mutate_local_check() {
+  step "Editing ci/local-check.sh (xcodegen → tuist)"
+  if [ ! -f "ci/local-check.sh" ]; then
+    fail "ci/local-check.sh missing — unexpected repo state"
+  fi
+  sed -i '' 's|require_cmd xcodegen|require_cmd tuist|g' ci/local-check.sh
+  sed -i '' 's|step "app: xcodegen generate"|step "app: tuist generate"|g' ci/local-check.sh
+  sed -i '' 's|( cd app && xcodegen generate >/dev/null )|( cd app \&\& tuist generate --no-open >/dev/null )|g' ci/local-check.sh
+  ok "ci/local-check.sh: xcodegen generate → tuist generate --no-open"
+}
+
+mutate_local_release_check() {
+  step "Editing ci/local-release-check.sh (xcodegen → tuist)"
+  if [ ! -f "ci/local-release-check.sh" ]; then
+    fail "ci/local-release-check.sh missing — unexpected repo state"
+  fi
+  sed -i '' 's|step "xcodegen generate"|step "tuist generate"|g' ci/local-release-check.sh
+  sed -i '' 's|( cd app && xcodegen generate >/dev/null )|( cd app \&\& tuist generate --no-open >/dev/null )|g' ci/local-release-check.sh
+  ok "ci/local-release-check.sh: xcodegen generate → tuist generate --no-open"
+}
+
+mutate_pr_workflow() {
+  step "Editing .github/workflows/pr.yml (3 jobs: xcodegen → tuist)"
+  if [ ! -f ".github/workflows/pr.yml" ]; then
+    fail ".github/workflows/pr.yml missing — unexpected repo state"
+  fi
+  sed -i '' 's|name: install xcbeautify + xcodegen|name: install xcbeautify + tuist|g' .github/workflows/pr.yml
+  sed -i '' 's|run: brew install xcbeautify xcodegen|run: brew install xcbeautify \&\& brew install --cask tuist|g' .github/workflows/pr.yml
+  sed -i '' 's|run: xcodegen generate|run: tuist generate --no-open|g' .github/workflows/pr.yml
+  ok ".github/workflows/pr.yml: xcodegen generate → tuist generate --no-open (3 jobs)"
+}
+
+# ── --dry-run preview ─────────────────────────────────────────────────────
+print_dry_run_plan() {
+  step "DRY RUN — no files will be modified"
+  echo
+  echo "Would remove:"
+  echo "  app/project.yml"
+  echo
+  echo "Would edit:"
+  echo "  Brewfile                       (drop 'brew \"xcodegen\"' line)"
+  echo "  Makefile                       (cd app && xcodegen generate → cd app && tuist generate --no-open)"
+  echo "  ci/local-check.sh              (require_cmd / step / xcodegen generate)"
+  echo "  ci/local-release-check.sh      (step + xcodegen generate)"
+  echo "  .github/workflows/pr.yml       (3 jobs: install + generate steps)"
+  echo
+  echo "Mutation count preview:"
+  printf '  %-40s %d hit(s)\n' "Brewfile brew \"xcodegen\"" \
+    "$(grep -c '^brew "xcodegen"' Brewfile 2>/dev/null || echo 0)"
+  printf '  %-40s %d hit(s)\n' "Makefile xcodegen generate" \
+    "$(grep -c 'xcodegen generate' Makefile 2>/dev/null || echo 0)"
+  printf '  %-40s %d hit(s)\n' "ci/local-check.sh xcodegen" \
+    "$(grep -c 'xcodegen' ci/local-check.sh 2>/dev/null || echo 0)"
+  printf '  %-40s %d hit(s)\n' "ci/local-release-check.sh xcodegen" \
+    "$(grep -c 'xcodegen' ci/local-release-check.sh 2>/dev/null || echo 0)"
+  printf '  %-40s %d hit(s)\n' ".github/workflows/pr.yml xcodegen" \
+    "$(grep -c 'xcodegen' .github/workflows/pr.yml 2>/dev/null || echo 0)"
+  echo
+  ok "dry run complete — re-run without --dry-run to apply"
+}
+
+# ── Main orchestration ────────────────────────────────────────────────────
+main() {
+  # Idempotency dispatch first (parity with bin/rename.sh):
+  # already-switched state must produce no stdout, even before printing
+  # the "Pre-flight gates" banner. The clean-tree gate runs after.
+  set +e
+  check_idempotency
+  IDEMPOT=$?
+  set -e
+
+  case "$IDEMPOT" in
+    0)
+      if [ "$DRY_RUN" = "1" ]; then
+        step "DRY RUN — already-switched state detected"
+        ok "no changes would be applied (already on Tuist)"
+      fi
+      # Real run on already-switched tree: silent exit 0. Disarm traps
+      # (no rollback needed because no mutations occurred).
+      trap - ERR EXIT INT TERM
+      exit 0
+      ;;
+    1)
+      step "Pre-flight"
+      step "Idempotency check"
+      if [ "$FORCE" = "1" ]; then
+        ok "partial state detected; --force bypass enabled — proceeding"
+      else
+        fail "partial switch-to-tuist state detected — restore manually or pass --force"
+      fi
+      ;;
+    2)
+      step "Pre-flight"
+      step "Idempotency check"
+      ok "pre-switch state confirmed — proceeding"
+      ;;
+  esac
+
+  # Pre-flight gates
+  gate_tuist_present
+  gate_project_swift_present
+
+  if [ "$DRY_RUN" != "1" ]; then
+    gate_clean_tree
+    gate_on_main
+  else
+    ok "clean-tree + on-main gates skipped on --dry-run path"
+  fi
+
+  step "All pre-flight gates passed"
+
+  if [ "$DRY_RUN" = "1" ]; then
+    print_dry_run_plan
+    trap - ERR EXIT INT TERM
+    exit 0
+  fi
+
+  # Mutation phase: arm rollback's destructive-op path. Any failure
+  # below this line triggers `git reset --hard HEAD` + `git clean -fd`.
+  MUTATION_STARTED=1
+  mutate_remove_project_yml
+  mutate_brewfile
+  mutate_makefile
+  mutate_local_check
+  mutate_local_release_check
+  mutate_pr_workflow
+
+  # Success path: disarm rollback traps.
+  trap - ERR EXIT INT TERM
+
+  step "Switch to Tuist complete"
+  ok "next: run 'cd app && tuist generate --no-open' then 'make check'"
+}
+
+main "$@"

--- a/ci/test-switch-to-tuist.sh
+++ b/ci/test-switch-to-tuist.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# ci/test-switch-to-tuist.sh — gate + integration test for bin/switch-to-tuist.sh.
+#
+# Why this exists:
+#   bin/switch-to-tuist.sh is invoked by two callers (bin/rename.sh
+#   --generator=tuist + the CI parity jobs). Both need confidence the
+#   script:
+#     - succeeds on a clean main + leaves the tree on Tuist
+#     - is idempotent (a second run is a silent no-op)
+#     - --dry-run produces a plan + leaves the tree clean
+#     - rolls back atomically when a mutation fails (parity with
+#       bin/rename.sh's reset-hard rollback)
+#     - produces a tree where `tuist generate --no-open` succeeds and
+#       `make check` is green
+#
+# Runs against a fresh clone of REPO_ROOT in a tmpdir so the running
+# tree is unaffected. Total budget ~3min (xcodegen build dominates).
+#
+# Usage:
+#   ci/test-switch-to-tuist.sh    # run from repo root
+#
+# Exit 0 = green; non-zero = a gate behaved unexpectedly.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK_DIR=""
+
+step() { printf '\n==> %s\n' "$*"; }
+ok()   { printf '    ✓ %s\n' "$*"; }
+fail() { printf '    ✗ %s\n' "$*" >&2; exit 1; }
+
+cleanup() {
+  if [ -n "$WORK_DIR" ] && [ -d "$WORK_DIR" ]; then
+    rm -rf "$WORK_DIR"
+  fi
+}
+trap 'cleanup' EXIT INT TERM
+
+# ── Pre-flight ────────────────────────────────────────────────────────────
+step "Pre-flight"
+cd "$REPO_ROOT"
+test -x bin/switch-to-tuist.sh || fail "bin/switch-to-tuist.sh not executable in $REPO_ROOT"
+test -f Tuist.swift             || fail "Tuist.swift missing — PR #1 not landed?"
+test -f app/Project.swift       || fail "app/Project.swift missing — PR #1 not landed?"
+test -f app/project.yml         || fail "app/project.yml missing — unexpected pre-switch state"
+command -v git    >/dev/null || fail "git not on PATH"
+command -v tuist  >/dev/null || fail "tuist not on PATH — install via 'brew install --cask tuist'"
+command -v make   >/dev/null || fail "make not on PATH"
+ok "tools present + Tuist manifests present"
+
+# ── Clone ─────────────────────────────────────────────────────────────────
+step "Clone REPO_ROOT to tmpdir"
+WORK_DIR="$(mktemp -d -t test-switch-to-tuist-XXXXXX)"
+git clone --no-hardlinks --quiet "$REPO_ROOT" "$WORK_DIR"
+( cd "$WORK_DIR" && git checkout --quiet -B main HEAD )
+ok "cloned to $WORK_DIR"
+
+# ── --dry-run leaves the tree clean ──────────────────────────────────────
+step "--dry-run produces plan + leaves tree clean"
+STATUS_BEFORE=$(cd "$WORK_DIR" && git status --short | sort)
+set +e
+DR_OUT=$(cd "$WORK_DIR" && bin/switch-to-tuist.sh --dry-run 2>&1)
+DR_EXIT=$?
+set -e
+STATUS_AFTER=$(cd "$WORK_DIR" && git status --short | sort)
+
+test "$DR_EXIT" -eq 0 || fail "--dry-run exited $DR_EXIT (expected 0); output: $DR_OUT"
+echo "$DR_OUT" | grep -q "DRY RUN" || fail "--dry-run output missing 'DRY RUN'; got: $DR_OUT"
+echo "$DR_OUT" | grep -q "Would remove" || fail "--dry-run output missing 'Would remove'; got: $DR_OUT"
+echo "$DR_OUT" | grep -q "Would edit" || fail "--dry-run output missing 'Would edit'; got: $DR_OUT"
+test "$STATUS_BEFORE" = "$STATUS_AFTER" || \
+  fail "--dry-run modified the tree:
+BEFORE: $STATUS_BEFORE
+AFTER:  $STATUS_AFTER"
+ok "--dry-run printed plan + tree unchanged"
+
+# ── Forced-failure rollback (chmod 000 trick) ─────────────────────────────
+# Force a failure on a mutation step by removing write permission from
+# the Brewfile (it's edited mid-script). The trap should run reset-hard
+# and the tree should end up exactly as pre-switch.
+step "Forced-failure rollback (chmod 000 Brewfile)"
+chmod 000 "$WORK_DIR/Brewfile"
+set +e
+( cd "$WORK_DIR" && bin/switch-to-tuist.sh >/dev/null 2>&1 )
+RB_EXIT=$?
+set -e
+chmod 644 "$WORK_DIR/Brewfile" 2>/dev/null || true
+
+test "$RB_EXIT" -ne 0 || fail "rollback test: forced failure should exit non-zero (got $RB_EXIT)"
+DIRTY=$(cd "$WORK_DIR" && git status --short | wc -l | tr -d ' ')
+test "$DIRTY" = "0" || \
+  fail "rollback test: working tree not clean after rollback (got $DIRTY entries):
+$(cd "$WORK_DIR" && git status --short)"
+test -f "$WORK_DIR/app/project.yml" || \
+  fail "rollback test: app/project.yml not restored"
+ok "forced-failure rollback restored pre-switch state (exit $RB_EXIT)"
+
+# ── Real switch ───────────────────────────────────────────────────────────
+step "Real switch (clean run)"
+( cd "$WORK_DIR" && bin/switch-to-tuist.sh ) || fail "bin/switch-to-tuist.sh failed on clean tree"
+
+test ! -f "$WORK_DIR/app/project.yml" || fail "post-switch: app/project.yml still present"
+test -f "$WORK_DIR/app/Project.swift" || fail "post-switch: app/Project.swift missing"
+test -f "$WORK_DIR/Tuist.swift" || fail "post-switch: Tuist.swift missing"
+
+! grep -q '^brew "xcodegen"' "$WORK_DIR/Brewfile" || \
+  fail "post-switch: Brewfile still has 'brew \"xcodegen\"'"
+grep -q 'cd app && tuist generate --no-open' "$WORK_DIR/Makefile" || \
+  fail "post-switch: Makefile missing 'tuist generate --no-open'"
+! grep -q 'cd app && xcodegen generate' "$WORK_DIR/Makefile" || \
+  fail "post-switch: Makefile still has 'cd app && xcodegen generate'"
+grep -q 'require_cmd tuist' "$WORK_DIR/ci/local-check.sh" || \
+  fail "post-switch: ci/local-check.sh missing 'require_cmd tuist'"
+! grep -q 'require_cmd xcodegen' "$WORK_DIR/ci/local-check.sh" || \
+  fail "post-switch: ci/local-check.sh still has 'require_cmd xcodegen'"
+grep -q 'tuist generate --no-open' "$WORK_DIR/.github/workflows/pr.yml" || \
+  fail "post-switch: .github/workflows/pr.yml missing 'tuist generate --no-open'"
+! grep -q 'run: xcodegen generate' "$WORK_DIR/.github/workflows/pr.yml" || \
+  fail "post-switch: .github/workflows/pr.yml still has 'run: xcodegen generate'"
+ok "all 5 mutation surfaces verified post-switch"
+
+# ── Idempotency: second run is silent no-op ───────────────────────────────
+step "Idempotency: second run is silent no-op"
+( cd "$WORK_DIR" && git add -A && git commit --quiet -m "Switch to Tuist (test fixture commit)" )
+STATUS_BEFORE=$(cd "$WORK_DIR" && git status --short | sort)
+set +e
+OUT=$(cd "$WORK_DIR" && bin/switch-to-tuist.sh 2>&1)
+EXIT=$?
+set -e
+STATUS_AFTER=$(cd "$WORK_DIR" && git status --short | sort)
+
+test "$EXIT" -eq 0 || fail "second run exit $EXIT (expected 0 silent no-op); output: $OUT"
+test -z "$OUT" || fail "second run was not silent (expected empty stdout, got):
+$OUT"
+test "$STATUS_BEFORE" = "$STATUS_AFTER" || \
+  fail "second run modified the tree:
+BEFORE: $STATUS_BEFORE
+AFTER:  $STATUS_AFTER"
+ok "second run was silent no-op (exit 0; status unchanged; stdout empty)"
+
+# ── Integration: tuist generate succeeds on the switched tree ─────────────
+step "Integration: tuist generate --no-open on switched tree"
+( cd "$WORK_DIR/app" && tuist generate --no-open >/dev/null 2>&1 ) || \
+  fail "tuist generate failed on switched tree"
+test -d "$WORK_DIR/app/HelloApp.xcodeproj" || \
+  fail "tuist generate did not produce app/HelloApp.xcodeproj"
+ok "tuist generate produces app/HelloApp.xcodeproj"
+
+# ── Integration: make check green on the switched tree ────────────────────
+step "Integration: make check (iOS device build) on switched tree"
+bash -euo pipefail <<BASH
+cd "$WORK_DIR"
+set +e
+make check 2>&1 | tee .test-switch-make-check.log
+EXIT=\${PIPESTATUS[0]}
+set -e
+test "\$EXIT" -eq 0 || { echo "ERROR: make check failed with exit \$EXIT"; exit 1; }
+BASH
+ok "make check exit 0 on switched tree"
+
+# ── Done ──────────────────────────────────────────────────────────────────
+step "ci/test-switch-to-tuist.sh: all assertions passed"
+ok "tmpdir cleanup will run via EXIT trap"


### PR DESCRIPTION
Second PR in the multi-PR series for first-class Tuist support — Refs #38.

## What

Adds `bin/switch-to-tuist.sh` — a standalone, idempotent, atomic script that converts a fork from XcodeGen-driven to Tuist-driven. Same gating + rollback contract as `bin/rename.sh` (clean-tree gate, on-main gate, MUTATION_STARTED guard, reset-hard rollback on any failure).

Two callers will reuse this:
1. `bin/rename.sh ... --generator=tuist` (PR 4) — invoked with `--force` because the rename script's tree is mid-mutation.
2. The 3 new Tuist parity jobs in `.github/workflows/pr.yml` (PR 3).

Factoring the surgery out of `bin/rename.sh` keeps both call-sites independently testable. No edits to existing scripts or workflows in this PR — the script and its harness are net-new.

## Files

- New: `bin/switch-to-tuist.sh` — script with full why-header (per PRINCIPLES.md #6)
- New: `ci/test-switch-to-tuist.sh` — gate + integration harness
- Modified: `CHANGELOG.md` — Unreleased / Added bullet

## Mutation surface (what the script edits)

- Removes `app/project.yml`
- `Brewfile`: drops `brew "xcodegen"` line
- `Makefile`: `cd app && xcodegen generate` → `cd app && tuist generate --no-open` (2 occurrences); help-line update
- `ci/local-check.sh`: `require_cmd xcodegen` → `require_cmd tuist`; `xcodegen generate` → `tuist generate --no-open`
- `ci/local-release-check.sh`: same pattern + `step` echo update
- `.github/workflows/pr.yml`: 3 jobs — install + generate steps swap to Tuist

## Test plan

`ci/test-switch-to-tuist.sh` (run locally — green) exercises:
1. **--dry-run** produces a plan + leaves the tree clean (`git status --short` byte-identical before/after).
2. **Forced-failure rollback**: `chmod 000 Brewfile` mid-script → script exits non-zero → `git reset --hard HEAD` + `git clean -fd` restore pre-switch state. `app/project.yml` reappears.
3. **Clean run** + post-switch grep assertions on all 5 mutation surfaces (Brewfile, Makefile, ci/local-check.sh, ci/local-release-check.sh, .github/workflows/pr.yml).
4. **Idempotency**: second `bin/switch-to-tuist.sh` is a silent no-op (exit 0, empty stdout, `git status --short` unchanged).
5. **`tuist generate --no-open`** succeeds on the switched tree → produces `app/HelloApp.xcodeproj`.
6. **`make check`** (iOS device build via the rewritten ci/local-check.sh) green on the switched tree.

`make check` on this PR's branch is also green — the new script is unused in the default flow, so XcodeGen path is unchanged.

SCOPE.md test: diff is `bin/switch-to-tuist.sh`, `ci/test-switch-to-tuist.sh`, `CHANGELOG.md` only. No Swift source under `app/HelloApp/` modified.

## References

- Refs #38 (the umbrella issue with the 5-PR sequence)
- Predecessor: #39 (Tuist 4 manifests on `main`)
- [PRINCIPLES.md](../blob/main/docs/PRINCIPLES.md) #6 (script why-header), #9 (CHANGELOG in same PR), #20 (test plan)
- [SCOPE.md](../blob/main/SCOPE.md) (in scope: developer-experience helper; app source untouched)
