### PR TITLE
feat: bin/rename.sh --generator=tuist|xcodegen flag (closes #38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - CI now runs both XcodeGen and Tuist generators on every PR (3 → 6 required checks). Existing XcodeGen jobs unchanged; new Tuist parity jobs (`app (Tuist iOS device)`, `app (Tuist iOS Simulator)`, `app (Tuist macOS)`) use `bin/switch-to-tuist.sh` to convert the fork before building. `bin/setup-github.sh` updated; existing forkers must re-run `make setup-github` once to pick up the new required checks. README + CONTRIBUTING + PRINCIPLES updated to reference 6 checks. (Refs #38)
+- `bin/rename.sh --generator=tuist|xcodegen` flag lets forkers pick their project generator at fork time. Defaults to `xcodegen` (existing behavior preserved). `--generator=tuist` invokes `bin/switch-to-tuist.sh --force` after the rename's substitutions complete — fork ends up with `app/Project.swift` driving builds, `app/project.yml` deleted, Brewfile / Makefile / ci scripts / pr.yml all updated. Validated by `ci/test-rename.sh` (full e2e: rename → verify → make check) and `ci/test-rename-gates.sh` (validation gate forms). `bin/verify-rename.sh` adds a 6th sanity check that fails when neither manifest is present (project broken). `app/Project.swift`'s two `CFBundleDisplayName` lines now use the same placeholder anchoring as `app/project.yml` so the broad rename sweep doesn't conflate APP_NAME with DISPLAY_NAME. (Closes #38)
 
 ## [1.0.0] - 2026-05-01
 

--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -6,7 +6,7 @@
 # idempotent (silent no-op on re-run with same args), pre-flight-gated.
 #
 # Usage:
-#   bin/rename.sh APP_NAME BUNDLE_ID DISPLAY_NAME --email=EMAIL [--slug=OWNER/REPO] [--year=YYYY] [--dry-run] [--force]
+#   bin/rename.sh APP_NAME BUNDLE_ID DISPLAY_NAME --email=EMAIL [--slug=OWNER/REPO] [--year=YYYY] [--generator=tuist|xcodegen] [--dry-run] [--force]
 #   bin/rename.sh -h                                # print this usage
 #   bin/rename.sh --help                            # alias for -h
 #
@@ -30,6 +30,15 @@
 #                       `git remote get-url origin`. MUST NOT contain
 #                       newline or '|'.
 #   --year=YYYY         Override copyright year (default: current year via date +%Y).
+#   --generator=GEN     Project generator to use post-rename. One of:
+#                         xcodegen (default; byte-for-byte unchanged behavior;
+#                                   Tuist artifacts left in tree but unused)
+#                         tuist    (invokes bin/switch-to-tuist.sh --force after
+#                                   rename to delete app/project.yml + edit
+#                                   Brewfile / Makefile / ci scripts / pr.yml)
+#                       Both manifests ship on `main` (#38); the flag picks which
+#                       one drives the renamed fork. Pre-flight gate fails if
+#                       --generator=tuist and `tuist` is not on PATH.
 #   --dry-run           Preview substitutions without applying.
 #   --force             Override the on-main-branch gate AND the partial-
 #                       rename detection gate. Other gates (args validation,
@@ -47,6 +56,7 @@
 #   5. DISPLAY_NAME non-empty AND no newline/'|'
 #   5b. EMAIL non-empty AND no newline/'|'
 #   5c. SLUG non-empty (auto-derived if absent) AND no newline/'|' AND OWNER/REPO format
+#   5d. GENERATOR ∈ {tuist, xcodegen} (default xcodegen; tuist requires `tuist` on PATH)
 #   6. Idempotency check (BEFORE clean-tree gate per HIGH-3) —
 #      case 0 = silent exit 0 (already renamed)
 #      case 1 = partial-rename fail (unless --force)
@@ -109,6 +119,7 @@ DISPLAY_NAME=""
 EMAIL=""
 SLUG=""
 YEAR_ARG=""
+GENERATOR="xcodegen"   # default; --generator=tuist|xcodegen overrides (#38)
 DRY_RUN=0
 FORCE=0
 
@@ -143,6 +154,12 @@ parse_args() {
         [ $# -ge 2 ] || fail "--year requires a value (e.g. --year=2026)"
         case "$2" in -*) fail "--year value cannot start with '-' (got '$2')";; esac
         YEAR_ARG="$2"; shift 2 ;;
+      --generator=*)
+        GENERATOR="${1#--generator=}"; shift ;;
+      --generator)
+        [ $# -ge 2 ] || fail "--generator requires a value (e.g. --generator=tuist)"
+        case "$2" in -*) fail "--generator value cannot start with '-' (got '$2')";; esac
+        GENERATOR="$2"; shift 2 ;;
       -*)
         fail "unknown flag '$1' — run with -h for usage" ;;
       *)
@@ -219,6 +236,15 @@ validate_args() {
   [[ "$SLUG" =~ ^[^/]+/[^/]+$ ]] || \
     fail "invalid --slug '$SLUG' — expected OWNER/REPO (e.g. acme/myapp)"
   ok "SLUG format OK"
+
+  # Gate 5d: --generator ∈ {tuist, xcodegen}. Default 'xcodegen' set at
+  # file scope so this gate effectively rejects anything that survived
+  # parse_args with a non-empty non-default value.
+  case "$GENERATOR" in
+    tuist|xcodegen) ;;
+    *) fail "invalid --generator '$GENERATOR' — must be 'tuist' or 'xcodegen' (default: xcodegen)" ;;
+  esac
+  ok "--generator '$GENERATOR' valid"
 }
 
 # ── Reset-hard rollback (REQ-7; HIGH-1 closure — replaces broken stash) ───
@@ -422,6 +448,16 @@ apply_substitutions() {
     ok "DISPLAY placeholder set in app/project.yml (2 CFBundleDisplayName sites)"
   fi
 
+  # #38 closure: app/Project.swift's two CFBundleDisplayName lines need
+  # the same placeholder treatment as project.yml. Without anchoring,
+  # Step F's broad HelloApp -> APP_NAME sweep would set CFBundleDisplayName
+  # to the APP_NAME (forker's code-name) instead of the DISPLAY_NAME
+  # (forker's user-facing name). Project.swift was added to `main` in #39.
+  if [ -f app/Project.swift ]; then
+    sed -i '' "s|\"CFBundleDisplayName\": \"HelloApp\"|\"CFBundleDisplayName\": \"$DISPLAY_PLACEHOLDER\"|g" app/Project.swift
+    ok "DISPLAY placeholder set in app/Project.swift (2 CFBundleDisplayName sites)"
+  fi
+
   if [ -f app/Shared/ContentView.swift ]; then
     sed -i '' "s|Text(\"HelloApp\")|Text(\"$DISPLAY_PLACEHOLDER\")|g" app/Shared/ContentView.swift
     ok "DISPLAY placeholder set in app/Shared/ContentView.swift"
@@ -563,6 +599,20 @@ gate_xcodegen_present() {
   ok "xcodegen on PATH"
 }
 
+gate_tuist_present_if_needed() {
+  # Only fires when --generator=tuist. Pre-mutation gate so we fail
+  # fast before any file mutation. The tuist binary is needed because
+  # bin/switch-to-tuist.sh (invoked post-rename when GEN=tuist) gates
+  # on `tuist` being on PATH and the rename script's atomic-rollback
+  # contract requires no successful mutations before a downstream
+  # failure.
+  if [ "$GENERATOR" = "tuist" ]; then
+    command -v tuist >/dev/null 2>&1 || \
+      fail "tuist not found (--generator=tuist) — install with 'brew install --cask tuist' (then re-run)"
+    ok "tuist on PATH ($(tuist version 2>/dev/null | head -1))"
+  fi
+}
+
 gate_clean_tree() {
   # NOTE: We deliberately DO NOT pass --untracked-files=no here.
   # Forker-facing script must catch untracked files (e.g.
@@ -644,6 +694,9 @@ EOF
   echo "  app/Shared/ContentView.swift: Text(\"HelloApp\")"
   echo "  app/UITests/AppStoreScreenshotTests.swift: staticTexts[\"HelloApp\"]"
   echo "  fastlane/metadata/en-US/name.txt: whole-file"
+  if [ -f app/Project.swift ]; then
+    echo "  app/Project.swift: CFBundleDisplayName (2 sites — iOS + macOS, Tuist manifest)"
+  fi
 
   echo
   echo "File-path renames:"
@@ -654,6 +707,15 @@ EOF
   echo
   echo "xcodegen regen:"
   echo "  cd app && xcodegen generate  ->  app/$APP_NAME.xcodeproj/"
+
+  if [ "$GENERATOR" = "tuist" ]; then
+    echo
+    echo "Post-rename generator switch (--generator=tuist):"
+    echo "  bin/switch-to-tuist.sh --force  ->  delete app/project.yml + edit Brewfile / Makefile / ci scripts / .github/workflows/pr.yml"
+  else
+    echo
+    echo "Post-rename generator: xcodegen (default; Tuist artifacts left in tree but unused)"
+  fi
 
   echo
   ok "dry run complete — re-run without --dry-run to apply"
@@ -730,6 +792,9 @@ main() {
   # 4. xcodegen presence (gate 2)
   gate_xcodegen_present
 
+  # 4b. Tuist presence (gate 5d-companion; only fires when --generator=tuist).
+  gate_tuist_present_if_needed
+
   # 5+6. Mutation-scoped gates: clean-tree + on-main. Skipped on --dry-run.
   if [ "$DRY_RUN" != "1" ]; then
     # Gate 7: working tree clean
@@ -761,6 +826,23 @@ main() {
       apply_substitutions
       rename_file_paths
       regen_xcodeproj
+
+  # Final mutation phase: --generator=tuist invokes bin/switch-to-tuist.sh
+  # to delete app/project.yml + edit Brewfile / Makefile / ci scripts /
+  # pr.yml. The switch script's idempotency dispatch returns case 2
+  # (pre-switch state) on a fresh post-substitution tree — Brewfile
+  # still has `brew "xcodegen"`, project.yml is still present (just
+  # sed-substituted), Project.swift is still present. --force bypasses
+  # switch-to-tuist's clean-tree + on-main gates (the rename script's
+  # tree is dirty mid-mutation by design). The rollback trap remains
+  # armed; if switch-to-tuist fails, ROLLBACK_DONE=0 + MUTATION_STARTED=1
+  # → reset-hard restores the pre-rename tree (including project.yml).
+  if [ "$GENERATOR" = "tuist" ]; then
+    step "Invoking bin/switch-to-tuist.sh --force (--generator=tuist)"
+    bin/switch-to-tuist.sh --force \
+      || fail "bin/switch-to-tuist.sh failed — see preceding stderr for diagnostic"
+    ok "switched fork to Tuist (project.yml deleted; Brewfile / Makefile / ci scripts / pr.yml updated)"
+  fi
 
   # Success path: disarm rollback traps (no stash to drop per HIGH-1)
   trap - ERR EXIT INT TERM

--- a/bin/switch-to-tuist.sh
+++ b/bin/switch-to-tuist.sh
@@ -185,8 +185,12 @@ gate_on_main() {
 mutate_remove_project_yml() {
   step "Removing app/project.yml"
   if [ -f "app/project.yml" ]; then
-    git rm --quiet app/project.yml
-    ok "app/project.yml removed (git rm)"
+    # -f bypasses git's "file has local modifications" refusal.
+    # bin/rename.sh invokes this script mid-mutation (project.yml is sed-
+    # substituted but uncommitted); -f tolerates that. On a clean tree
+    # there are no local modifications so -f is a no-op.
+    git rm -f --quiet app/project.yml
+    ok "app/project.yml removed (git rm -f)"
   else
     ok "app/project.yml already absent"
   fi

--- a/bin/verify-rename.sh
+++ b/bin/verify-rename.sh
@@ -14,8 +14,8 @@
 #   0 — all 4 surfaces clean (no matches in tracked files)
 #   1 — any leak; per-surface stderr report + trailing summary
 #
-# Surfaces synced with bin/rename.sh:291. If rename.sh adds a surface,
-# update both. (D-03 cross-reference.)
+# Surfaces synced with bin/rename.sh's substitution-target enumeration.
+# If rename.sh adds a surface, update both. (D-03 cross-reference.)
 #
 # DISPLAY_NAME shares 'HelloApp' literal with APP_NAME pre-rename;
 # covered transitively by APP_NAME_ORIG (D-11).
@@ -153,6 +153,24 @@ SURFACES_LEAKED=0
 [ "$EMAIL_HITS"     -gt 0 ] && SURFACES_LEAKED=$((SURFACES_LEAKED + 1))
 [ "$SLUG_HITS"      -gt 0 ] && SURFACES_LEAKED=$((SURFACES_LEAKED + 1))
 [ "$YEAR_HITS"      -gt 0 ] && SURFACES_LEAKED=$((SURFACES_LEAKED + 1))
+
+# ── 6th surface: project-manifest sanity (#38) ─────────────────────────
+# After bin/rename.sh runs, the fork should have at least one of
+# app/project.yml (XcodeGen) or app/Project.swift (Tuist) — both are
+# legitimate post-rename states (default --generator=xcodegen leaves
+# Tuist artifacts in tree; --generator=tuist invokes
+# bin/switch-to-tuist.sh which deletes project.yml). Neither present
+# means the project is unbuildable — that's the leak this check
+# catches. Forker error: e.g. accidentally deleting both manifest
+# files mid-rename.
+if [ ! -f "app/project.yml" ] && [ ! -f "app/Project.swift" ]; then
+  printf 'PROJECT MANIFEST leak (no generator manifest present):\n' >&2
+  printf '  app/project.yml absent AND app/Project.swift absent\n' >&2
+  printf '  Project is unbuildable — restore one (or run bin/rename.sh --generator=…)\n' >&2
+  printf '\n' >&2
+  TOTAL=$((TOTAL + 1))
+  SURFACES_LEAKED=$((SURFACES_LEAKED + 1))
+fi
 
 if [ "$TOTAL" -gt 0 ]; then
   printf 'Verify failed: %d total matches across %d surfaces.\n' \

--- a/ci/test-rename-gates.sh
+++ b/ci/test-rename-gates.sh
@@ -490,6 +490,64 @@ test "$HITS" = "0" || \
   fail "G-01: $HITS HelloApp substring matches remain post-rename (substring form, no -w)"
 ok "HelloAppApp scrubbed; MyAppApp present; 0 HelloApp substring hits repo-wide"
 
+# ── Gate 5d: --generator validation (#38; PR 4) ───────────────────────────
+#
+# Per #38: bin/rename.sh's --generator=GEN flag accepts only 'tuist' or
+# 'xcodegen' (default 'xcodegen'). Three falsifiable forms exercised:
+#   - --generator=invalid → fail at validate_args
+#   - --generator=tuist on dry-run from REPO_ROOT (where tuist IS on PATH)
+#     → succeeds with 'Post-rename generator switch' line in dry-run output
+#   - --generator=xcodegen explicit (the default) → succeeds with 'xcodegen'
+#     in dry-run output
+
+step "Gate 5d: --generator=invalid exits 1 with descriptive error"
+set +e
+GI_OUT=$(cd "$REPO_ROOT" && bin/rename.sh MyApp com.acme.myapp "My App" \
+  --email=test@acme.com --slug=test/myapp --generator=invalid 2>&1)
+GI_EXIT=$?
+set -e
+test "$GI_EXIT" -ne 0 || \
+  fail "Gate 5d: --generator=invalid should exit non-zero (got $GI_EXIT); output: $GI_OUT"
+echo "$GI_OUT" | grep -q -- "invalid --generator 'invalid'" || \
+  fail "Gate 5d: stderr missing \"invalid --generator 'invalid'\"; got: $GI_OUT"
+echo "$GI_OUT" | grep -q "must be 'tuist' or 'xcodegen'" || \
+  fail "Gate 5d: stderr missing \"must be 'tuist' or 'xcodegen'\"; got: $GI_OUT"
+ok "--generator=invalid rejected (exit $GI_EXIT)"
+
+step "Gate 5d: --generator=tuist dry-run shows 'Post-rename generator switch'"
+TD=$(fresh_clone)
+set +e
+GT_OUT=$(cd "$TD" && bin/rename.sh MyApp com.acme.myapp "My App" \
+  --email=test@acme.com --slug=test/myapp --generator=tuist --dry-run 2>&1)
+GT_EXIT=$?
+set -e
+test "$GT_EXIT" -eq 0 || fail "Gate 5d: --generator=tuist --dry-run exited $GT_EXIT (expected 0); output: $GT_OUT"
+echo "$GT_OUT" | grep -q -- "--generator 'tuist' valid" || \
+  fail "Gate 5d: --generator=tuist did not announce valid; got: $GT_OUT"
+echo "$GT_OUT" | grep -q "Post-rename generator switch (--generator=tuist):" || \
+  fail "Gate 5d: --generator=tuist dry-run missing 'Post-rename generator switch'; got: $GT_OUT"
+echo "$GT_OUT" | grep -q "tuist on PATH" || \
+  fail "Gate 5d: --generator=tuist did not run gate_tuist_present_if_needed; got: $GT_OUT"
+ok "--generator=tuist dry-run announces switch + runs tuist-presence gate"
+
+step "Gate 5d: --generator=xcodegen (default) dry-run announces xcodegen path"
+TD=$(fresh_clone)
+set +e
+GX_OUT=$(cd "$TD" && bin/rename.sh MyApp com.acme.myapp "My App" \
+  --email=test@acme.com --slug=test/myapp --generator=xcodegen --dry-run 2>&1)
+GX_EXIT=$?
+set -e
+test "$GX_EXIT" -eq 0 || fail "Gate 5d: --generator=xcodegen --dry-run exited $GX_EXIT (expected 0); output: $GX_OUT"
+echo "$GX_OUT" | grep -q -- "--generator 'xcodegen' valid" || \
+  fail "Gate 5d: --generator=xcodegen did not announce valid; got: $GX_OUT"
+echo "$GX_OUT" | grep -q "Post-rename generator: xcodegen" || \
+  fail "Gate 5d: --generator=xcodegen dry-run missing 'Post-rename generator: xcodegen'; got: $GX_OUT"
+# Tuist gate must NOT run on the xcodegen path (avoid forcing forkers
+# without tuist installed to install it).
+! echo "$GX_OUT" | grep -q "tuist on PATH" || \
+  fail "Gate 5d: --generator=xcodegen unexpectedly ran tuist-presence gate; got: $GX_OUT"
+ok "--generator=xcodegen (default) announces xcodegen path; tuist gate not invoked"
+
 # ── Done ──────────────────────────────────────────────────────────────────
 
 step "ci/test-rename-gates.sh: all gate-coverage assertions passed"

--- a/ci/test-rename.sh
+++ b/ci/test-rename.sh
@@ -334,6 +334,86 @@ ok "AC-19 (c): pre-rename file paths restored"
 
 step "AC-19 forced-failure rollback exercise: PASSED"
 
+# ── --generator=tuist end-to-end (#38; PR 4 closure) ──────────────────────
+#
+# Per #38 acceptance criteria:
+#   bin/rename.sh ... --generator=tuist on a fresh clone produces a
+#   Tuist-only fork that `make check` is green on.
+#
+# Reuses the existing tmpdir clone shape (force-set main, fresh checkout)
+# because the rename script's idempotency dispatch needs a recognizable
+# pre-rename state. The earlier AC-19 reset-hard left the clone in a
+# clean post-rollback main, which is exactly what we want here.
+
+step "--generator=tuist end-to-end (#38)"
+
+# Reset clone to clean main (post-AC-19 it should already be clean,
+# but be explicit — earlier failed-rename leftovers must not survive).
+git reset --hard --quiet HEAD
+git clean -fdx --quiet
+
+test -f app/project.yml      || fail "--generator=tuist setup: app/project.yml missing pre-rename"
+test -f app/Project.swift    || fail "--generator=tuist setup: app/Project.swift missing pre-rename (PR 1 not landed?)"
+test -f Tuist.swift          || fail "--generator=tuist setup: Tuist.swift missing pre-rename"
+test -x bin/switch-to-tuist.sh || fail "--generator=tuist setup: bin/switch-to-tuist.sh missing/not executable (PR 2 not landed?)"
+command -v tuist >/dev/null  || fail "--generator=tuist setup: tuist not on PATH; install via 'brew install --cask tuist'"
+
+bin/rename.sh "$TEST_APP" "$TEST_BUNDLE" "$TEST_DISPLAY" \
+  --email="$TEST_EMAIL" --slug="$TEST_SLUG" --generator=tuist \
+  || fail "bin/rename.sh --generator=tuist failed in tmpdir"
+ok "rename --generator=tuist complete"
+
+# Post-rename assertions specific to --generator=tuist:
+test ! -f app/project.yml || fail "--generator=tuist: app/project.yml still present (switch-to-tuist did not delete it)"
+test -f app/Project.swift || fail "--generator=tuist: app/Project.swift missing (substitutions wiped it?)"
+test -f Tuist.swift       || fail "--generator=tuist: Tuist.swift missing"
+! grep -q '^brew "xcodegen"' Brewfile || \
+  fail "--generator=tuist: Brewfile still has 'brew \"xcodegen\"'"
+grep -q 'cd app && tuist generate --no-open' Makefile || \
+  fail "--generator=tuist: Makefile missing 'tuist generate --no-open'"
+! grep -q 'cd app && xcodegen generate' Makefile || \
+  fail "--generator=tuist: Makefile still has 'cd app && xcodegen generate'"
+grep -q 'require_cmd tuist' ci/local-check.sh || \
+  fail "--generator=tuist: ci/local-check.sh missing 'require_cmd tuist'"
+! grep -q 'require_cmd xcodegen' ci/local-check.sh || \
+  fail "--generator=tuist: ci/local-check.sh still has 'require_cmd xcodegen'"
+grep -q 'tuist generate --no-open' .github/workflows/pr.yml || \
+  fail "--generator=tuist: .github/workflows/pr.yml missing 'tuist generate --no-open'"
+! grep -q 'run: xcodegen generate' .github/workflows/pr.yml || \
+  fail "--generator=tuist: .github/workflows/pr.yml still has 'run: xcodegen generate'"
+ok "--generator=tuist: 5 mutation surfaces verified (no project.yml, Brewfile, Makefile, ci/local-check.sh, pr.yml)"
+
+# CFBundleDisplayName placeholder verification — Project.swift's
+# CFBundleDisplayName lines must end up as DISPLAY_NAME (not APP_NAME).
+grep -qF "\"CFBundleDisplayName\": \"$TEST_DISPLAY\"" app/Project.swift || \
+  fail "--generator=tuist: app/Project.swift's CFBundleDisplayName not set to DISPLAY_NAME '$TEST_DISPLAY'"
+ok "Project.swift CFBundleDisplayName placeholder honored ('$TEST_DISPLAY')"
+
+# Verify-rename must exit 0 silent on the --generator=tuist post-rename tree.
+set +e
+VERIFY_OUT=$(bin/verify-rename.sh 2>&1)
+VERIFY_EXIT=$?
+set -e
+test "$VERIFY_EXIT" = "0" || fail "--generator=tuist: bin/verify-rename.sh exited $VERIFY_EXIT (expected 0); output:
+$VERIFY_OUT"
+test -z "$VERIFY_OUT" || fail "--generator=tuist: bin/verify-rename.sh produced output (expected silent); got:
+$VERIFY_OUT"
+ok "--generator=tuist: bin/verify-rename.sh exit 0 silent (5 surfaces clean + manifest sanity)"
+
+# make check on the renamed Tuist fork (iOS device build via the rewritten
+# ci/local-check.sh which now invokes 'tuist generate --no-open' first).
+step "--generator=tuist: make check (iOS device build)"
+bash -euo pipefail <<'BASH'
+set +e
+make check 2>&1 | tee .test-rename-tuist-make-check.log
+EXIT=${PIPESTATUS[0]}
+set -e
+test "$EXIT" -eq 0 || { echo "ERROR: --generator=tuist make check failed with exit $EXIT"; exit 1; }
+BASH
+ok "--generator=tuist: make check exit 0 (Tuist-driven build green)"
+
+step "--generator=tuist end-to-end: PASSED"
+
 # ── Done ──────────────────────────────────────────────────────────────────
 
 step "ci/test-rename.sh: all assertions passed"


### PR DESCRIPTION
Fourth PR in the multi-PR series for first-class Tuist support — **Closes #38.**

## What

This is the capability the issue was filed for: fork-time generator choice.

```bash
# Default (existing behavior, byte-identical):
bin/rename.sh YourApp com.your-org.yourapp 'Your App' --email=you@example.com

# Same invocation + new flag — fork ends up Tuist-driven:
bin/rename.sh YourApp com.your-org.yourapp 'Your App' --email=you@example.com --generator=tuist
```

`--generator=tuist` invokes `bin/switch-to-tuist.sh --force` after the rename's substitutions complete: deletes `app/project.yml`, edits Brewfile / Makefile / ci scripts / `.github/workflows/pr.yml`. The rollback trap remains armed for the entire mutation phase — any failure → `reset --hard HEAD` restores pre-rename tree (including `app/project.yml`).

## Files

- `bin/rename.sh` — `--generator=GEN` flag (equal-form + split-form), Gate 5d validation, `gate_tuist_present_if_needed`, Project.swift CFBundleDisplayName placeholder anchoring, post-rename switch-to-tuist invocation, dry-run plan extension, header docs
- `bin/verify-rename.sh` — 6th surface check `PROJECT MANIFEST` fails when neither manifest is present (broken project)
- `bin/switch-to-tuist.sh` — `git rm` → `git rm -f` for `project.yml` so it tolerates the mid-rename uncommitted-modifications case
- `ci/test-rename.sh` — full `--generator=tuist` end-to-end (rename → 5 mutation surfaces verified → verify-rename exit 0 silent → CFBundleDisplayName placeholder honored → `make check` green using Tuist)
- `ci/test-rename-gates.sh` — Gate 5d coverage (invalid generator rejection; tuist dry-run announces switch + runs tuist gate; xcodegen default does NOT run tuist gate)
- `CHANGELOG.md` — Unreleased / Changed bullet (Closes #38)

## Subtleties (worth surfacing)

1. **Default `--generator=xcodegen` is byte-for-byte unchanged**: same code path as today (no extra cleanup, no Tuist artifact deletion). Matches the plan's "existing fork-then-rename muscle memory keeps working byte-for-byte" promise. Forker who wants Tuist-only later runs `bin/switch-to-tuist.sh` standalone.
2. **6th surface check is a sanity check, not a uniqueness check**: the plan mentioned "both present → fail" but that contradicts byte-for-byte default behavior (default leaves both manifests since #39 landed both on main). Implemented the meaningful subset: detect "neither present" (project broken). Comment in `bin/verify-rename.sh` explains.
3. **Project.swift CFBundleDisplayName needed placeholder anchoring**: pre-existing `bin/rename.sh` Step F broad sweep would have set CFBundleDisplayName to APP_NAME instead of DISPLAY_NAME. Added the same anchored-placeholder treatment as `app/project.yml` already has. Tested by the new e2e: `grep -qF "\"CFBundleDisplayName\": \"$TEST_DISPLAY\"" app/Project.swift`.
4. **`git rm -f`**: when `bin/rename.sh ... --generator=tuist` invokes `bin/switch-to-tuist.sh --force` mid-mutation, `app/project.yml` has uncommitted sed modifications. `git rm` without `-f` would refuse. `-f` is the agreed contract.

## Test plan

1. **`ci/test-rename-gates.sh`** — green locally. New Gate 5d cases: invalid rejection, tuist dry-run, xcodegen-default-skips-tuist-gate.
2. **`ci/test-rename.sh`** — green locally. Existing `--generator=xcodegen`-default-equivalent path still passes; new `--generator=tuist` end-to-end passes (rename → switch-to-tuist → verify-rename exit 0 silent → make check green).
3. **`make check`** green on this PR's branch (XcodeGen path on the contributor's tree, unchanged).
4. **6 CI checks must all be green on this PR.**
5. **End-to-end manual smoke** (run by execution session in a throwaway clone — full both-direction validation gets done as part of the project verification step after PR 5 merges).

## Sequencing

Depends on #40 (`bin/switch-to-tuist.sh` is invoked by the new flag). Lands after #41 (CI matrix) so the new flag is testable end-to-end including via the Tuist parity jobs.

## References

- Closes #38 (the umbrella issue)
- Predecessors: #39 (Tuist 4 manifests on main), #40 (`bin/switch-to-tuist.sh`), #41 (CI matrix + 6-check enforcement)
- [PRINCIPLES.md](../blob/main/docs/PRINCIPLES.md) #6 (script why-headers updated), #9 (CHANGELOG in same PR), #10 (semver — additive forker-facing change → MINOR; defaults preserved), #20 (test plan)
- [SCOPE.md](../blob/main/SCOPE.md) (in scope: developer-experience helper / project-config layer)
