### PR TITLE
chore(.gitignore): exclude .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ ehthumbs.db
 # Generated artifacts (regenerable from CHANGELOG.md)
 release-notes.md
 .bootstrap.env
+.claude/


### PR DESCRIPTION
Tiny follow-up to PR #52. The `.claude/` line for Claude Code session state was added to .gitignore on the bootstrap branch but didn't make it into the squashed PR.