### PR TITLE
feat(fastlane): add bootstrap_certs lane to wrap 3 raw match calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,14 +195,17 @@ One-time bootstrap:
    ```bash
    set -a; source ~/.config/secrets.env; set +a
    bundle exec fastlane register_app_id
-   bundle exec fastlane match appstore --app_identifier <bundle-id>
-   bundle exec fastlane match appstore --app_identifier <bundle-id> --platform macos
-   bundle exec fastlane match development --app_identifier <bundle-id>
+   bundle exec fastlane bootstrap_certs              # iOS dist + macOS dist + iOS dev (3 match calls in one process)
    # macOS .pkg installer cert (separate cert type, see G1 in docs/CONTINUOUS-VALIDATION.md):
    bundle exec ruby bin/mint-installer-cert.rb
    export INSTALLER_CERT_ID=<id-printed-by-mint-script>
    bundle exec ruby bin/import-installer-to-match.rb
    ```
+
+   `bootstrap_certs` wraps the 3 raw match calls in a single fastlane lane so
+   `before_all` runs once and the ASC API key is loaded for every call.
+   Running raw `fastlane match` from the CLI skips `before_all` and dies with
+   "Missing username, and running in non-interactive shell".
 7. **Create the ASC App record once** via [appstoreconnect.apple.com/apps](https://appstoreconnect.apple.com/apps)
    (Apple's public API does not allow `POST /apps`; one-time human step
    unblocks all future automated runs). Then run

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -255,6 +255,38 @@ lane :bootstrap_asc do
   end
 end
 
+desc "Run match readonly:false against all 3 cert types (one-time bootstrap)."
+desc ""
+desc "Wraps the 3 raw `fastlane match` invocations from the README's signing"
+desc "setup so before_all runs once and the ASC API key is loaded for every"
+desc "call. Without this lane, raw `fastlane match appstore --app_identifier"
+desc "...` from the CLI hits 'Missing username, and running in non-interactive"
+desc "shell' because it skips before_all. After running this lane once, the"
+desc "release pipeline (which only does match readonly:true) finds everything"
+desc "in the certs repo and never has to mint."
+desc ""
+desc "Run after editing fastlane/Matchfile (git_url) and setting the 7 GH"
+desc "Secrets / .env.local. The Mac Installer Distribution cert is bootstrapped"
+desc "separately via bin/mint-installer-cert.rb + bin/import-installer-to-match.rb"
+desc "(see Matchfile header for why)."
+lane :bootstrap_certs do
+  unless File.exist?(File.join(__dir__, "Matchfile"))
+    UI.user_error!("fastlane/Matchfile not found. Edit + commit it first (replace CHANGE-ME-ORG/CHANGE-ME-REPO-certs.git).")
+  end
+
+  match(type: "appstore",    app_identifier: APP_IDENTIFIER, platform: "ios")
+  match(type: "appstore",    app_identifier: APP_IDENTIFIER, platform: "macos")
+  match(type: "development", app_identifier: APP_IDENTIFIER, platform: "ios")
+
+  UI.success(<<~MSG)
+    bootstrap_certs done. Now run:
+      bundle exec ruby bin/mint-installer-cert.rb
+      export INSTALLER_CERT_ID=<id-printed-by-mint-script>
+      bundle exec ruby bin/import-installer-to-match.rb
+    See README "Optional: enable CI signing via fastlane match" for the full sequence.
+  MSG
+end
+
 # ─── iOS lanes ────────────────────────────────────────────────────────────────
 platform :ios do
   desc "Sign + upload to TestFlight + push tag"


### PR DESCRIPTION
Discovered by E2E refork test. Raw `fastlane match` invocations from the CLI skip `before_all`, so the ASC API key never loads — first command fails immediately with 'Missing username'.

`bootstrap_certs` wraps all 3 match calls in a single lane invocation. `before_all` runs once, auth is shared, and the README's documented bootstrap flow actually works.