### PR TITLE
fix(.env.local.example): rename ASC_API_KEY_BASE64 to ASC_API_KEY_P8_BASE64

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -18,11 +18,11 @@ FASTLANE_APPLE_ID=
 # After creating, download the .p8 file. Then:
 #   ASC_API_KEY_ID:        the 10-char Key ID shown in the table
 #   ASC_API_KEY_ISSUER_ID: the Issuer ID shown above the table (UUID format)
-#   ASC_API_KEY_BASE64:    base64 -i AuthKey_XXXXXXXXXX.p8 | tr -d '\n'
+#   ASC_API_KEY_P8_BASE64: base64 -i AuthKey_XXXXXXXXXX.p8 | tr -d '\n'
 
 ASC_API_KEY_ID=
 ASC_API_KEY_ISSUER_ID=
-ASC_API_KEY_BASE64=
+ASC_API_KEY_P8_BASE64=
 
 # ─── Optional ─────────────────────────────────────────────────────────────────
 # Override the bundle ID used by ci/bump-asc-version.rb. Default: com.example.helloapp


### PR DESCRIPTION
PR #44 swept this rename across the entire codebase but missed `.env.local.example`. Forker copying it to `.env.local` would set the wrong env var name, and local fastlane runs would silently fail to authenticate to ASC.

Caught by the smoketest E2E refork test.