### PR TITLE
feat: CI matrix — 3 XcodeGen + 3 Tuist parity jobs (refs #38)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -98,3 +98,109 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
             2>&1 | xcbeautify --renderer github-actions
+
+  # ─── Tuist parity matrix ────────────────────────────────────────────────────
+  # The Tuist manifests (Tuist.swift + app/Project.swift) ship alongside
+  # app/project.yml so forkers can pick their generator at fork time
+  # (bin/rename.sh --generator=tuist|xcodegen). These 3 jobs run
+  # bin/switch-to-tuist.sh against a fresh checkout, regenerate
+  # HelloApp.xcodeproj from Project.swift, and run the same xcodebuild
+  # commands as the XcodeGen jobs above. Keeps both manifests in sync
+  # on every PR — drift fails CI immediately.
+  app-tuist-ios-device:
+    name: app (Tuist iOS device)
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install xcbeautify + tuist
+        run: |
+          brew install xcbeautify
+          brew install --cask tuist
+
+      - name: switch fork to Tuist
+        run: bin/switch-to-tuist.sh --force
+
+      - name: regenerate Xcode project (Tuist)
+        working-directory: app
+        run: tuist generate --no-open
+
+      - name: build iOS device (unsigned)
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -project app/HelloApp.xcodeproj \
+            -scheme HelloApp-iOS \
+            -configuration Debug \
+            -sdk iphoneos \
+            -destination 'generic/platform=iOS' \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            2>&1 | xcbeautify --renderer github-actions
+
+  app-tuist-ios-sim:
+    name: app (Tuist iOS Simulator)
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install xcbeautify + tuist
+        run: |
+          brew install xcbeautify
+          brew install --cask tuist
+
+      - name: switch fork to Tuist
+        run: bin/switch-to-tuist.sh --force
+
+      - name: regenerate Xcode project (Tuist)
+        working-directory: app
+        run: tuist generate --no-open
+
+      - name: build iOS Simulator (unsigned)
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -project app/HelloApp.xcodeproj \
+            -scheme HelloApp-iOS \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            2>&1 | xcbeautify --renderer github-actions
+
+  app-tuist-macos:
+    name: app (Tuist macOS)
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install xcbeautify + tuist
+        run: |
+          brew install xcbeautify
+          brew install --cask tuist
+
+      - name: switch fork to Tuist
+        run: bin/switch-to-tuist.sh --force
+
+      - name: regenerate Xcode project (Tuist)
+        working-directory: app
+        run: tuist generate --no-open
+
+      - name: build macOS (unsigned)
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -project app/HelloApp.xcodeproj \
+            -scheme HelloApp-macOS \
+            -configuration Debug \
+            -destination 'generic/platform=macOS' \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            2>&1 | xcbeautify --renderer github-actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Tuist.swift` + `app/Project.swift` — Tuist 4 manifests committed alongside `app/project.yml`. XcodeGen remains the default; Tuist users can `cd app && tuist generate --no-open` and build directly. Forker-time selection arrives in a follow-up PR (Refs #38)
 - `bin/switch-to-tuist.sh` — convert a fork from XcodeGen to Tuist via a single command. Idempotent + atomic-rollback (parity with `bin/rename.sh`'s contract). Edits Brewfile, Makefile, ci/local-check.sh, ci/local-release-check.sh, .github/workflows/pr.yml; removes `app/project.yml`. Exercised by `ci/test-switch-to-tuist.sh` and reused by the `bin/rename.sh --generator=tuist` flag in a follow-up PR. (Refs #38)
 
+### Changed
+- CI now runs both XcodeGen and Tuist generators on every PR (3 → 6 required checks). Existing XcodeGen jobs unchanged; new Tuist parity jobs (`app (Tuist iOS device)`, `app (Tuist iOS Simulator)`, `app (Tuist macOS)`) use `bin/switch-to-tuist.sh` to convert the fork before building. `bin/setup-github.sh` updated; existing forkers must re-run `make setup-github` once to pick up the new required checks. README + CONTRIBUTING + PRINCIPLES updated to reference 6 checks. (Refs #38)
+
 ## [1.0.0] - 2026-05-01
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,11 +49,11 @@ the primary signal.
 
 ## What every PR needs
 
-1. **Three CI checks green.** Branch protection on `main` enforces this.
-   The required jobs are:
-   - `app (iOS device)`
-   - `app (iOS Simulator)`
-   - `app (macOS)`
+1. **Six CI checks green.** Branch protection on `main` enforces this.
+   The required jobs are 3 XcodeGen + 3 Tuist parity:
+   - `app (iOS device)`              · `app (Tuist iOS device)`
+   - `app (iOS Simulator)`           · `app (Tuist iOS Simulator)`
+   - `app (macOS)`                   · `app (Tuist macOS)`
 
    These names are pinned in `.github/workflows/pr.yml` and mirrored in
    `bin/setup-github.sh`. Renaming a job means updating both — see

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ What you get out of the box:
 
 - **Local checks** — `ci/local-check.sh --fast` runs an unsigned iOS device
   build (the primary CI signal) on every `git push` via lefthook.
-- **GitHub Actions** — three jobs on every PR: iOS device, iOS Simulator, macOS.
+- **GitHub Actions** — six jobs on every PR: 3 XcodeGen (iOS device, iOS Simulator, macOS) + 3 Tuist parity (same matrix, exercises `bin/switch-to-tuist.sh` before building).
   Branch protection on `main` blocks direct pushes.
 - **Signed release pipeline** — `fastlane release tag:v0.1.0` builds signed
   `.ipa` + `.pkg`, uploads both to TestFlight, then pushes the git tag.
@@ -283,7 +283,7 @@ This applies the following settings to your repo:
 
 - **Branch protection on `main`**:
   - Require PR before merging (no direct pushes — even for repo admins)
-  - Require 3 CI checks green: `app (iOS device)`, `app (iOS Simulator)`, `app (macOS)`
+  - Require 6 CI checks green: `app (iOS device)`, `app (iOS Simulator)`, `app (macOS)` (XcodeGen) + `app (Tuist iOS device)`, `app (Tuist iOS Simulator)`, `app (Tuist macOS)` (parity matrix)
   - Require checks to be up-to-date with `main` before merge (strict mode)
   - Enforce on admins (no bypass)
   - Require linear history

--- a/bin/setup-github.sh
+++ b/bin/setup-github.sh
@@ -6,7 +6,9 @@
 #   - Default branch: main
 #   - Branch protection on main:
 #       * Require PR before merging (no direct pushes)
-#       * Require 3 status checks: app (iOS device), app (iOS Simulator), app (macOS)
+#       * Require 6 status checks: 3 XcodeGen (app (iOS device), app (iOS Simulator),
+#         app (macOS)) + 3 Tuist parity (app (Tuist iOS device),
+#         app (Tuist iOS Simulator), app (Tuist macOS))
 #       * Require status checks to be up-to-date before merge
 #       * Enforce on admins (no bypass — same rules apply to repo owner)
 #       * Require linear history
@@ -85,7 +87,10 @@ PROTECTION_JSON=$(cat <<'JSON'
     "checks": [
       { "context": "app (iOS device)" },
       { "context": "app (iOS Simulator)" },
-      { "context": "app (macOS)" }
+      { "context": "app (macOS)" },
+      { "context": "app (Tuist iOS device)" },
+      { "context": "app (Tuist iOS Simulator)" },
+      { "context": "app (Tuist macOS)" }
     ]
   },
   "enforce_admins": true,
@@ -114,8 +119,8 @@ echo "$PROTECTION_JSON" | gh api -X PUT "repos/$REPO/branches/main/protection" \
   # PUT returns 404. Make this error clearer.
   fail "could not apply protection — does '$REPO' have a 'main' branch yet? Push at least one commit first."
 }
-ok "main: PR-required, 3 CI checks (strict), enforce on admins, linear history"
+ok "main: PR-required, 6 CI checks (3 XcodeGen + 3 Tuist, strict), enforce on admins, linear history"
 
 step "Done"
-ok "$REPO is configured (PR-required, 3 CI checks, squash-only, auto-merge)."
+ok "$REPO is configured (PR-required, 6 CI checks, squash-only, auto-merge)."
 ok "Direct pushes to main are blocked. Open PRs and let CI run."

--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -11,9 +11,11 @@ first and let's talk.
 
 ## Quality gates
 
-1. **Every PR runs CI.** Three jobs (`app (iOS device)`, `app (iOS Simulator)`,
-   `app (macOS)`) must be green before merge. Branch protection enforces this
-   for everyone, including maintainers.
+1. **Every PR runs CI.** Six jobs (3 XcodeGen — `app (iOS device)`,
+   `app (iOS Simulator)`, `app (macOS)` — plus 3 Tuist parity —
+   `app (Tuist iOS device)`, `app (Tuist iOS Simulator)`, `app (Tuist macOS)`)
+   must be green before merge. Branch protection enforces this for
+   everyone, including maintainers.
 2. **No direct pushes to `main`.** Even one-line fixes go through a PR. The
    pre-push hook (`lefthook` → `ci/local-check.sh --fast`) catches breakage
    before it reaches GitHub.


### PR DESCRIPTION
Third PR in the multi-PR series for first-class Tuist support — Refs #38.

## What

Adds 3 new CI jobs that mirror the existing XcodeGen jobs but exercise the Tuist manifest path. Each new job:

1. Fresh `actions/checkout@v4`
2. `brew install xcbeautify` + `brew install --cask tuist`
3. `bin/switch-to-tuist.sh --force` (converts the fork — the script landed in #40)
4. `cd app && tuist generate --no-open`
5. The exact same `xcodebuild build` command as the corresponding XcodeGen job

This proves the Tuist manifest stays compatible with `app/project.yml` on every PR — drift fails CI immediately. That's the structural defense that lets us keep both manifests on `main` long-term.

`bin/setup-github.sh` updated: required-checks list grows from 3 → 6. Existing forkers re-run `make setup-github` once to pick up the new requirement (called out in the CHANGELOG bullet).

## Files

- `.github/workflows/pr.yml` — 3 new jobs: `app (Tuist iOS device)`, `app (Tuist iOS Simulator)`, `app (Tuist macOS)`
- `bin/setup-github.sh` — required-checks array 3 → 6; header + log lines updated
- `README.md` — "What you get" + branch-protection sections reflect 6 checks
- `CONTRIBUTING.md` — "What every PR needs" reflects 6 checks
- `docs/PRINCIPLES.md` — Quality Gates rule #1 reflects 6 checks
- `CHANGELOG.md` — Unreleased / Changed bullet

## Test plan

1. **6 CI checks must all be green on this PR**, including the 3 new Tuist parity jobs. They depend on `bin/switch-to-tuist.sh` from #40 (already on `main`), so the script is available in the checkout.
2. `make check` green locally (XcodeGen path unchanged on the contributor's tree).
3. Workflow YAML parses cleanly: `python3 -c "import yaml; …"` lists all 6 jobs.
4. `bin/setup-github.sh` bash-syntax green.
5. Post-merge, maintainer runs `make setup-github` against this repo so branch protection enforces the 6-check rule for subsequent PRs.

## Sequencing constraint

Depends on #40 (the Tuist parity jobs invoke `bin/switch-to-tuist.sh`). #40 is merged on `main` so this PR's CI checkout finds the script.

## References

- Refs #38 (the umbrella issue)
- Predecessors: #39 (Tuist 4 manifests), #40 (`bin/switch-to-tuist.sh`)
- [PRINCIPLES.md](../blob/main/docs/PRINCIPLES.md) #1 (CI gates), #9 (CHANGELOG in same PR), #10 (semver — adding required checks is forker-facing additive → MINOR; existing checks unchanged)
- [SCOPE.md](../blob/main/SCOPE.md) (in scope: CI providers / build tooling)
