### PR TITLE
feat: config-driven bootstrap (.bootstrap.env + make doctor + make bootstrap-fork)

### DIFF
--- a/.bootstrap.env.example
+++ b/.bootstrap.env.example
@@ -1,0 +1,85 @@
+# ─── Fork bootstrap configuration ─────────────────────────────────────────────
+#
+# Copy this file to `.bootstrap.env` (gitignored), fill in values, then run:
+#   make doctor      # validate config + probe Apple/GH; print what's done vs missing
+#   make bootstrap   # idempotent: drive every programmatic step from this config
+#   make ship        # trigger release.yml + tail until green
+#   make verify      # confirm TestFlight build appeared in App Store Connect
+#
+# Sensitive values are referenced by file path (so the dotenv itself stays low-
+# blast-radius). The actual secret bytes live in mode-0600 files outside the
+# repo, typically under ~/.config/secrets/.
+#
+# Each `make doctor` run validates this config end-to-end. If it complains, fix
+# the offending field and re-run — the doctor is idempotent and side-effect-free.
+
+# ─── App identity ─────────────────────────────────────────────────────────────
+# These end up in: scheme name, product name, CFBundleIdentifier, display
+# name, project file name, IPA/PKG names, fastlane appfile, README, etc.
+
+APP_NAME=YourApp                         # CamelCase. Becomes scheme + product.
+BUNDLE_ID=com.your-org.yourapp           # iOS + macOS share the same bundle id.
+DISPLAY_NAME='Your App'                  # CFBundleDisplayName (visible on home screen).
+APP_EMAIL=you@example.com                # Maintainer email used in CHANGELOG, fastlane Appfile, etc.
+GENERATOR=xcodegen                       # 'xcodegen' (default) or 'tuist'. Both manifests
+                                         #   ship on `main`; this picks the one your fork uses.
+
+# ─── Apple credentials ────────────────────────────────────────────────────────
+# Get these from your Apple Developer account. The team id is at
+# https://developer.apple.com/account/#/membership. The ASC API key is
+# created at https://appstoreconnect.apple.com/access/api (App Manager role).
+
+FASTLANE_TEAM_ID=                        # 10-char alphanumeric, e.g. A26TJZ8QHQ
+ASC_API_KEY_ID=                          # 10-char alphanumeric from the API Keys table
+ASC_API_KEY_ISSUER_ID=                   # UUID format, shown above the table
+
+# Path to the .p8 file you downloaded when you created the API key. Apple shows
+# it once; if you lost it, generate a new key and revoke the old one.
+ASC_API_KEY_P8_PATH=                     # e.g. ~/Downloads/AuthKey_AAAAAA1234.p8
+
+# ─── GitHub identity ──────────────────────────────────────────────────────────
+# The org/user that owns both repos. Both must already exist (the app repo from
+# `gh repo create --template`; the certs repo is created by `make bootstrap` if
+# absent).
+
+GH_ORG=                                  # e.g. your-org or your-username
+GH_APP_REPO=                             # e.g. your-app — created via gh repo create --template
+GH_CERTS_REPO=                           # e.g. your-app-certs — created by `make bootstrap` if absent
+
+# Path to a file containing the fine-grained PAT scoped to GH_CERTS_REPO with
+# Contents: read+write. Generate at https://github.com/settings/tokens?type=beta.
+# Token name suggestion: <APP_NAME>-certs-pat. Save the value to a 0600 file.
+GH_PAT_FILE=                             # e.g. ~/.config/secrets/your-app-pat
+
+# ─── Match credentials ────────────────────────────────────────────────────────
+# These two passwords protect the encrypted certs repo + the CI keychain. If
+# the file paths below don't exist when `make bootstrap` runs, random 32-char
+# values will be generated and written for you. If they already exist, the
+# existing values are reused (so re-running bootstrap doesn't rotate them).
+
+MATCH_PASSWORD_FILE=                     # e.g. ~/.config/secrets/match-password
+KEYCHAIN_PASSWORD_FILE=                  # e.g. ~/.config/secrets/keychain-password
+
+# ─── Optional design assets ───────────────────────────────────────────────────
+# If ICON_1024_PATH is set and points to a 1024×1024 PNG, `make bootstrap` will
+# replace app/iOS/Assets.xcassets/AppIcon.appiconset/Icon-1024.png and
+# regenerate the macOS .icns from it. Leave blank to keep the template's hammer
+# stub icon (fine for TestFlight; not for App Store review).
+
+ICON_1024_PATH=
+
+# ─── App Store Connect App record ─────────────────────────────────────────────
+# The ASC App record cannot be created via API (Apple disallows POST /apps).
+# Create it manually at https://appstoreconnect.apple.com/apps before running
+# `make bootstrap` — `bootstrap_asc` lane verifies it exists and fails loud
+# with creation instructions otherwise.
+#
+# The SKU is anything unique (often the bundle id reversed, or a UUID). It
+# isn't used for anything programmatic; you'll just see it in ASC reports.
+#
+# These two fields don't get used by `make bootstrap` directly — they're
+# documentation hints for the human-gated step. Copy them into the ASC web
+# UI form when you create the App.
+
+ASC_APP_SKU=                             # e.g. yourapp-001
+ASC_APP_NAME=                            # the human-readable App Store name; can equal DISPLAY_NAME

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ ehthumbs.db
 
 # Generated artifacts (regenerable from CHANGELOG.md)
 release-notes.md
+.bootstrap.env

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ help:
 	@echo "  screenshots      Capture App Store screenshots (iOS + macOS) to fastlane/screenshots/"
 	@echo "  release-dryrun   fastlane release tag:v0.0.0 skip_upload:true skip_tag:true"
 	@echo "  setup-github     Apply branch protection settings to current repo"
+	@echo "  doctor           Read .bootstrap.env, validate Apple+GH credentials, print pipeline status"
+	@echo "  bootstrap-fork   Idempotent: drive every programmatic fork-bootstrap step from .bootstrap.env"
+	@echo "  ship             Trigger release.yml workflow_dispatch + tail until the run completes"
+	@echo "  verify           Confirm the latest tagged build appeared in App Store Connect"
 	@echo "  phase-checklist  Print the GSD canonical per-phase checklist (usage: make phase-checklist N=3.1)"
 	@echo "  milestone-checklist  Print the GSD milestone wrap-up checklist (usage: make milestone-checklist M=1)"
 
@@ -58,6 +62,18 @@ release-dryrun:
 
 setup-github:
 	bin/setup-github.sh
+
+doctor:
+	@bundle exec ruby bin/doctor.rb
+
+bootstrap-fork:
+	@bundle exec ruby bin/bootstrap-fork.rb
+
+ship:
+	@bundle exec ruby bin/ship.rb
+
+verify:
+	@bundle exec ruby bin/verify-testflight.rb
 
 phase-checklist:
 	@if [ -z "$(N)" ]; then echo "usage: make phase-checklist N=<phase>  (e.g. N=3.1)"; exit 2; fi

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ The template ships with a working `HelloApp` stub that builds green on both iOS 
 
 ![HelloApp template running natively on macOS — same hammer icon, title, and rename instruction](docs/screenshots/macos-home.png)
 
-## Quickstart in 5 minutes
+## Quickstart — fork to TestFlight in ~15 minutes
 
-**Prereqs:** macOS with Xcode (the full app, not just Command Line Tools), Homebrew, and `gh` authenticated.
+**Prereqs:** macOS with Xcode (the full app, not just Command Line Tools), Homebrew, `gh` authenticated, and an Apple Developer Program membership.
 
-**Don't have all of those?** Run `bin/preflight.sh` first — it checks every prereq and walks you through installing the missing ones (Homebrew, gh CLI, gh auth, bundler). One-time setup, then you're ready:
+**Missing some?** Run `bin/preflight.sh` first — it checks every prereq and walks you through installing the missing ones:
 
 ```bash
 git clone https://github.com/indiagrams/ios-macos-template.git /tmp/preflight \
@@ -69,34 +69,50 @@ git clone https://github.com/indiagrams/ios-macos-template.git /tmp/preflight \
   && rm -rf /tmp/preflight
 ```
 
-**Apple Developer account?** See [`docs/APPLE-PREREQS.md`](docs/APPLE-PREREQS.md) — a free Apple ID is enough to build and run on Simulator; the paid Developer Program ($99/yr) is required for TestFlight + App Store. The doc covers Team ID, App Store Connect API keys, and code-signing artifacts to keep out of git.
+Apple side: see [`docs/APPLE-PREREQS.md`](docs/APPLE-PREREQS.md) for Team ID, App Store Connect API key, and the one-time human ASC App record creation.
 
-**5 minutes from `gh repo create` to a green build:**
-
-```bash
-gh repo create my-app --template indiagrams/ios-macos-template --public --clone && cd my-app   # ~30s — fork from template + clone
-bin/rename.sh YourApp com.your-org.yourapp 'Your App' --email=you@example.com   # ~30s — substitute identity surfaces (app name, bundle ID, display, maintainer email; repo slug auto-derived from git remote)
-                                                                                # add --generator=tuist (default: xcodegen) for a Tuist-driven fork; both manifests ship on main, the flag picks one.
-make bootstrap   # ~3min — brew bundle + lefthook + xcodegen (or tuist) + bundle install (warm Homebrew cache)
-make check   # ~1.5min — iOS device build (primary signal)
-```
-
-Want branch protection + push to a fresh remote? See [Renaming the stub](#renaming-the-stub) for the full 5-command flow.
-
-## Renaming the stub
-
-Run these five commands from the cloned repo:
+### The flow
 
 ```bash
-bin/rename.sh YourApp com.your-org.yourapp 'Your App' --email=you@example.com    # substitute identity surfaces (app name, bundle ID, display, maintainer email, repo slug)
-                                                                                 # append --generator=tuist (default: xcodegen) to drive the fork from app/Project.swift instead of app/project.yml.
-bin/verify-rename.sh                                                              # assert no leftover originals (run BEFORE commit so a bad rename never lands in git history)
-git add -A && git commit -m "Rename app stub"                                    # record the rename (rename.sh mutates the tree but does not commit)
-git push -u origin main                                                          # publish your renamed fork BEFORE branch protection is enabled
-bin/setup-github.sh                                                              # branch protection + auto-merge + squash-only (runs LAST so it doesn't gate the initial publish)
+# 1. Fork from template
+gh repo create my-app --template indiagrams/ios-macos-template --public --clone && cd my-app
+
+# 2. Fill in .bootstrap.env — see docs/BOOTSTRAP.md for what each field is
+cp .bootstrap.env.example .bootstrap.env
+$EDITOR .bootstrap.env
+
+# 3. Validate config + probe Apple/GH
+make doctor
+
+# 4. Run every programmatic step idempotently (rename, push, branch protection,
+#    7 GH Secrets, certs repo, match for 4 cert types, optional icon swap)
+make bootstrap-fork
+
+# 5. Trigger release.yml + tail until done (~5 min)
+make ship
+
+# 6. Confirm TestFlight ingestion
+make verify
 ```
 
-That's it — your fork is renamed, verified, committed, pushed, and locked down with branch protection.
+`make doctor` is read-only — run it as often as you like. `make bootstrap-fork` is idempotent — re-run safely after partial failures. The only step that can require human action is creating the ASC App record (Apple disallows `POST /apps`); `make doctor` will tell you the exact form to fill in if it's missing.
+
+Full walkthrough + config field reference: [`docs/BOOTSTRAP.md`](docs/BOOTSTRAP.md).
+
+### Manual flow (if you don't want to use `make bootstrap-fork`)
+
+The bootstrap is glue + idempotency over scripts that already exist; you can drive them yourself:
+
+```bash
+bin/rename.sh YourApp com.your-org.yourapp 'Your App' --email=you@example.com
+bin/verify-rename.sh
+make bootstrap   # toolchain only: brew + lefthook + xcodegen + bundler
+git add -A && git commit -m "Rename app stub"
+git push -u origin main
+bin/setup-github.sh
+```
+
+Then "Setting up signing + ASC" below for the certs + secrets dance.
 
 Prefer Tuist over XcodeGen? Re-run with `--generator=tuist` (e.g. `bin/rename.sh YourApp com.your-org.yourapp 'Your App' --email=you@example.com --generator=tuist`) and the flag invokes `bin/switch-to-tuist.sh` for you — `app/project.yml` is removed and Brewfile / Makefile / ci scripts / `.github/workflows/pr.yml` are flipped to drive `app/Project.swift` via `tuist generate`. Already renamed and want to switch later? Run `bin/switch-to-tuist.sh` standalone — see [`docs/MIGRATING-TO-TUIST.md`](docs/MIGRATING-TO-TUIST.md) for the in-place switch guide.
 

--- a/bin/bootstrap-fork.rb
+++ b/bin/bootstrap-fork.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Idempotent driver for forking the template. Reads `.bootstrap.env`, runs
+# every programmatic step (rename, push, branch protection, GH secrets,
+# certs repo, match, installer cert, optional icon swap). Halts on first
+# blocker (typically: ASC App record not yet created — Apple disallows POST).
+#
+# Each step is no-op if its desired state is already reached, so re-running
+# after a partial failure picks up where you left off.
+#
+# Usage: bundle exec ruby bin/bootstrap-fork.rb
+
+require_relative "lib/bootstrap"
+
+config = Bootstrap::Config.load!
+Bootstrap::Runner.new(config).bootstrap

--- a/bin/doctor.rb
+++ b/bin/doctor.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Read-only validator for `.bootstrap.env`. Probes Apple + GitHub + local repo
+# state, prints a checklist showing which steps are done vs pending vs blocked.
+# Exit codes:
+#   0  all steps done OR pending steps with no blockers (run `make bootstrap`)
+#   1  argument / I/O failure
+#   2  one or more blockers (need user action; see output)
+#
+# Side-effect free.
+#
+# Usage: bundle exec ruby bin/doctor.rb
+
+require_relative "lib/bootstrap"
+
+config = Bootstrap::Config.load!
+Bootstrap::Runner.new(config).doctor

--- a/bin/lib/bootstrap.rb
+++ b/bin/lib/bootstrap.rb
@@ -1,0 +1,727 @@
+# frozen_string_literal: true
+
+# Shared library for `bin/doctor.rb` (read-only) and `bin/bootstrap-fork.rb`
+# (idempotent driver). Reads `.bootstrap.env`, validates config, exposes a
+# pipeline of 14 steps. Each step has a `check` (returns bool, no side effects)
+# and a `do_it` (idempotent: safe to re-run on partial state).
+#
+# Doctor mode just calls every `check` and reports.
+# Bootstrap mode calls `check || do_it` per step and stops on first failure.
+#
+# Steps that can't be automated (Apple disallows POST /apps + API key creation,
+# GitHub disallows programmatic PAT creation) fail loud in `do_it` with
+# explicit web-UI instructions.
+
+require "base64"
+require "digest"
+require "fileutils"
+require "json"
+require "open3"
+require "pathname"
+require "securerandom"
+require "shellwords"
+require "tmpdir"
+
+module Bootstrap
+  REPO_ROOT = Pathname.new(__dir__).join("..", "..").expand_path
+  ENV_FILE  = REPO_ROOT.join(".bootstrap.env")
+
+  # The 7 GH Secrets the release pipeline needs. Order: stable for doctor.
+  REQUIRED_SECRETS = %w[
+    MATCH_PASSWORD
+    MATCH_GIT_BASIC_AUTHORIZATION
+    KEYCHAIN_PASSWORD
+    ASC_API_KEY_ID
+    ASC_API_KEY_ISSUER_ID
+    ASC_API_KEY_P8_BASE64
+    FASTLANE_TEAM_ID
+  ].freeze
+
+  # ─── Config loader ──────────────────────────────────────────────────────────
+
+  class Config
+    REQUIRED = %w[
+      APP_NAME BUNDLE_ID DISPLAY_NAME APP_EMAIL GENERATOR
+      FASTLANE_TEAM_ID ASC_API_KEY_ID ASC_API_KEY_ISSUER_ID ASC_API_KEY_P8_PATH
+      GH_ORG GH_APP_REPO GH_CERTS_REPO GH_PAT_FILE
+      MATCH_PASSWORD_FILE KEYCHAIN_PASSWORD_FILE
+    ].freeze
+
+    OPTIONAL = %w[ICON_1024_PATH ASC_APP_SKU ASC_APP_NAME].freeze
+
+    attr_reader :values
+
+    def self.load!
+      env_file = ENV_FILE
+      unless env_file.exist?
+        UI.fail!(<<~MSG)
+          .bootstrap.env not found at #{env_file}.
+
+          Copy the example and fill in your values:
+            cp .bootstrap.env.example .bootstrap.env
+            $EDITOR .bootstrap.env
+
+          See docs/BOOTSTRAP.md for what each field means and where to source it.
+        MSG
+      end
+      new(parse(env_file))
+    end
+
+    def self.parse(path)
+      values = {}
+      path.each_line.with_index do |line, idx|
+        line = line.strip
+        next if line.empty? || line.start_with?("#")
+        key, _, val = line.partition("=")
+        UI.fail!(".bootstrap.env line #{idx + 1}: missing '='") if val.nil? || key.strip.empty?
+        # Strip surrounding quotes if symmetric
+        val = val.strip
+        if (val.start_with?("'") && val.end_with?("'")) || (val.start_with?('"') && val.end_with?('"'))
+          val = val[1..-2]
+        end
+        values[key.strip] = val
+      end
+      values
+    end
+
+    def initialize(values)
+      @values = values
+    end
+
+    def [](key)
+      @values[key].to_s
+    end
+
+    def set?(key)
+      v = @values[key]
+      !v.nil? && !v.strip.empty?
+    end
+
+    def expand_path(key)
+      raw = self[key]
+      return nil if raw.empty?
+      Pathname.new(raw).expand_path
+    end
+
+    def validate!
+      missing = REQUIRED.reject { |k| set?(k) }
+      return if missing.empty?
+      UI.fail!(<<~MSG)
+        .bootstrap.env is missing required fields:
+        #{missing.map { |k| "  - #{k}" }.join("\n")}
+
+        Edit .bootstrap.env and re-run.
+      MSG
+    end
+
+    def repo_slug
+      "#{self["GH_ORG"]}/#{self["GH_APP_REPO"]}"
+    end
+
+    def certs_slug
+      "#{self["GH_ORG"]}/#{self["GH_CERTS_REPO"]}"
+    end
+
+    def certs_url
+      "https://github.com/#{certs_slug}.git"
+    end
+  end
+
+  # ─── UI helpers ─────────────────────────────────────────────────────────────
+
+  module UI
+    GREEN  = "\e[32m"
+    RED    = "\e[31m"
+    YELLOW = "\e[33m"
+    DIM    = "\e[2m"
+    BOLD   = "\e[1m"
+    RESET  = "\e[0m"
+
+    module_function
+
+    def tty?
+      $stdout.tty?
+    end
+
+    def colorize(text, color)
+      tty? ? "#{color}#{text}#{RESET}" : text
+    end
+
+    def ok(text); colorize("✓ #{text}", GREEN); end
+    def miss(text); colorize("✗ #{text}", RED); end
+    def warn(text); colorize("⚠ #{text}", YELLOW); end
+    def dim(text); colorize(text, DIM); end
+    def bold(text); colorize(text, BOLD); end
+
+    def fail!(msg)
+      $stderr.puts colorize("ERROR: #{msg}", RED)
+      exit 1
+    end
+
+    def section(text)
+      puts
+      puts bold(text)
+      puts colorize("─" * text.length, DIM)
+    end
+
+    def step_header(num, total, name)
+      puts colorize("[#{num}/#{total}] #{name}", BOLD)
+    end
+  end
+
+  # ─── Shell + tool helpers ───────────────────────────────────────────────────
+
+  module Sh
+    module_function
+
+    # Run a command; raise on non-zero exit.
+    def run!(*cmd, env: {}, cwd: REPO_ROOT)
+      Dir.chdir(cwd) do
+        out, err, status = Open3.capture3(env, *cmd)
+        unless status.success?
+          UI.fail!("command failed (exit #{status.exitstatus}):\n  #{cmd.join(' ')}\nstdout: #{out}\nstderr: #{err}")
+        end
+        out
+      end
+    end
+
+    # Run a command; capture output regardless of exit. Returns [stdout, success?]
+    def run(*cmd, env: {}, cwd: REPO_ROOT)
+      Dir.chdir(cwd) do
+        out, _err, status = Open3.capture3(env, *cmd)
+        [out, status.success?]
+      end
+    end
+
+    # Quiet boolean check.
+    def ok?(*cmd, env: {}, cwd: REPO_ROOT)
+      _out, success = run(*cmd, env: env, cwd: cwd)
+      success
+    end
+  end
+
+  # ─── Step base class ────────────────────────────────────────────────────────
+
+  class Step
+    attr_reader :config
+
+    def initialize(config)
+      @config = config
+    end
+
+    # Subclasses override.
+    def name; self.class.name.split("::").last; end
+    def category; "programmatic"; end
+    # check returns one of:
+    #   :done            — already in desired state, skip do_it
+    #   :pending         — not in desired state, run do_it
+    #   [:blocked, msg]  — human-gated, do_it will fail loud with msg
+    def check; raise NotImplementedError; end
+    def do_it; raise NotImplementedError; end
+  end
+
+  # ─── Concrete steps ─────────────────────────────────────────────────────────
+
+  class CheckAppleCreds < Step
+    def name; "Apple credentials"; end
+    def category; "preflight"; end
+
+    def check
+      p8 = config.expand_path("ASC_API_KEY_P8_PATH")
+      return [:blocked, "ASC_API_KEY_P8_PATH file does not exist: #{p8}"] unless p8 && p8.file?
+
+      # Probe ASC API by requesting current user
+      require "spaceship"
+      pem_path = write_p8(p8)
+      token = Spaceship::ConnectAPI::Token.create(
+        key_id:    config["ASC_API_KEY_ID"],
+        issuer_id: config["ASC_API_KEY_ISSUER_ID"],
+        filepath:  pem_path
+      )
+      Spaceship::ConnectAPI.token = token
+      apps = Spaceship::ConnectAPI::App.all(limit: 1)
+      :done
+    rescue StandardError => e
+      [:blocked, "ASC API probe failed: #{e.class.name}: #{e.message}"]
+    end
+
+    def do_it
+      # No automation possible — credentials must be valid.
+      UI.fail!("Apple credentials invalid. Fix .bootstrap.env then re-run.")
+    end
+
+    private
+
+    def write_p8(src)
+      # If src is .p8 PEM, return path. (Spaceship reads PEM from filepath.)
+      src.to_s
+    end
+  end
+
+  class CheckGHCreds < Step
+    def name; "GitHub credentials"; end
+    def category; "preflight"; end
+
+    def check
+      pat_file = config.expand_path("GH_PAT_FILE")
+      return [:blocked, "GH_PAT_FILE doesn't exist: #{pat_file}"] unless pat_file && pat_file.file?
+      pat = pat_file.read.strip
+      return [:blocked, "GH_PAT_FILE is empty"] if pat.empty?
+
+      # Probe certs repo via PAT
+      out, success = Sh.run("curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
+                            "-H", "Authorization: Bearer #{pat}",
+                            "-H", "Accept: application/vnd.github+json",
+                            "https://api.github.com/repos/#{config.certs_slug}")
+      case out
+      when "200" then :done
+      when "404"
+        # PAT might be valid but certs repo missing — that's a separate step.
+        # Probe whether PAT itself works on user endpoint.
+        out2, _ = Sh.run("curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
+                         "-H", "Authorization: Bearer #{pat}",
+                         "https://api.github.com/user")
+        return :done if out2 == "200"
+        [:blocked, "PAT itself appears invalid (HTTP #{out2} on /user)"]
+      when "401", "403"
+        [:blocked, "PAT lacks access to #{config.certs_slug} (HTTP #{out}). Check token scopes at github.com/settings/tokens"]
+      else
+        [:blocked, "Unexpected HTTP #{out} probing #{config.certs_slug}"]
+      end
+    end
+
+    def do_it
+      UI.fail!("GitHub credentials invalid. Fix #{config['GH_PAT_FILE']} or PAT scope, then re-run.")
+    end
+  end
+
+  class RenameStub < Step
+    def name; "Rename HelloApp → #{config['APP_NAME']}"; end
+
+    def check
+      # Done iff: shared swift file exists AND no leftover HelloApp / com.example.helloapp
+      # references in source tree (excluding vendor, .git, .planning, build).
+      shared = REPO_ROOT.join("app", "Shared", "#{config['APP_NAME']}.swift")
+      shared.file? ? :done : :pending
+    end
+
+    def do_it
+      args = [
+        "bin/rename.sh",
+        config["APP_NAME"], config["BUNDLE_ID"], config["DISPLAY_NAME"],
+        "--email=#{config['APP_EMAIL']}",
+        "--generator=#{config['GENERATOR']}"
+      ]
+      Sh.run!(*args)
+      Sh.run!("bin/verify-rename.sh")
+    end
+  end
+
+  class EditMatchfile < Step
+    def name; "Wire fastlane/Matchfile to certs repo"; end
+
+    def matchfile; REPO_ROOT.join("fastlane", "Matchfile"); end
+
+    def check
+      return :pending unless matchfile.file?
+      content = matchfile.read
+      return :pending if content.include?("CHANGE-ME-ORG/CHANGE-ME-REPO-certs.git")
+      content.include?(config.certs_slug) ? :done : :pending
+    end
+
+    def do_it
+      content = matchfile.read
+      content = content.gsub(
+        %r{git_url\("https://github\.com/[^/]+/[^/]+\.git"\)},
+        %{git_url("#{config.certs_url}")}
+      )
+      matchfile.write(content)
+    end
+  end
+
+  class BrewBootstrap < Step
+    def name; "Toolchain (brew + bundler + xcodegen/tuist + lefthook)"; end
+
+    def check
+      return :pending unless Sh.ok?("bundle", "check")
+      tool = config["GENERATOR"] == "tuist" ? "tuist" : "xcodegen"
+      Sh.ok?("which", tool) && Sh.ok?("which", "lefthook") ? :done : :pending
+    end
+
+    def do_it
+      Sh.run!("make", "bootstrap")
+    end
+  end
+
+  class InitialPush < Step
+    def name; "Initial commit + push"; end
+
+    def check
+      out, ok = Sh.run("git", "ls-remote", "--heads", "origin", "main")
+      return :pending unless ok && !out.strip.empty?
+      # main exists on origin. Has rename landed?
+      out2, _ = Sh.run("git", "diff", "--stat", "origin/main", "--", "app/Shared")
+      out2.strip.empty? ? :done : :pending
+    end
+
+    def do_it
+      _out, dirty = Sh.run("git", "diff", "--quiet")
+      Sh.run!("git", "add", "-A") unless dirty
+      Sh.run!("git", "-c", "user.email=#{config['APP_EMAIL']}", "-c", "user.name=#{config['APP_NAME']} bootstrap",
+              "commit", "-m", "Bootstrap fork: rename + wire Matchfile") unless dirty
+      Sh.run!("git", "push", "-u", "origin", "main")
+    end
+  end
+
+  class BranchProtection < Step
+    def name; "GitHub branch protection on main"; end
+
+    def check
+      Sh.ok?("gh", "api", "repos/#{config.repo_slug}/branches/main/protection") ? :done : :pending
+    end
+
+    def do_it
+      Sh.run!("bin/setup-github.sh")
+    end
+  end
+
+  class GHSecrets < Step
+    def name; "Set 7 GH Secrets on app repo"; end
+
+    def check
+      out, ok = Sh.run("gh", "secret", "list", "--repo", config.repo_slug)
+      return :pending unless ok
+      present = out.lines.map { |l| l.split(/\s+/).first }.compact
+      REQUIRED_SECRETS.all? { |s| present.include?(s) } ? :done : :pending
+    end
+
+    def do_it
+      # Generate or load match + keychain passwords.
+      match_pw    = ensure_random_password("MATCH_PASSWORD_FILE", 32)
+      keychain_pw = ensure_random_password("KEYCHAIN_PASSWORD_FILE", 32)
+      pat         = config.expand_path("GH_PAT_FILE").read.strip
+      gh_user     = github_user
+      basic       = Base64.strict_encode64("#{gh_user}:#{pat}")
+
+      p8 = config.expand_path("ASC_API_KEY_P8_PATH").read
+      p8_base64 = Base64.strict_encode64(p8)
+
+      values = {
+        "MATCH_PASSWORD"                => match_pw,
+        "MATCH_GIT_BASIC_AUTHORIZATION" => basic,
+        "KEYCHAIN_PASSWORD"             => keychain_pw,
+        "ASC_API_KEY_ID"                => config["ASC_API_KEY_ID"],
+        "ASC_API_KEY_ISSUER_ID"         => config["ASC_API_KEY_ISSUER_ID"],
+        "ASC_API_KEY_P8_BASE64"         => p8_base64,
+        "FASTLANE_TEAM_ID"              => config["FASTLANE_TEAM_ID"]
+      }
+
+      values.each do |key, val|
+        IO.popen(["gh", "secret", "set", key, "--repo", config.repo_slug], "w") { |io| io.write(val) }
+        UI.fail!("gh secret set #{key} failed") unless $?.success?
+      end
+    end
+
+    private
+
+    def github_user
+      out = Sh.run!("gh", "api", "/user", "-q", ".login").strip
+      out
+    end
+
+    def ensure_random_password(env_key, length)
+      path = config.expand_path(env_key)
+      UI.fail!("#{env_key} not set in .bootstrap.env") unless path
+      if path.file? && !path.read.strip.empty?
+        return path.read.strip
+      end
+      FileUtils.mkdir_p(path.dirname)
+      pw = SecureRandom.base64(length).gsub(/[^A-Za-z0-9]/, "")[0, length]
+      path.write(pw)
+      File.chmod(0o600, path.to_s)
+      pw
+    end
+  end
+
+  class CreateCertsRepo < Step
+    def name; "Private certs repo"; end
+
+    def check
+      Sh.ok?("gh", "repo", "view", config.certs_slug) ? :done : :pending
+    end
+
+    def do_it
+      Sh.run!("gh", "repo", "create", config.certs_slug, "--private",
+              "--description", "Encrypted certs + profiles for #{config.repo_slug} (managed via fastlane match)")
+    end
+  end
+
+  class RegisterAppId < Step
+    def name; "Register Bundle ID in Apple Developer Portal"; end
+
+    def check
+      require "spaceship"
+      Bootstrap.ensure_asc_token!(config)
+      Spaceship::ConnectAPI::BundleId.find(config["BUNDLE_ID"]) ? :done : :pending
+    rescue StandardError => e
+      [:blocked, "ASC probe failed: #{e.message}"]
+    end
+
+    def do_it
+      env = asc_env(config)
+      Sh.run!("bundle", "exec", "fastlane", "register_app_id", env: env)
+    end
+  end
+
+  class VerifyAscApp < Step
+    def name; "Verify ASC App record exists"; end
+    def category; "human-gated"; end
+
+    def check
+      require "spaceship"
+      Bootstrap.ensure_asc_token!(config)
+      Spaceship::ConnectAPI::App.find(config["BUNDLE_ID"]) ? :done : [:blocked, asc_creation_msg]
+    rescue StandardError => e
+      [:blocked, "ASC probe failed: #{e.message}"]
+    end
+
+    def do_it
+      UI.fail!(asc_creation_msg)
+    end
+
+    private
+
+    def asc_creation_msg
+      <<~MSG
+        ASC App record for #{config['BUNDLE_ID']} not found.
+
+        The App Store Connect API does not allow POST /apps. Create the App
+        record once via the web UI:
+
+          1. Open https://appstoreconnect.apple.com/apps  →  + (New App)
+          2. Platforms:        iOS + macOS
+             Name:             #{config['ASC_APP_NAME'].to_s.empty? ? config['DISPLAY_NAME'] : config['ASC_APP_NAME']}
+             Primary Language: English (U.S.)
+             Bundle ID:        #{config['BUNDLE_ID']}
+             SKU:              #{config['ASC_APP_SKU'].to_s.empty? ? '(any unique string)' : config['ASC_APP_SKU']}
+             User Access:      Full Access
+          3. Re-run `make bootstrap` — this step will pass.
+      MSG
+    end
+  end
+
+  class BootstrapCerts < Step
+    def name; "Mint iOS dist + dev + macOS dist certs (via match)"; end
+
+    def check
+      tree = certs_tree
+      return :pending if tree.empty?
+      has_dist  = tree.any? { |p| p.start_with?("certs/distribution/") && p.end_with?(".cer") }
+      has_dev   = tree.any? { |p| p.start_with?("certs/development/") && p.end_with?(".cer") }
+      has_ios   = tree.any? { |p| p.match?(%r{^profiles/appstore/.*\.mobileprovision$}) }
+      has_macos = tree.any? { |p| p.match?(%r{^profiles/appstore/.*\.provisionprofile$}) }
+      has_devp  = tree.any? { |p| p.match?(%r{^profiles/development/.*\.mobileprovision$}) }
+      (has_dist && has_dev && has_ios && has_macos && has_devp) ? :done : :pending
+    end
+
+    def do_it
+      env = asc_env(config).merge(match_env(config))
+      Sh.run!("bundle", "exec", "fastlane", "bootstrap_certs", env: env)
+    end
+
+    private
+
+    def certs_tree
+      out, ok = Sh.run("gh", "api", "repos/#{config.certs_slug}/git/trees/master?recursive=true",
+                       "--jq", ".tree[].path")
+      ok ? out.lines.map(&:strip) : []
+    end
+  end
+
+  class MintInstaller < Step
+    def name; "Mint Mac Installer Distribution cert"; end
+
+    def check
+      out, ok = Sh.run("gh", "api", "repos/#{config.certs_slug}/git/trees/master?recursive=true",
+                       "--jq", ".tree[].path")
+      return :pending unless ok
+      out.lines.any? { |p| p.start_with?("certs/mac_installer_distribution/") && p.end_with?(".cer\n") } ? :done : :pending
+    end
+
+    def do_it
+      env = asc_env(config).merge(match_env(config))
+      out = Sh.run!("bundle", "exec", "ruby", "bin/mint-installer-cert.rb", env: env)
+      cert_id = out.lines.grep(/^Cert id:/).first&.split(":", 2)&.last&.strip
+      UI.fail!("could not parse INSTALLER_CERT_ID from mint-installer-cert.rb output") if cert_id.to_s.empty?
+      env2 = env.merge("INSTALLER_CERT_ID" => cert_id)
+      Sh.run!("bundle", "exec", "ruby", "bin/import-installer-to-match.rb", env: env2)
+    end
+  end
+
+  class Icon1024 < Step
+    def name; "Replace 1024 icon"; end
+
+    def icon_target
+      REPO_ROOT.join("app", "iOS", "Assets.xcassets", "AppIcon.appiconset", "Icon-1024.png")
+    end
+
+    def check
+      return :done unless config.set?("ICON_1024_PATH") # optional
+      src = config.expand_path("ICON_1024_PATH")
+      return [:blocked, "ICON_1024_PATH does not exist: #{src}"] unless src.file?
+      return :pending unless icon_target.file?
+      Digest::SHA256.file(src).hexdigest == Digest::SHA256.file(icon_target).hexdigest ? :done : :pending
+    end
+
+    def do_it
+      src = config.expand_path("ICON_1024_PATH")
+      FileUtils.cp(src, icon_target)
+    end
+  end
+
+  class MakeIcons < Step
+    def name; "Regenerate macOS icon set + .icns"; end
+
+    def check
+      return :done unless config.set?("ICON_1024_PATH") # optional gate
+      icns = REPO_ROOT.join("app", "macOS", "Assets.xcassets", "AppIcon.appiconset", "icon_512x512@2x.png")
+      icons_target_mtime = icns.file? ? icns.mtime : Time.at(0)
+      icon_src = REPO_ROOT.join("app", "iOS", "Assets.xcassets", "AppIcon.appiconset", "Icon-1024.png")
+      icons_target_mtime >= icon_src.mtime ? :done : :pending
+    end
+
+    def do_it
+      Sh.run!("make", "icons")
+    end
+  end
+
+  # ─── Pipeline ───────────────────────────────────────────────────────────────
+
+  class Runner
+    PIPELINE = [
+      CheckAppleCreds,
+      CheckGHCreds,
+      RenameStub,
+      EditMatchfile,
+      BrewBootstrap,
+      InitialPush,
+      BranchProtection,
+      CreateCertsRepo,
+      GHSecrets,
+      RegisterAppId,
+      VerifyAscApp,
+      BootstrapCerts,
+      MintInstaller,
+      Icon1024,
+      MakeIcons
+    ].freeze
+
+    def initialize(config)
+      @config = config
+      @steps = PIPELINE.map { |klass| klass.new(config) }
+    end
+
+    def doctor
+      @config.validate!
+      UI.section "Configuration"
+      puts "  app:    #{@config['APP_NAME']} (#{@config['BUNDLE_ID']})"
+      puts "  apple:  team #{@config['FASTLANE_TEAM_ID']}, ASC key #{@config['ASC_API_KEY_ID']}"
+      puts "  gh:     app=#{@config.repo_slug} certs=#{@config.certs_slug}"
+
+      UI.section "Pipeline status"
+      results = []
+      @steps.each_with_index do |step, idx|
+        result = step.check
+        case result
+        when :done
+          puts "  #{(idx + 1).to_s.rjust(2)}. #{UI.ok step.name}"
+          results << :done
+        when :pending
+          puts "  #{(idx + 1).to_s.rjust(2)}. #{UI.miss step.name}#{UI.dim ' — will run on bootstrap'}"
+          results << :pending
+        when Array
+          puts "  #{(idx + 1).to_s.rjust(2)}. #{UI.warn step.name}"
+          puts result[1].lines.map { |l| "      #{l}" }.join
+          results << :blocked
+        end
+      end
+
+      UI.section "Summary"
+      done    = results.count(:done)
+      pending = results.count(:pending)
+      blocked = results.count(:blocked)
+      puts "  #{UI.ok "#{done} done"}    #{UI.miss "#{pending} pending"}    #{UI.warn "#{blocked} blocked"}"
+
+      if blocked > 0
+        puts
+        puts UI.bold "Action required: resolve the ⚠ items above, then re-run `make doctor`."
+        exit 2
+      elsif pending > 0
+        puts
+        puts UI.bold "Run `make bootstrap` to close the ✗ items."
+        exit 0
+      else
+        puts
+        puts UI.bold "All steps complete. Run `make ship` to trigger a release."
+        exit 0
+      end
+    end
+
+    def bootstrap
+      @config.validate!
+      total = @steps.length
+      @steps.each_with_index do |step, idx|
+        UI.step_header(idx + 1, total, step.name)
+        result = step.check
+        case result
+        when :done
+          puts "  #{UI.ok 'already done'}"
+        when :pending
+          step.do_it
+          puts "  #{UI.ok 'done'}"
+        when Array
+          UI.fail!(result[1])
+        end
+      end
+      puts
+      puts UI.bold "✅ Bootstrap complete."
+      puts "Next: #{UI.bold 'make ship'} to trigger the release pipeline."
+    end
+  end
+
+  # ─── Module-level helpers used by multiple steps ────────────────────────────
+
+  module_function
+
+  def Bootstrap.ensure_asc_token!(config)
+    return if Spaceship::ConnectAPI.token
+    p8_path = config.expand_path("ASC_API_KEY_P8_PATH")
+    Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.create(
+      key_id:    config["ASC_API_KEY_ID"],
+      issuer_id: config["ASC_API_KEY_ISSUER_ID"],
+      filepath:  p8_path.to_s
+    )
+  end
+
+  def asc_env(config)
+    {
+      "ASC_API_KEY_ID"          => config["ASC_API_KEY_ID"],
+      "ASC_API_KEY_ISSUER_ID"   => config["ASC_API_KEY_ISSUER_ID"],
+      "ASC_API_KEY_P8_BASE64"   => Base64.strict_encode64(config.expand_path("ASC_API_KEY_P8_PATH").read),
+      "FASTLANE_TEAM_ID"        => config["FASTLANE_TEAM_ID"],
+      "FASTLANE_HIDE_CHANGELOG" => "1",
+      "FASTLANE_SKIP_UPDATE_CHECK" => "1"
+    }
+  end
+
+  def match_env(config)
+    pat   = config.expand_path("GH_PAT_FILE").read.strip
+    user  = `gh api /user -q .login`.strip
+    {
+      "MATCH_PASSWORD"                => config.expand_path("MATCH_PASSWORD_FILE").read.strip,
+      "MATCH_GIT_BASIC_AUTHORIZATION" => Base64.strict_encode64("#{user}:#{pat}"),
+      "KEYCHAIN_PASSWORD"             => config.expand_path("KEYCHAIN_PASSWORD_FILE").read.strip,
+      "CERT_KEYCHAIN_PATH"            => Pathname.new(Dir.home).join("Library", "Keychains", "match-tmp.keychain-db").to_s
+    }
+  end
+end

--- a/bin/ship.rb
+++ b/bin/ship.rb
@@ -1,0 +1,67 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Trigger release.yml via workflow_dispatch on the configured app repo, then
+# poll until the run completes. Prints the run URL up front so you can also
+# watch in browser.
+#
+# Usage: bundle exec ruby bin/ship.rb [--dry-run]
+#   --dry-run    pass dry_run=true (build + sign + export, skip TestFlight upload)
+#
+# Exit codes:
+#   0 release succeeded (TestFlight upload + tag pushed)
+#   1 invocation / I/O error
+#   2 the workflow run completed with conclusion != success
+
+require_relative "lib/bootstrap"
+
+config = Bootstrap::Config.load!
+config.validate!
+
+dry_run = ARGV.include?("--dry-run") ? "true" : "false"
+repo = config.repo_slug
+
+puts Bootstrap::UI.bold("Triggering release.yml on #{repo} (dry_run=#{dry_run})…")
+out, ok = Bootstrap::Sh.run("gh", "workflow", "run", "release.yml", "--ref", "main",
+                            "-f", "dry_run=#{dry_run}", "--repo", repo)
+unless ok
+  Bootstrap::UI.fail!("gh workflow run failed:\n#{out}")
+end
+
+# gh doesn't print the run id immediately; poll the runs list briefly.
+sleep 5
+run_id = nil
+20.times do
+  out, _ = Bootstrap::Sh.run("gh", "run", "list", "--workflow", "release.yml",
+                             "--repo", repo, "--limit", "1",
+                             "--json", "databaseId,status,createdAt", "--jq", ".[0].databaseId")
+  run_id = out.strip
+  break unless run_id.empty?
+  sleep 2
+end
+Bootstrap::UI.fail!("could not find newly-triggered run id") if run_id.to_s.empty?
+
+run_url = "https://github.com/#{repo}/actions/runs/#{run_id}"
+puts "  → #{run_url}"
+puts
+
+# Poll until completed
+loop do
+  out, _ = Bootstrap::Sh.run("gh", "run", "view", run_id, "--repo", repo,
+                             "--json", "status,conclusion", "--jq", '"\(.status) \(.conclusion // "-")"')
+  status, conclusion = out.strip.split(" ", 2)
+  ts = Time.now.strftime("%H:%M:%S")
+  puts "[#{ts}] #{status} #{conclusion}"
+  if status == "completed"
+    if conclusion == "success"
+      puts
+      puts Bootstrap::UI.bold("✅ Release succeeded.")
+      puts "Tag pushed; both binaries uploaded to App Store Connect."
+      puts "Run `make verify` to confirm TestFlight ingestion (~5-15 min ASC processing time)."
+      exit 0
+    else
+      Bootstrap::UI.fail!("Release run #{run_id} concluded with: #{conclusion}\nSee #{run_url}")
+    end
+  end
+  sleep 30
+end

--- a/bin/verify-testflight.rb
+++ b/bin/verify-testflight.rb
@@ -1,0 +1,55 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Confirm the latest tagged release built+uploaded by `make ship` actually
+# made it into App Store Connect. Probes ASC for the most recent build
+# attached to the configured Bundle ID; prints version + state. Exits 0 if
+# any build exists for this app, else 2.
+#
+# Usage: bundle exec ruby bin/verify-testflight.rb
+
+require_relative "lib/bootstrap"
+
+config = Bootstrap::Config.load!
+config.validate!
+
+require "spaceship"
+Bootstrap.ensure_asc_token!(config)
+
+app = Spaceship::ConnectAPI::App.find(config["BUNDLE_ID"])
+unless app
+  puts Bootstrap::UI.miss("ASC App record not found for #{config['BUNDLE_ID']}")
+  puts "  Did you create it? See `make doctor` output."
+  exit 2
+end
+
+builds = Spaceship::ConnectAPI::Build.all(app_id: app.id, sort: "-uploadedDate", limit: 5)
+if builds.empty?
+  puts Bootstrap::UI.miss("No TestFlight builds found for #{config['BUNDLE_ID']} (id=#{app.id})")
+  puts "  Try `make ship` first; ASC ingestion takes 5-15 min after upload."
+  exit 2
+end
+
+puts Bootstrap::UI.bold("Latest #{builds.length} builds for #{config['BUNDLE_ID']}:")
+builds.each do |b|
+  v = "#{b.version} (#{b.app_version})"
+  state = b.processing_state
+  uploaded = b.uploaded_date
+  puts "  #{Bootstrap::UI.ok v}  state=#{state}  uploaded=#{uploaded}"
+end
+
+newest = builds.first
+case newest.processing_state
+when "VALID"
+  puts
+  puts Bootstrap::UI.bold("✅ Latest build #{newest.version} is processed and ready for TestFlight testers.")
+  exit 0
+when "PROCESSING"
+  puts
+  puts Bootstrap::UI.warn("⏳ Latest build #{newest.version} is still processing. Re-run in 5-10 min.")
+  exit 0
+else
+  puts
+  puts Bootstrap::UI.miss("Latest build #{newest.version} state=#{newest.processing_state}; check ASC for details.")
+  exit 2
+end

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -1,0 +1,171 @@
+# Bootstrap your fork
+
+Time-to-TestFlight: ~15 minutes once your `.bootstrap.env` is filled in.
+
+This template ships a config-driven fork bootstrap. You fill out one file with
+your identity + credentials, then `make bootstrap-fork` drives every
+programmatic step (rename, push, branch protection, GH Secrets, certs repo,
+match, installer cert, icon swap, …) idempotently. The only manual steps are
+the ones Apple and GitHub deliberately don't expose to APIs.
+
+```bash
+# 1. Fork from template
+gh repo create my-app --template indiagrams/ios-macos-template --public --clone
+cd my-app
+
+# 2. Fill in .bootstrap.env (see "Config reference" below)
+cp .bootstrap.env.example .bootstrap.env
+$EDITOR .bootstrap.env
+
+# 3. Validate — see what's done, what's pending, what's blocked
+make doctor
+
+# 4. Run the bootstrap (idempotent — re-run safely)
+make bootstrap-fork
+
+# 5. Trigger the release pipeline
+make ship          # tails the workflow run until success
+
+# 6. Confirm TestFlight ingestion
+make verify
+```
+
+## Config reference
+
+`.bootstrap.env` is gitignored. Its values are mostly non-secret config
+(team IDs, repo slugs, etc.) plus *paths* to mode-0600 files containing the
+actual secret bytes. The dotenv itself is low-blast-radius.
+
+| Field | What it is | Where to get it |
+|---|---|---|
+| `APP_NAME` | CamelCase scheme + product name. Becomes the Xcode target. | You decide |
+| `BUNDLE_ID` | Reverse-DNS bundle id, used for both iOS + macOS apps | You decide |
+| `DISPLAY_NAME` | `CFBundleDisplayName`, visible on home screen | You decide |
+| `APP_EMAIL` | Maintainer email for Appfile, CHANGELOG, fastlane metadata | You decide |
+| `GENERATOR` | `xcodegen` (default) or `tuist` | Pick whichever project format you want to drive your fork |
+| `FASTLANE_TEAM_ID` | 10-char Apple Developer Team ID | <https://developer.apple.com/account/#/membership> |
+| `ASC_API_KEY_ID` | 10-char ASC API key ID | <https://appstoreconnect.apple.com/access/api> → Users and Access → Integrations → App Store Connect API |
+| `ASC_API_KEY_ISSUER_ID` | UUID format issuer ID | Same page, shown above the keys table |
+| `ASC_API_KEY_P8_PATH` | Path to the `.p8` file Apple gave you when you created the API key | Apple shows it once at creation time. If lost, generate a new key + revoke old |
+| `GH_ORG` | GitHub user/org that owns both repos | You decide |
+| `GH_APP_REPO` | App repo name (you already created this via `gh repo create --template`) | Already done if you ran the quickstart |
+| `GH_CERTS_REPO` | Private certs repo name (created by `make bootstrap-fork` if absent) | Convention: `<app-repo>-certs` |
+| `GH_PAT_FILE` | Path to a file containing a fine-grained PAT scoped to `GH_CERTS_REPO` (Contents: read+write) | <https://github.com/settings/tokens?type=beta>. See [PAT scope tradeoff](#pat-scope-tradeoff) below |
+| `MATCH_PASSWORD_FILE` | Path to a file containing the certs-repo encryption password. Auto-generated as 32 random chars if absent | Created on first `make bootstrap-fork` |
+| `KEYCHAIN_PASSWORD_FILE` | Path to a file containing the CI keychain password. Auto-generated if absent | Created on first `make bootstrap-fork` |
+| `ICON_1024_PATH` (optional) | Path to your 1024×1024 PNG. If set, replaces the template hammer icon and runs `make icons` | Designer artifact |
+| `ASC_APP_SKU` (optional) | Documentation hint for the manual ASC App creation step | Any unique string |
+| `ASC_APP_NAME` (optional) | Documentation hint — defaults to `DISPLAY_NAME` | The human-readable name you want shown in the App Store |
+
+## What `make bootstrap-fork` does
+
+15 steps, in order. Each step has a `check` (no side effects) and a `do_it`.
+A step is skipped if its desired state is already reached, so re-running after
+a partial failure picks up where you left off.
+
+| # | Step | What changes |
+|---|---|---|
+| 1 | Apple credentials | Validates `.p8` + key id + issuer id by probing ASC API |
+| 2 | GitHub credentials | Validates PAT can see `GH_CERTS_REPO` |
+| 3 | Rename HelloApp → APP_NAME | Runs `bin/rename.sh` + `bin/verify-rename.sh` |
+| 4 | Wire fastlane/Matchfile | Substitutes `git_url` to point at your certs repo |
+| 5 | Toolchain | `make bootstrap` (brew bundle + lefthook + xcodegen/tuist + bundler) |
+| 6 | Initial commit + push | First commit (rename + Matchfile) pushed to `origin/main` |
+| 7 | Branch protection | `bin/setup-github.sh` (6 required checks, squash-only, linear history) |
+| 8 | Private certs repo | `gh repo create --private` if absent |
+| 9 | 7 GH Secrets | Generates `MATCH_PASSWORD` + `KEYCHAIN_PASSWORD` if absent, encodes the PAT + p8, sets all 7 secrets |
+| 10 | Bundle ID registration | `fastlane register_app_id` (idempotent — Spaceship `BundleId.create` rescues `ALREADY_EXISTS`) |
+| 11 | Verify ASC App | Probes for the App record. **Fails loud with web-UI instructions if missing** — Apple disallows `POST /apps`, so this is the one human-gated step inside the pipeline |
+| 12 | Mint certs (iOS dist + dev + macOS dist) | `fastlane bootstrap_certs` (3 match calls in one process) |
+| 13 | Mac Installer Distribution cert | `bin/mint-installer-cert.rb` + `bin/import-installer-to-match.rb` |
+| 14 | (optional) Replace 1024 icon | If `ICON_1024_PATH` set, copies it to the iOS asset catalog |
+| 15 | (optional) Regenerate macOS icns | `make icons` — only if step 14 ran |
+
+## What you still have to do by hand
+
+These can't be automated — Apple and GitHub deliberately don't expose them
+to public APIs:
+
+- **Enroll in the Apple Developer Program** ($99/yr; ~24-48 hr Apple review)
+- **Create the App Store Connect API Key** (web UI; Apple shows the `.p8` once)
+- **Create the App Store Connect App record** (Apple disallows `POST /apps`).
+  Step 11 of `make bootstrap-fork` fails loud with the exact form values to
+  paste — re-run after creating, and step 11 turns ✓
+- **Generate a fine-grained PAT** for the certs repo (web UI)
+- **Provide a 1024 icon and metadata text** (designer + product artifacts —
+  see "After bootstrap" below)
+
+## After bootstrap
+
+`make ship` triggers `release.yml` and tails it until success. Tag pushed,
+binaries uploaded, ASC ingestion in flight. Then `make verify` polls ASC
+for the most recent build's processing state.
+
+For App Store *review* (not just TestFlight), you still need:
+
+- Replace `app/iOS/Assets.xcassets/AppIcon.appiconset/Icon-1024.png` and
+  run `make icons` (or set `ICON_1024_PATH` and let bootstrap do it)
+- Fill `fastlane/metadata/en-US/*.txt` (replace TODO markers in `name`,
+  `subtitle`, `description`, `keywords`, `release_notes`, `marketing_url`,
+  `privacy_url`, `support_url`)
+- Fill `fastlane/metadata/review_information/*.txt` (`first_name`,
+  `last_name`, `email_address`, `phone_number`, `notes`)
+- Update `fastlane/metadata/copyright.txt`
+- Capture screenshots: `ci/take-screenshots.sh`
+- Upload metadata + screenshots: `bundle exec fastlane ios upload_metadata` etc.
+
+These aren't gates for TestFlight — TestFlight just needs the build. They're
+gates for App Store review.
+
+## PAT scope tradeoff
+
+The fine-grained PAT can be scoped two ways:
+
+- **"Only select repositories" → just your certs repo** (most secure default).
+  Caveat: fine-grained PATs are pinned to a specific repo's *database ID*. If
+  you ever delete + recreate the certs repo, the PAT 404s on the new repo
+  even though the name is identical, and you have to update the PAT scope on
+  github.com/settings/tokens. See `docs/CONTINUOUS-VALIDATION.md` G12 and
+  `bin/refork-smoketest.sh` for the recreation-resilient approach.
+
+- **"All repositories"** — defense in depth, survives recreation. Same narrow
+  Contents permission, but bound to your user/org rather than a specific
+  repo's database ID.
+
+Either is fine; the first is the most secure default and what `.bootstrap.env`
+expects.
+
+## Why is `.bootstrap.env` gitignored?
+
+Even though most fields are non-secret (team ID, repo slugs), the file
+references *paths* to your `.p8` API key and your fine-grained PAT. Anyone who
+gets the file gets a roadmap to your secret bytes. Treat it the same way you
+treat `~/.ssh/config` — not a catastrophic leak by itself, but enough to be
+worth keeping out of source control.
+
+## Troubleshooting
+
+- **Step N fails with a stack trace from `bundle exec ruby`** — the script
+  uses fastlane's bundle for Spaceship + match. Run `bundle install` first.
+- **`make doctor` says PAT 404s on certs repo, but I just created it** —
+  fine-grained PATs are pinned to repo database IDs. If you recreated the
+  certs repo, edit the PAT's repo list at github.com/settings/tokens.
+- **Step 11 (Verify ASC App) is blocked but I created the App** — ASC API
+  is eventually consistent. Wait 30 seconds and re-run `make doctor`.
+- **Step 12 (match) hits "Could not create another Distribution certificate,
+  reached the maximum number of available Distribution certificates"** —
+  Apple's distribution cert quota is 3/team. Revoke an unused one via
+  `bundle exec fastlane revoke_cert id:<CERT_ID>` (run `make doctor` after,
+  the cert step will retry).
+- **Step 12 hits "Could not find the newly generated certificate installed"
+  on a populated login keychain** — see `docs/CONTINUOUS-VALIDATION.md` G11.
+  The bootstrap pipeline sets `CERT_KEYCHAIN_PATH` to a temp keychain to
+  avoid this; if you still hit it, run match against a fresh keychain.
+
+## What `bin/lib/bootstrap.rb` is
+
+The orchestrator. Pure Ruby, ~700 lines, depends only on the gems already
+in this template's `Gemfile` (fastlane + spaceship). Every step lives as a
+separate class (`RenameStub`, `BrewBootstrap`, `BootstrapCerts`, …) so
+adding new steps or skipping ones is a one-class change. `bin/doctor.rb`
+and `bin/bootstrap-fork.rb` are thin wrappers on `Bootstrap::Runner`.


### PR DESCRIPTION
## What

Collapses the 14+ step forker journey into 4 commands:

```bash
cp .bootstrap.env.example .bootstrap.env  # fill in 13 fields
make doctor          # probe Apple/GH/repo state
make bootstrap-fork  # idempotent driver
make ship            # trigger release.yml + tail until success
```

## How

`bin/lib/bootstrap.rb` is a Ruby library with 15 `Bootstrap::Step` subclasses, each with a side-effect-free `check` and an idempotent `do_it`. Doctor calls every `check` and prints a checklist; bootstrap calls `check || do_it` per step.

The 14+ original scripts (`bin/rename.sh`, `bin/setup-github.sh`, `bin/mint-installer-cert.rb`, `fastlane bootstrap_certs`, etc.) become implementation details. They still work standalone for advanced users.

## Tested

End-to-end on `indiagrams/ios-macos-smoketest` (already fully bootstrapped from prior E2E test):

```
$ make doctor
✓ 15 done    ✗ 0 pending    ⚠ 0 blocked

$ make bootstrap-fork
[1/15] ... [15/15] — all already done; no-op
✅ Bootstrap complete.
```

## Files

- `.bootstrap.env.example` (new, committed)
- `bin/lib/bootstrap.rb` (new, 700 lines, pure Ruby)
- `bin/doctor.rb`, `bin/bootstrap-fork.rb`, `bin/ship.rb`, `bin/verify-testflight.rb` (new wrappers)
- `Makefile` — 4 new targets
- `docs/BOOTSTRAP.md` (new)
- `README.md` — Quickstart rewritten to point at new flow
- `.gitignore` — `.bootstrap.env` added