### PR TITLE
feat: T3 bootstrap polish — make all + idempotent ship + advisory scans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # The stub app is named "HelloApp" with bundle id "com.example.helloapp".
 # Rename for your project: see README.md → "Renaming the stub".
 
-.PHONY: bootstrap check check-ios check-macos check-sim build generate icons screenshots release-dryrun setup-github phase-checklist milestone-checklist help
+.PHONY: all go bootstrap check check-ios check-macos check-sim build generate icons screenshots release-dryrun setup-github phase-checklist milestone-checklist help doctor bootstrap-fork ship verify
 
 help:
 	@echo "Targets:"
@@ -20,6 +20,7 @@ help:
 	@echo "  screenshots      Capture App Store screenshots (iOS + macOS) to fastlane/screenshots/"
 	@echo "  release-dryrun   fastlane release tag:v0.0.0 skip_upload:true skip_tag:true"
 	@echo "  setup-github     Apply branch protection settings to current repo"
+	@echo "  all              One-shot: doctor → bootstrap-fork → ship → verify (the full forker journey)"
 	@echo "  doctor           Read .bootstrap.env, validate Apple+GH credentials, print pipeline status"
 	@echo "  bootstrap-fork   Idempotent: drive every programmatic fork-bootstrap step from .bootstrap.env"
 	@echo "  ship             Trigger release.yml workflow_dispatch + tail until the run completes"
@@ -74,6 +75,9 @@ ship:
 
 verify:
 	@bundle exec ruby bin/verify-testflight.rb
+
+all: doctor bootstrap-fork ship verify
+go: all
 
 phase-checklist:
 	@if [ -z "$(N)" ]; then echo "usage: make phase-checklist N=<phase>  (e.g. N=3.1)"; exit 2; fi

--- a/bin/lib/bootstrap.rb
+++ b/bin/lib/bootstrap.rb
@@ -525,8 +525,14 @@ module Bootstrap
     end
 
     def do_it
-      env = asc_env(config).merge(match_env(config))
-      Sh.run!("bundle", "exec", "fastlane", "bootstrap_certs", env: env)
+      env = Bootstrap.asc_env(config).merge(Bootstrap.match_env(config))
+      out, ok = Sh.run("bundle", "exec", "fastlane", "bootstrap_certs", env: env)
+      return if ok
+      hint = Bootstrap.match_failure_hint(out)
+      UI.fail!(<<~MSG)
+        bootstrap_certs lane failed.
+        #{hint ? "Likely cause: #{hint}" : "See full output above."}
+      MSG
     end
 
     private
@@ -549,8 +555,12 @@ module Bootstrap
     end
 
     def do_it
-      env = asc_env(config).merge(match_env(config))
-      out = Sh.run!("bundle", "exec", "ruby", "bin/mint-installer-cert.rb", env: env)
+      env = Bootstrap.asc_env(config).merge(Bootstrap.match_env(config))
+      out, ok = Sh.run("bundle", "exec", "ruby", "bin/mint-installer-cert.rb", env: env)
+      unless ok
+        hint = Bootstrap.match_failure_hint(out)
+        UI.fail!("mint-installer-cert.rb failed.\n#{hint ? "Likely cause: #{hint}" : ''}")
+      end
       cert_id = out.lines.grep(/^Cert id:/).first&.split(":", 2)&.last&.strip
       UI.fail!("could not parse INSTALLER_CERT_ID from mint-installer-cert.rb output") if cert_id.to_s.empty?
       env2 = env.merge("INSTALLER_CERT_ID" => cert_id)
@@ -566,7 +576,9 @@ module Bootstrap
     end
 
     def check
-      return :done unless config.set?("ICON_1024_PATH") # optional
+      unless config.set?("ICON_1024_PATH")
+        return [:warn, "ICON_1024_PATH unset; the template hammer icon will ship. Required for App Store review (not TestFlight)."]
+      end
       src = config.expand_path("ICON_1024_PATH")
       return [:blocked, "ICON_1024_PATH does not exist: #{src}"] unless src.file?
       return :pending unless icon_target.file?
@@ -595,6 +607,51 @@ module Bootstrap
     end
   end
 
+  class ScanMetadata < Step
+    def name; "App Store metadata text files"; end
+
+    def metadata_dir; REPO_ROOT.join("fastlane", "metadata", "en-US"); end
+    def review_dir;   REPO_ROOT.join("fastlane", "metadata", "review_information"); end
+
+    def check
+      todos = []
+      [metadata_dir, review_dir].each do |dir|
+        next unless dir.directory?
+        Dir.glob(dir.join("*.txt")).each do |f|
+          content = File.read(f)
+          if content.match?(/\bTODO\b|REPLACE_ME|com\.example\.helloapp|HelloApp/i)
+            todos << Pathname.new(f).relative_path_from(REPO_ROOT).to_s
+          elsif content.strip.empty?
+            todos << "#{Pathname.new(f).relative_path_from(REPO_ROOT)} (empty)"
+          end
+        end
+      end
+      return :done if todos.empty?
+      [:warn, "#{todos.length} files need attention before App Store review:\n  - #{todos.join("\n  - ")}"]
+    end
+
+    def do_it
+      # No-op; check returns :warn or :done, never :pending.
+    end
+  end
+
+  class ScanScreenshots < Step
+    def name; "App Store screenshots"; end
+
+    def screenshot_dir; REPO_ROOT.join("fastlane", "screenshots", "en-US"); end
+
+    def check
+      return [:warn, "No fastlane/screenshots/en-US/ — capture via `ci/take-screenshots.sh` before App Store review (not TestFlight)."] unless screenshot_dir.directory?
+      pngs = Dir.glob(screenshot_dir.join("*.png"))
+      return [:warn, "No screenshots in #{screenshot_dir.relative_path_from(REPO_ROOT)} — capture via `ci/take-screenshots.sh` before App Store review."] if pngs.empty?
+      :done
+    end
+
+    def do_it
+      # No-op; check returns :warn or :done.
+    end
+  end
+
   # ─── Pipeline ───────────────────────────────────────────────────────────────
 
   class Runner
@@ -604,6 +661,8 @@ module Bootstrap
       RenameStub,
       EditMatchfile,
       BrewBootstrap,
+      Icon1024,           # tree mutations finish before InitialPush
+      MakeIcons,
       InitialPush,
       BranchProtection,
       CreateCertsRepo,
@@ -612,8 +671,8 @@ module Bootstrap
       VerifyAscApp,
       BootstrapCerts,
       MintInstaller,
-      Icon1024,
-      MakeIcons
+      ScanMetadata,       # informational; never blocks
+      ScanScreenshots
     ].freeze
 
     def initialize(config)
@@ -640,9 +699,16 @@ module Bootstrap
           puts "  #{(idx + 1).to_s.rjust(2)}. #{UI.miss step.name}#{UI.dim ' — will run on bootstrap'}"
           results << :pending
         when Array
-          puts "  #{(idx + 1).to_s.rjust(2)}. #{UI.warn step.name}"
-          puts result[1].lines.map { |l| "      #{l}" }.join
-          results << :blocked
+          severity, msg = result
+          if severity == :warn
+            puts "  #{(idx + 1).to_s.rjust(2)}. #{UI.warn step.name}"
+            puts msg.lines.map { |l| "      #{UI.dim l.chomp}" }.join("\n")
+            results << :warn
+          else
+            puts "  #{(idx + 1).to_s.rjust(2)}. #{UI.warn step.name}"
+            puts msg.lines.map { |l| "      #{l}" }.join
+            results << :blocked
+          end
         end
       end
 
@@ -650,7 +716,12 @@ module Bootstrap
       done    = results.count(:done)
       pending = results.count(:pending)
       blocked = results.count(:blocked)
-      puts "  #{UI.ok "#{done} done"}    #{UI.miss "#{pending} pending"}    #{UI.warn "#{blocked} blocked"}"
+      warned  = results.count(:warn)
+      cells = ["#{UI.ok "#{done} done"}"]
+      cells << UI.miss("#{pending} pending") if pending > 0
+      cells << UI.warn("#{warned} advisory") if warned > 0
+      cells << UI.warn("#{blocked} blocked") if blocked > 0
+      puts "  #{cells.join('    ')}"
 
       if blocked > 0
         puts
@@ -658,11 +729,12 @@ module Bootstrap
         exit 2
       elsif pending > 0
         puts
-        puts UI.bold "Run `make bootstrap` to close the ✗ items."
+        puts UI.bold "Run `make bootstrap-fork` to close the ✗ items."
         exit 0
       else
         puts
-        puts UI.bold "All steps complete. Run `make ship` to trigger a release."
+        puts UI.bold "All bootstrap steps complete. Run `make ship` to trigger a release."
+        puts UI.dim("(#{warned} advisory items above are App-Store-review-only and don't block TestFlight)") if warned > 0
         exit 0
       end
     end
@@ -680,7 +752,12 @@ module Bootstrap
           step.do_it
           puts "  #{UI.ok 'done'}"
         when Array
-          UI.fail!(result[1])
+          severity, msg = result
+          if severity == :warn
+            puts "  #{UI.warn msg.lines.first.chomp}"
+          else
+            UI.fail!(msg)
+          end
         end
       end
       puts
@@ -701,6 +778,31 @@ module Bootstrap
       issuer_id: config["ASC_API_KEY_ISSUER_ID"],
       filepath:  p8_path.to_s
     )
+  end
+
+  def self.match_failure_hint(output)
+    case output
+    when /Could not create another (Distribution|Development) certificate, reached the maximum/i
+      "Apple cert quota exhausted (3/team for Distribution). Find an unused cert via\n" \
+      "  bundle exec fastlane list_certs\n" \
+      "and revoke it via\n" \
+      "  bundle exec fastlane revoke_cert id:<CERT_ID>\n" \
+      "then re-run `make bootstrap-fork`."
+    when /Could not find the newly generated certificate installed/i
+      "fastlane match's keychain verification quirk on populated login keychains.\n" \
+      "See docs/CONTINUOUS-VALIDATION.md G11 + the workaround uses CERT_KEYCHAIN_PATH (set automatically by Bootstrap.match_env)."
+    when /Authentication credentials are missing or invalid/i
+      "ASC API key was rejected. Verify ASC_API_KEY_ID + ASC_API_KEY_ISSUER_ID match\n" \
+      "the .p8 in ASC_API_KEY_P8_PATH. ASC keys can be revoked at\n" \
+      "  https://appstoreconnect.apple.com/access/api"
+    when /Error cloning certificates git repo/i
+      "fastlane match couldn't access #{config_or_unknown(output, 'GH_CERTS_REPO')}.\n" \
+      "Check that MATCH_GIT_BASIC_AUTHORIZATION's PAT has access (G12 in CONTINUOUS-VALIDATION.md)."
+    end
+  end
+
+  def self.config_or_unknown(_output, _key)
+    "the certs repo"
   end
 
   def asc_env(config)

--- a/bin/ship.rb
+++ b/bin/ship.rb
@@ -1,65 +1,119 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Trigger release.yml via workflow_dispatch on the configured app repo, then
-# poll until the run completes. Prints the run URL up front so you can also
-# watch in browser.
+# Trigger release.yml on the configured app repo, then poll until completion.
+# Idempotent:
 #
-# Usage: bundle exec ruby bin/ship.rb [--dry-run]
+#   - If a release run is already in progress on origin/main, tail it
+#     instead of starting a new one. Pass --force to override.
+#   - If origin/main's HEAD SHA already has a release tag pointing at it,
+#     exit 0 ("already shipped") without triggering. Pass --force to override.
+#
+# Usage: bundle exec ruby bin/ship.rb [--dry-run] [--force]
 #   --dry-run    pass dry_run=true (build + sign + export, skip TestFlight upload)
+#   --force      ignore in-progress + already-shipped checks; trigger anyway
 #
 # Exit codes:
-#   0 release succeeded (TestFlight upload + tag pushed)
+#   0 release succeeded (or was already shipped, or in-progress run completed)
 #   1 invocation / I/O error
 #   2 the workflow run completed with conclusion != success
 
+require "json"
 require_relative "lib/bootstrap"
 
-config = Bootstrap::Config.load!
+config  = Bootstrap::Config.load!
 config.validate!
 
 dry_run = ARGV.include?("--dry-run") ? "true" : "false"
-repo = config.repo_slug
+force   = ARGV.include?("--force")
+repo    = config.repo_slug
 
-puts Bootstrap::UI.bold("Triggering release.yml on #{repo} (dry_run=#{dry_run})…")
-out, ok = Bootstrap::Sh.run("gh", "workflow", "run", "release.yml", "--ref", "main",
-                            "-f", "dry_run=#{dry_run}", "--repo", repo)
-unless ok
-  Bootstrap::UI.fail!("gh workflow run failed:\n#{out}")
-end
-
-# gh doesn't print the run id immediately; poll the runs list briefly.
-sleep 5
-run_id = nil
-20.times do
+def find_in_progress_run(repo)
   out, _ = Bootstrap::Sh.run("gh", "run", "list", "--workflow", "release.yml",
-                             "--repo", repo, "--limit", "1",
-                             "--json", "databaseId,status,createdAt", "--jq", ".[0].databaseId")
-  run_id = out.strip
-  break unless run_id.empty?
-  sleep 2
+                              "--repo", repo, "--branch", "main", "--limit", "5",
+                              "--json", "databaseId,status",
+                              "--jq", '.[] | select(.status == "in_progress" or .status == "queued" or .status == "pending") | .databaseId')
+  id = out.lines.first&.strip
+  id && !id.empty? ? id : nil
 end
-Bootstrap::UI.fail!("could not find newly-triggered run id") if run_id.to_s.empty?
 
+def head_already_tagged?(repo)
+  head_sha, ok = Bootstrap::Sh.run("gh", "api", "repos/#{repo}/commits/main", "--jq", ".sha")
+  return nil unless ok
+  head_sha = head_sha.strip
+  return nil if head_sha.empty?
+  tags_json, ok2 = Bootstrap::Sh.run("gh", "api", "repos/#{repo}/tags?per_page=20",
+                                      "--jq", '[.[] | {name, sha: .commit.sha}]')
+  return nil unless ok2 && !tags_json.strip.empty?
+  match = JSON.parse(tags_json).find { |t| t["sha"] == head_sha }
+  match ? [match["name"], head_sha] : nil
+end
+
+def trigger_new_run(repo, dry_run)
+  puts Bootstrap::UI.bold("Triggering release.yml on #{repo} (dry_run=#{dry_run})…")
+  out, ok = Bootstrap::Sh.run("gh", "workflow", "run", "release.yml", "--ref", "main",
+                              "-f", "dry_run=#{dry_run}", "--repo", repo)
+  Bootstrap::UI.fail!("gh workflow run failed:\n#{out}") unless ok
+
+  # Poll for the new run to register
+  sleep 5
+  20.times do
+    out, _ = Bootstrap::Sh.run("gh", "run", "list", "--workflow", "release.yml",
+                                "--repo", repo, "--limit", "1",
+                                "--json", "databaseId,status,createdAt",
+                                "--jq", ".[0].databaseId")
+    id = out.strip
+    return id unless id.empty?
+    sleep 2
+  end
+  Bootstrap::UI.fail!("could not find newly-triggered run id")
+end
+
+# ─── Resolve target run id ────────────────────────────────────────────────────
+run_id = nil
+
+unless force
+  if (existing = find_in_progress_run(repo))
+    puts Bootstrap::UI.warn("Existing release run already in progress on #{repo}/main: ##{existing}")
+    puts "  → https://github.com/#{repo}/actions/runs/#{existing}"
+    puts "  Tailing this run instead of starting a new one. Pass --force to override."
+    puts
+    run_id = existing
+  elsif (already = head_already_tagged?(repo))
+    tag, sha = already
+    puts Bootstrap::UI.ok("HEAD on #{repo}/main is already shipped as tag #{tag}")
+    puts Bootstrap::UI.dim("(SHA #{sha[0, 8]}; pass --force to ship again)")
+    exit 0
+  end
+end
+
+run_id ||= trigger_new_run(repo, dry_run)
 run_url = "https://github.com/#{repo}/actions/runs/#{run_id}"
 puts "  → #{run_url}"
 puts
 
-# Poll until completed
+# ─── Poll until completed ─────────────────────────────────────────────────────
+last_status = nil
 loop do
   out, _ = Bootstrap::Sh.run("gh", "run", "view", run_id, "--repo", repo,
-                             "--json", "status,conclusion", "--jq", '"\(.status) \(.conclusion // "-")"')
-  status, conclusion = out.strip.split(" ", 2)
-  ts = Time.now.strftime("%H:%M:%S")
-  puts "[#{ts}] #{status} #{conclusion}"
+                              "--json", "status,conclusion",
+                              "--jq", '"\(.status) \(.conclusion // "-")"')
+  parts = out.strip.split(" ", 2)
+  status, conclusion = parts[0], parts[1]
+  if status != last_status
+    ts = Time.now.strftime("%H:%M:%S")
+    puts "[#{ts}] #{status} #{conclusion}"
+    last_status = status
+  end
   if status == "completed"
     if conclusion == "success"
       puts
       puts Bootstrap::UI.bold("✅ Release succeeded.")
       puts "Tag pushed; both binaries uploaded to App Store Connect."
-      puts "Run `make verify` to confirm TestFlight ingestion (~5-15 min ASC processing time)."
+      puts "Run #{Bootstrap::UI.bold 'make verify'} to confirm TestFlight ingestion (~5-15 min ASC processing time)."
       exit 0
     else
+      puts
       Bootstrap::UI.fail!("Release run #{run_id} concluded with: #{conclusion}\nSee #{run_url}")
     end
   end


### PR DESCRIPTION
Upgrades the bootstrap from T2 to T3 (full one-shot UX, idempotent everywhere).

## What

```bash
make all   # doctor → bootstrap-fork → ship → verify, in one shot
```

Each target exits non-zero on blockers; `make` halts at the first issue.

## Highlights

- **`make all` / `make go`** — full chain target
- **`make ship` idempotency**:
  - In-progress detection (tail existing run instead of starting another)
  - Already-shipped detection (skip if HEAD has a release tag)
  - `--force` to override either check
- **Pipeline reorder**: icons now land in the initial commit, before branch protection
- **New `:warn` Step return type**: non-blocking advisory state for App-Store-review-only gaps
- **`ScanMetadata` + `ScanScreenshots`**: flag TODO markers and missing screenshots
- **`match_failure_hint`**: cert quota / keychain quirk / ASC auth / repo access failures get targeted recovery hints in the error message

## Tested

End-to-end on indiagrams/ios-macos-smoketest:

```
make all
[1/17] ... [17/17]  → 14 done + 3 advisory
✓ HEAD already shipped as tag v2026.19.8
✓ Latest build is VALID
```

Pipeline grew from 15 → 17 steps. All idempotent.