### PR TITLE
feat: RELEASE_MODE (ci|local) + make init for forker convenience

### DIFF
--- a/.bootstrap.env.example
+++ b/.bootstrap.env.example
@@ -24,6 +24,19 @@ APP_EMAIL=you@example.com                # Maintainer email used in CHANGELOG, f
 GENERATOR=xcodegen                       # 'xcodegen' (default) or 'tuist'. Both manifests
                                          #   ship on `main`; this picks the one your fork uses.
 
+# ─── Release mode ─────────────────────────────────────────────────────────────
+# 'ci' (default) — full setup: certs repo, fastlane match, 7 GH Secrets;
+#                  `make ship` triggers .github/workflows/release.yml on the
+#                  app repo. The release runs on macos-15 with signing material
+#                  pulled from the certs repo via match.
+# 'local'        — minimal setup: no certs repo, no GH Secrets, no match.
+#                  Signing comes from the certs already in your login keychain
+#                  (Apple Distribution + Apple Development + 3rd Party Mac
+#                  Developer Installer). `make ship` runs fastlane release on
+#                  this machine. Faster to bootstrap; worse for a team
+#                  (no shared signing material; only your laptop can release).
+RELEASE_MODE=ci
+
 # ─── Apple credentials ────────────────────────────────────────────────────────
 # Get these from your Apple Developer account. The team id is at
 # https://developer.apple.com/account/#/membership. The ASC API key is
@@ -38,9 +51,11 @@ ASC_API_KEY_ISSUER_ID=                   # UUID format, shown above the table
 ASC_API_KEY_P8_PATH=                     # e.g. ~/Downloads/AuthKey_AAAAAA1234.p8
 
 # ─── GitHub identity ──────────────────────────────────────────────────────────
-# The org/user that owns both repos. Both must already exist (the app repo from
-# `gh repo create --template`; the certs repo is created by `make bootstrap` if
-# absent).
+# The org/user that owns the app repo. GH_APP_REPO must already exist (you
+# created it via `gh repo create --template` before running `make init`).
+# GH_CERTS_REPO is created by `make bootstrap-fork` if absent.
+#
+# GH_CERTS_REPO + GH_PAT_FILE are used only when RELEASE_MODE=ci.
 
 GH_ORG=                                  # e.g. your-org or your-username
 GH_APP_REPO=                             # e.g. your-app — created via gh repo create --template
@@ -51,10 +66,10 @@ GH_CERTS_REPO=                           # e.g. your-app-certs — created by `m
 # Token name suggestion: <APP_NAME>-certs-pat. Save the value to a 0600 file.
 GH_PAT_FILE=                             # e.g. ~/.config/secrets/your-app-pat
 
-# ─── Match credentials ────────────────────────────────────────────────────────
+# ─── Match credentials (only used when RELEASE_MODE=ci) ──────────────────────
 # These two passwords protect the encrypted certs repo + the CI keychain. If
-# the file paths below don't exist when `make bootstrap` runs, random 32-char
-# values will be generated and written for you. If they already exist, the
+# the file paths below don't exist when `make bootstrap-fork` runs, random
+# 32-char values will be generated and written for you. If they already exist,
 # existing values are reused (so re-running bootstrap doesn't rotate them).
 
 MATCH_PASSWORD_FILE=                     # e.g. ~/.config/secrets/match-password

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # The stub app is named "HelloApp" with bundle id "com.example.helloapp".
 # Rename for your project: see README.md → "Renaming the stub".
 
-.PHONY: all go bootstrap check check-ios check-macos check-sim build generate icons screenshots release-dryrun setup-github phase-checklist milestone-checklist help doctor bootstrap-fork ship verify
+.PHONY: all go bootstrap check check-ios check-macos check-sim build generate icons screenshots release-dryrun setup-github phase-checklist milestone-checklist help init doctor bootstrap-fork ship verify
 
 help:
 	@echo "Targets:"
@@ -20,6 +20,7 @@ help:
 	@echo "  screenshots      Capture App Store screenshots (iOS + macOS) to fastlane/screenshots/"
 	@echo "  release-dryrun   fastlane release tag:v0.0.0 skip_upload:true skip_tag:true"
 	@echo "  setup-github     Apply branch protection settings to current repo"
+	@echo "  init             Scaffold .bootstrap.env from .bootstrap.env.example, auto-fill GH_ORG/GH_APP_REPO from origin remote"
 	@echo "  all              One-shot: doctor → bootstrap-fork → ship → verify (the full forker journey)"
 	@echo "  doctor           Read .bootstrap.env, validate Apple+GH credentials, print pipeline status"
 	@echo "  bootstrap-fork   Idempotent: drive every programmatic fork-bootstrap step from .bootstrap.env"
@@ -63,6 +64,9 @@ release-dryrun:
 
 setup-github:
 	bin/setup-github.sh
+
+init:
+	@bin/init-bootstrap-env.sh
 
 doctor:
 	@bundle exec ruby bin/doctor.rb

--- a/README.md
+++ b/README.md
@@ -77,21 +77,24 @@ Apple side: see [`docs/APPLE-PREREQS.md`](docs/APPLE-PREREQS.md) for Team ID, Ap
 # 1. Fork from template
 gh repo create my-app --template indiagrams/ios-macos-template --public --clone && cd my-app
 
-# 2. Fill in .bootstrap.env — see docs/BOOTSTRAP.md for what each field is
-cp .bootstrap.env.example .bootstrap.env
+# 2. Scaffold .bootstrap.env (auto-fills GH_ORG/GH_APP_REPO from your origin remote)
+make init
+
+# 3. Edit .bootstrap.env — fill APP_NAME, BUNDLE_ID, Apple credentials,
+#    and RELEASE_MODE (ci for GH workflow signing, local for laptop signing)
 $EDITOR .bootstrap.env
 
-# 3. Validate config + probe Apple/GH
+# 4. Validate config + probe Apple/GH
 make doctor
 
-# 4. Run every programmatic step idempotently (rename, push, branch protection,
-#    7 GH Secrets, certs repo, match for 4 cert types, optional icon swap)
+# 5. Run every programmatic step idempotently
 make bootstrap-fork
 
-# 5. Trigger release.yml + tail until done (~5 min)
+# 6. Trigger a release. RELEASE_MODE=ci triggers .github/workflows/release.yml;
+#    RELEASE_MODE=local runs `bundle exec fastlane release` on this machine.
 make ship
 
-# 6. Confirm TestFlight ingestion
+# 7. Confirm TestFlight ingestion
 make verify
 ```
 

--- a/bin/init-bootstrap-env.sh
+++ b/bin/init-bootstrap-env.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Scaffold .bootstrap.env from .bootstrap.env.example, auto-filling GH_ORG +
+# GH_APP_REPO from the current git remote so the forker doesn't have to retype
+# their repo coordinates. Other fields are left blank for the forker to fill.
+#
+# Idempotent:
+#   - if .bootstrap.env already exists, refuses to overwrite (use --force)
+#   - if `git remote get-url origin` fails, GH_ORG/GH_APP_REPO are left blank
+#     (forker fills manually)
+#
+# Usage:  bin/init-bootstrap-env.sh [--force]
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$REPO_ROOT/.bootstrap.env.example"
+DST="$REPO_ROOT/.bootstrap.env"
+FORCE=false
+
+case "${1:-}" in
+  --force) FORCE=true ;;
+  "") ;;
+  *) echo "usage: $0 [--force]" >&2; exit 64 ;;
+esac
+
+if [ ! -f "$SRC" ]; then
+  echo "missing $SRC — are you in the template repo root?" >&2
+  exit 1
+fi
+
+if [ -f "$DST" ] && [ "$FORCE" = false ]; then
+  echo ".bootstrap.env already exists. Pass --force to overwrite." >&2
+  exit 1
+fi
+
+cp "$SRC" "$DST"
+
+# Auto-fill GH_ORG + GH_APP_REPO from `git remote get-url origin` if available.
+remote=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || true)
+if [ -n "$remote" ]; then
+  # https://github.com/ORG/REPO.git or git@github.com:ORG/REPO.git
+  slug=$(echo "$remote" | sed -nE 's|^(https://github\.com/\|git@github\.com:)([^/]+)/([^/]+)(\.git)?$|\2/\3|p' | sed 's/\.git$//')
+  if [[ "$slug" == */* ]]; then
+    org="${slug%%/*}"
+    repo="${slug##*/}"
+    # Use BSD sed compat (-i ''); runs on macOS only per template scope
+    sed -i '' -e "s|^GH_ORG=.*|GH_ORG=$org|" \
+              -e "s|^GH_APP_REPO=.*|GH_APP_REPO=$repo|" \
+              -e "s|^GH_CERTS_REPO=.*|GH_CERTS_REPO=$repo-certs|" \
+              "$DST"
+    echo "Auto-filled GH_ORG=$org, GH_APP_REPO=$repo, GH_CERTS_REPO=$repo-certs from git remote."
+  fi
+fi
+
+echo "Created $DST."
+echo "Next: \$EDITOR .bootstrap.env  (fill APP_NAME, BUNDLE_ID, Apple credentials, RELEASE_MODE), then \`make doctor\`."

--- a/bin/lib/bootstrap.rb
+++ b/bin/lib/bootstrap.rb
@@ -40,11 +40,14 @@ module Bootstrap
   # ─── Config loader ──────────────────────────────────────────────────────────
 
   class Config
-    REQUIRED = %w[
-      APP_NAME BUNDLE_ID DISPLAY_NAME APP_EMAIL GENERATOR
+    REQUIRED_ALWAYS = %w[
+      APP_NAME BUNDLE_ID DISPLAY_NAME APP_EMAIL GENERATOR RELEASE_MODE
       FASTLANE_TEAM_ID ASC_API_KEY_ID ASC_API_KEY_ISSUER_ID ASC_API_KEY_P8_PATH
-      GH_ORG GH_APP_REPO GH_CERTS_REPO GH_PAT_FILE
-      MATCH_PASSWORD_FILE KEYCHAIN_PASSWORD_FILE
+      GH_ORG GH_APP_REPO
+    ].freeze
+
+    REQUIRED_CI_ONLY = %w[
+      GH_CERTS_REPO GH_PAT_FILE MATCH_PASSWORD_FILE KEYCHAIN_PASSWORD_FILE
     ].freeze
 
     OPTIONAL = %w[ICON_1024_PATH ASC_APP_SKU ASC_APP_NAME].freeze
@@ -104,15 +107,28 @@ module Bootstrap
     end
 
     def validate!
-      missing = REQUIRED.reject { |k| set?(k) }
+      mode = release_mode
+      unless %w[ci local].include?(mode)
+        UI.fail!(".bootstrap.env: RELEASE_MODE must be 'ci' or 'local' (got: #{mode.inspect})")
+      end
+      required = REQUIRED_ALWAYS + (mode == "ci" ? REQUIRED_CI_ONLY : [])
+      missing = required.reject { |k| set?(k) }
       return if missing.empty?
       UI.fail!(<<~MSG)
-        .bootstrap.env is missing required fields:
+        .bootstrap.env is missing required fields (RELEASE_MODE=#{mode}):
         #{missing.map { |k| "  - #{k}" }.join("\n")}
 
         Edit .bootstrap.env and re-run.
       MSG
     end
+
+    def release_mode
+      m = self["RELEASE_MODE"]
+      m.empty? ? "ci" : m
+    end
+
+    def ci_mode?;    release_mode == "ci";    end
+    def local_mode?; release_mode == "local"; end
 
     def repo_slug
       "#{self["GH_ORG"]}/#{self["GH_APP_REPO"]}"
@@ -203,10 +219,20 @@ module Bootstrap
   # ─── Step base class ────────────────────────────────────────────────────────
 
   class Step
+    # Each subclass may override MODES to restrict applicability:
+    #   class EditMatchfile < Step; MODES = %w[ci]; end
+    #   class LocalKeychainCerts < Step; MODES = %w[local]; end
+    # Default: run in both modes.
+    MODES = %w[ci local].freeze
+
     attr_reader :config
 
     def initialize(config)
       @config = config
+    end
+
+    def applicable?(mode)
+      self.class.const_get(:MODES).include?(mode)
     end
 
     # Subclasses override.
@@ -263,16 +289,17 @@ module Bootstrap
     def category; "preflight"; end
 
     def check
+      return :done if config.local_mode? # PAT not used in local mode
       pat_file = config.expand_path("GH_PAT_FILE")
       return [:blocked, "GH_PAT_FILE doesn't exist: #{pat_file}"] unless pat_file && pat_file.file?
       pat = pat_file.read.strip
       return [:blocked, "GH_PAT_FILE is empty"] if pat.empty?
 
       # Probe certs repo via PAT
-      out, success = Sh.run("curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
-                            "-H", "Authorization: Bearer #{pat}",
-                            "-H", "Accept: application/vnd.github+json",
-                            "https://api.github.com/repos/#{config.certs_slug}")
+      out, _ok = Sh.run("curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
+                        "-H", "Authorization: Bearer #{pat}",
+                        "-H", "Accept: application/vnd.github+json",
+                        "https://api.github.com/repos/#{config.certs_slug}")
       case out
       when "200" then :done
       when "404"
@@ -318,6 +345,7 @@ module Bootstrap
   end
 
   class EditMatchfile < Step
+    MODES = %w[ci].freeze
     def name; "Wire fastlane/Matchfile to certs repo"; end
 
     def matchfile; REPO_ROOT.join("fastlane", "Matchfile"); end
@@ -386,6 +414,7 @@ module Bootstrap
   end
 
   class GHSecrets < Step
+    MODES = %w[ci].freeze
     def name; "Set 7 GH Secrets on app repo"; end
 
     def check
@@ -444,6 +473,7 @@ module Bootstrap
   end
 
   class CreateCertsRepo < Step
+    MODES = %w[ci].freeze
     def name; "Private certs repo"; end
 
     def check
@@ -511,6 +541,7 @@ module Bootstrap
   end
 
   class BootstrapCerts < Step
+    MODES = %w[ci].freeze
     def name; "Mint iOS dist + dev + macOS dist certs (via match)"; end
 
     def check
@@ -545,6 +576,7 @@ module Bootstrap
   end
 
   class MintInstaller < Step
+    MODES = %w[ci].freeze
     def name; "Mint Mac Installer Distribution cert"; end
 
     def check
@@ -652,40 +684,106 @@ module Bootstrap
     end
   end
 
+  class RemoteMatches < Step
+    def name; "GH_APP_REPO matches origin git remote"; end
+    def category; "preflight"; end
+
+    def check
+      out, ok = Sh.run("git", "remote", "get-url", "origin")
+      return [:warn, "no origin remote yet (initial push hasn't happened — that's fine)"] unless ok
+      url = out.strip
+      expected = "https://github.com/#{config.repo_slug}.git"
+      expected_ssh = "git@github.com:#{config.repo_slug}.git"
+      return :done if url == expected || url == expected_ssh
+      [:blocked, <<~MSG]
+        .bootstrap.env GH_APP_REPO=#{config['GH_APP_REPO']} (#{config.repo_slug})
+        but git remote points at: #{url}
+
+        Fix one or the other:
+          - update GH_ORG/GH_APP_REPO in .bootstrap.env, or
+          - run: git remote set-url origin #{expected}
+      MSG
+    end
+
+    def do_it
+      UI.fail!("git remote and .bootstrap.env GH_APP_REPO disagree; fix manually.")
+    end
+  end
+
+  class LocalKeychainCerts < Step
+    MODES = %w[local].freeze
+    def name; "Local keychain has signing identities"; end
+
+    REQUIRED_IDENTITIES = [
+      "Apple Distribution",
+      "Apple Development",
+      "3rd Party Mac Developer Installer"
+    ].freeze
+
+    def check
+      return :done if config.ci_mode? # only relevant in local mode
+      out, _ok = Sh.run("security", "find-identity", "-v", "-p", "codesigning",
+                        File.expand_path("~/Library/Keychains/login.keychain-db"))
+      missing = REQUIRED_IDENTITIES.reject { |id| out.include?(id) }
+      return :done if missing.empty?
+      [:blocked, <<~MSG]
+        Login keychain is missing #{missing.length} signing identit#{missing.length == 1 ? 'y' : 'ies'}:
+        #{missing.map { |m| "  - #{m}" }.join("\n")}
+
+        Add via Xcode → Settings → Accounts → (your team) → Manage Certificates → +.
+        Or via Apple Developer Portal → Certificates → + (then double-click the .cer).
+      MSG
+    end
+
+    def do_it
+      UI.fail!("Local mode requires signing identities in your login keychain. Add them and re-run.")
+    end
+  end
+
   # ─── Pipeline ───────────────────────────────────────────────────────────────
 
   class Runner
+    # Single source of truth. Each Step subclass sets MODES = %w[ci]
+    # / %w[local] / both (default). Runner filters at construction time.
     PIPELINE = [
       CheckAppleCreds,
       CheckGHCreds,
+      RemoteMatches,
       RenameStub,
-      EditMatchfile,
+      EditMatchfile,        # ci-only
       BrewBootstrap,
-      Icon1024,           # tree mutations finish before InitialPush
+      Icon1024,              # tree mutations land before InitialPush
       MakeIcons,
       InitialPush,
       BranchProtection,
-      CreateCertsRepo,
-      GHSecrets,
+      CreateCertsRepo,       # ci-only
+      GHSecrets,             # ci-only
       RegisterAppId,
       VerifyAscApp,
-      BootstrapCerts,
-      MintInstaller,
-      ScanMetadata,       # informational; never blocks
+      BootstrapCerts,        # ci-only
+      MintInstaller,         # ci-only
+      LocalKeychainCerts,    # local-only
+      ScanMetadata,          # informational
       ScanScreenshots
     ].freeze
 
     def initialize(config)
       @config = config
-      @steps = PIPELINE.map { |klass| klass.new(config) }
+      mode = config.release_mode
+      @steps = PIPELINE
+        .map { |klass| klass.new(config) }
+        .select { |step| step.applicable?(mode) }
     end
 
     def doctor
       @config.validate!
       UI.section "Configuration"
-      puts "  app:    #{@config['APP_NAME']} (#{@config['BUNDLE_ID']})"
-      puts "  apple:  team #{@config['FASTLANE_TEAM_ID']}, ASC key #{@config['ASC_API_KEY_ID']}"
-      puts "  gh:     app=#{@config.repo_slug} certs=#{@config.certs_slug}"
+      puts "  app:     #{@config['APP_NAME']} (#{@config['BUNDLE_ID']})"
+      puts "  mode:    RELEASE_MODE=#{UI.bold @config.release_mode}"
+      puts "  apple:   team #{@config['FASTLANE_TEAM_ID']}, ASC key #{@config['ASC_API_KEY_ID']}"
+      gh_line = "  gh:      app=#{@config.repo_slug}"
+      gh_line += " certs=#{@config.certs_slug}" if @config.ci_mode?
+      puts gh_line
 
       UI.section "Pipeline status"
       results = []

--- a/bin/ship.rb
+++ b/bin/ship.rb
@@ -1,22 +1,27 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Trigger release.yml on the configured app repo, then poll until completion.
-# Idempotent:
+# Trigger a release. Behavior depends on .bootstrap.env's RELEASE_MODE:
 #
-#   - If a release run is already in progress on origin/main, tail it
-#     instead of starting a new one. Pass --force to override.
-#   - If origin/main's HEAD SHA already has a release tag pointing at it,
-#     exit 0 ("already shipped") without triggering. Pass --force to override.
+#   ci    — triggers .github/workflows/release.yml on the configured app repo,
+#           then polls until completion. Idempotent:
+#             - if a release run is already in progress on origin/main, tail it
+#             - if origin/main HEAD already has a release tag, exit 0
+#             - --force overrides both checks
 #
-# Usage: bundle exec ruby bin/ship.rb [--dry-run] [--force]
-#   --dry-run    pass dry_run=true (build + sign + export, skip TestFlight upload)
-#   --force      ignore in-progress + already-shipped checks; trigger anyway
+#   local — runs `bundle exec fastlane release tag:vYYYY.WW.HHMM` on this
+#           machine. Signing comes from the login keychain (Apple Distribution
+#           + Apple Development + 3rd Party Mac Developer Installer must be
+#           present — `make doctor` verifies). No Idempotency check: the
+#           fastlane release lane is itself idempotent (refuses to re-tag
+#           an existing tag).
 #
-# Exit codes:
+# Usage:  bundle exec ruby bin/ship.rb [--dry-run] [--force]
+#
+# Exit:
 #   0 release succeeded (or was already shipped, or in-progress run completed)
 #   1 invocation / I/O error
-#   2 the workflow run completed with conclusion != success
+#   2 the workflow run / fastlane lane completed with conclusion != success
 
 require "json"
 require_relative "lib/bootstrap"
@@ -26,7 +31,30 @@ config.validate!
 
 dry_run = ARGV.include?("--dry-run") ? "true" : "false"
 force   = ARGV.include?("--force")
-repo    = config.repo_slug
+
+# ─── Local mode: run fastlane release on this machine ─────────────────────────
+if config.local_mode?
+  tag = "v#{Time.now.utc.strftime('%Y.%V.%H%M')}"
+  puts Bootstrap::UI.bold("Running fastlane release locally — tag #{tag}")
+  env = Bootstrap.asc_env(config)
+  args = ["bundle", "exec", "fastlane", "release", "tag:#{tag}"]
+  args << "skip_upload:true" if dry_run == "true"
+
+  out, ok = Bootstrap::Sh.run(*args, env: env)
+  if ok
+    puts
+    puts Bootstrap::UI.bold("✅ Local release succeeded.")
+    puts "Tag #{tag} pushed; binaries uploaded to App Store Connect."
+    puts "Run #{Bootstrap::UI.bold 'make verify'} to confirm TestFlight ingestion (~5-15 min)."
+    exit 0
+  else
+    puts out
+    Bootstrap::UI.fail!("fastlane release failed.")
+  end
+end
+
+# ─── CI mode: trigger release.yml + tail ──────────────────────────────────────
+repo = config.repo_slug
 
 def find_in_progress_run(repo)
   out, _ = Bootstrap::Sh.run("gh", "run", "list", "--workflow", "release.yml",
@@ -55,7 +83,6 @@ def trigger_new_run(repo, dry_run)
                               "-f", "dry_run=#{dry_run}", "--repo", repo)
   Bootstrap::UI.fail!("gh workflow run failed:\n#{out}") unless ok
 
-  # Poll for the new run to register
   sleep 5
   20.times do
     out, _ = Bootstrap::Sh.run("gh", "run", "list", "--workflow", "release.yml",
@@ -69,7 +96,6 @@ def trigger_new_run(repo, dry_run)
   Bootstrap::UI.fail!("could not find newly-triggered run id")
 end
 
-# ─── Resolve target run id ────────────────────────────────────────────────────
 run_id = nil
 
 unless force
@@ -92,7 +118,6 @@ run_url = "https://github.com/#{repo}/actions/runs/#{run_id}"
 puts "  → #{run_url}"
 puts
 
-# ─── Poll until completed ─────────────────────────────────────────────────────
 last_status = nil
 loop do
   out, _ = Bootstrap::Sh.run("gh", "run", "view", run_id, "--repo", repo,

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -13,22 +13,43 @@ the ones Apple and GitHub deliberately don't expose to APIs.
 gh repo create my-app --template indiagrams/ios-macos-template --public --clone
 cd my-app
 
-# 2. Fill in .bootstrap.env (see "Config reference" below)
-cp .bootstrap.env.example .bootstrap.env
+# 2. Scaffold .bootstrap.env from the example, auto-filling GH_ORG/GH_APP_REPO
+#    from `git remote get-url origin`
+make init
+
+# 3. Edit .bootstrap.env — fill APP_NAME, BUNDLE_ID, Apple credentials,
+#    RELEASE_MODE (ci or local). See "Config reference" below.
 $EDITOR .bootstrap.env
 
-# 3. Validate — see what's done, what's pending, what's blocked
+# 4. Validate config + probe Apple/GH
 make doctor
 
-# 4. Run the bootstrap (idempotent — re-run safely)
+# 5. Run every programmatic step idempotently
 make bootstrap-fork
 
-# 5. Trigger the release pipeline
-make ship          # tails the workflow run until success
+# 6. Trigger a release (CI workflow if RELEASE_MODE=ci, fastlane locally if =local)
+make ship
 
-# 6. Confirm TestFlight ingestion
+# 7. Confirm TestFlight ingestion
 make verify
 ```
+
+## Two release modes
+
+`.bootstrap.env` has a `RELEASE_MODE` field. Choose one:
+
+| | `ci` (default) | `local` |
+|---|---|---|
+| **Setup includes** | Private certs repo, fastlane match, 7 GH Secrets, branch protection, ASC App | Login keychain identities check, branch protection, ASC App |
+| **`make ship` does** | Triggers `.github/workflows/release.yml` on the app repo | Runs `bundle exec fastlane release tag:vYYYY.WW.HHMM` on this machine |
+| **Signing material lives** | Encrypted in the certs repo; CI decrypts via `MATCH_PASSWORD` | In your login keychain (Apple Distribution + Apple Development + 3rd Party Mac Developer Installer) |
+| **Who can release** | Anyone with `GH_PAT_FILE` (and ASC API key) | Only this laptop |
+| **Best for** | Teams, weekly TestFlight cron, repeatable builds | Solo devs, fast iteration, no shared CI |
+| **Cost to bootstrap** | ~10 min (PAT + certs repo + 7 secrets + match) | ~3 min (just verify keychain has the certs) |
+
+The same `fastlane/Fastfile` drives both — the release lane gates the `match` calls on `File.exist?(fastlane/Matchfile)`, so a `local`-mode fork that never touches Matchfile uses local Keychain signing automatically.
+
+You can switch modes later by editing `RELEASE_MODE` and re-running `make bootstrap-fork`. Going `local → ci`: bootstrap will set up the certs repo + secrets. Going `ci → local`: bootstrap won't tear down the existing certs repo (you'd remove that manually); CI just stops running.
 
 ## Config reference
 
@@ -44,15 +65,16 @@ actual secret bytes. The dotenv itself is low-blast-radius.
 | `APP_EMAIL` | Maintainer email for Appfile, CHANGELOG, fastlane metadata | You decide |
 | `GENERATOR` | `xcodegen` (default) or `tuist` | Pick whichever project format you want to drive your fork |
 | `FASTLANE_TEAM_ID` | 10-char Apple Developer Team ID | <https://developer.apple.com/account/#/membership> |
+| `RELEASE_MODE` | `ci` or `local`. See [Two release modes](#two-release-modes) above | You decide |
 | `ASC_API_KEY_ID` | 10-char ASC API key ID | <https://appstoreconnect.apple.com/access/api> → Users and Access → Integrations → App Store Connect API |
 | `ASC_API_KEY_ISSUER_ID` | UUID format issuer ID | Same page, shown above the keys table |
 | `ASC_API_KEY_P8_PATH` | Path to the `.p8` file Apple gave you when you created the API key | Apple shows it once at creation time. If lost, generate a new key + revoke old |
 | `GH_ORG` | GitHub user/org that owns both repos | You decide |
-| `GH_APP_REPO` | App repo name (you already created this via `gh repo create --template`) | Already done if you ran the quickstart |
-| `GH_CERTS_REPO` | Private certs repo name (created by `make bootstrap-fork` if absent) | Convention: `<app-repo>-certs` |
-| `GH_PAT_FILE` | Path to a file containing a fine-grained PAT scoped to `GH_CERTS_REPO` (Contents: read+write) | <https://github.com/settings/tokens?type=beta>. See [PAT scope tradeoff](#pat-scope-tradeoff) below |
-| `MATCH_PASSWORD_FILE` | Path to a file containing the certs-repo encryption password. Auto-generated as 32 random chars if absent | Created on first `make bootstrap-fork` |
-| `KEYCHAIN_PASSWORD_FILE` | Path to a file containing the CI keychain password. Auto-generated if absent | Created on first `make bootstrap-fork` |
+| `GH_APP_REPO` | App repo name (already created via `gh repo create --template`; auto-filled by `make init` from origin remote) | The name you used in `gh repo create` |
+| `GH_CERTS_REPO` *(ci-only)* | Private certs repo name (created by `make bootstrap-fork` if absent) | Convention: `<app-repo>-certs` |
+| `GH_PAT_FILE` *(ci-only)* | Path to a file containing a fine-grained PAT scoped to `GH_CERTS_REPO` (Contents: read+write) | <https://github.com/settings/tokens?type=beta>. See [PAT scope tradeoff](#pat-scope-tradeoff) below |
+| `MATCH_PASSWORD_FILE` *(ci-only)* | Path to a file containing the certs-repo encryption password. Auto-generated as 32 random chars if absent | Created on first `make bootstrap-fork` |
+| `KEYCHAIN_PASSWORD_FILE` *(ci-only)* | Path to a file containing the CI keychain password. Auto-generated if absent | Created on first `make bootstrap-fork` |
 | `ICON_1024_PATH` (optional) | Path to your 1024×1024 PNG. If set, replaces the template hammer icon and runs `make icons` | Designer artifact |
 | `ASC_APP_SKU` (optional) | Documentation hint for the manual ASC App creation step | Any unique string |
 | `ASC_APP_NAME` (optional) | Documentation hint — defaults to `DISPLAY_NAME` | The human-readable name you want shown in the App Store |


### PR DESCRIPTION
Adds two pieces to PR #54's T3 surface:

## RELEASE_MODE in .bootstrap.env

Two values:
- `ci` (default) — current behavior. Certs repo, match, 7 GH Secrets, `make ship` triggers release.yml.
- `local` — minimal setup. No certs repo, no GH Secrets. Signing from login keychain. `make ship` runs `fastlane release` locally.

Single `PIPELINE` array; each Step subclass declares a `MODES` constant. Runner filters at construction. New steps:
- `RemoteMatches` — checks GH_APP_REPO matches `git remote get-url origin`
- `LocalKeychainCerts` (local-only) — probes login keychain for required identities

## make init

`bin/init-bootstrap-env.sh` (20-line shell). Copies the .example file to .bootstrap.env and auto-fills GH_ORG / GH_APP_REPO / GH_CERTS_REPO from `git remote get-url origin`.

## Tested

End-to-end on indiagrams/ios-macos-smoketest:

| Test | Result |
|---|---|
| make init from clean state | ✓ auto-filled all 3 GH fields |
| make doctor (RELEASE_MODE=ci) | ✓ 18 steps, 15 done + 3 advisory; RemoteMatches passes |
| make doctor (RELEASE_MODE=local) | ✓ 14 steps; LocalKeychainCerts correctly flagged missing installer cert |
| make bootstrap-fork (local, blocked) | ✓ bails at step 12 with Xcode Accounts instructions |

Forker flow:
```bash
gh repo create my-app --template ... --public --clone && cd my-app
make init
$EDITOR .bootstrap.env   # fill APP_NAME, BUNDLE_ID, Apple credentials, RELEASE_MODE
make all                  # doctor → bootstrap-fork → ship → verify
```