### PR TITLE
chore: rename repo ios-macos-template → apple-shipkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Versioning
 
-This CHANGELOG tracks **template versions** — releases of the `ios-macos-template` repo itself, not the forker apps that consume it. Forker apps maintain their own CHANGELOG and version policy independently.
+This CHANGELOG tracks **template versions** — releases of the `apple-shipkit` repo itself, not the forker apps that consume it. Forker apps maintain their own CHANGELOG and version policy independently.
 
 Pre-1.0 (`0.x`) is the development phase: breaking changes are allowed without bumping a major version. The `0.x` retrospective entry above summarizes what shipped during M1–M4 milestones; further pre-1.0 work lands under `[Unreleased]` until the public flip.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to ios-macos-template
+# Contributing to apple-shipkit
 
 This is a small, opinionated template for iOS + macOS apps. We say yes to
 fixes for the gotchas hiding in `xcodebuild`, `fastlane deliver`, `actool`,
@@ -19,8 +19,8 @@ If the answer to all is yes, open a PR. If you're unsure, open an issue first.
 
 ```bash
 # 1. Fork on GitHub, then clone your fork
-git clone https://github.com/<you>/ios-macos-template.git
-cd ios-macos-template
+git clone https://github.com/<you>/apple-shipkit.git
+cd apple-shipkit
 
 # 2. One-time setup (brew bundle, lefthook install, xcodegen, bundle install)
 make bootstrap
@@ -130,7 +130,7 @@ The full operating manual is [docs/PRINCIPLES.md](docs/PRINCIPLES.md)
 For larger changes — anything touching `ci/lib/`, the release pipeline,
 the renaming script (when it lands), or the public template "API"
 (directory layout, script names, Makefile targets) — open a [GitHub
-issue](https://github.com/indiagrams/ios-macos-template/issues) first.
+issue](https://github.com/indiagrams/apple-shipkit/issues) first.
 We'll discuss the shape before you spend time on the implementation.
 
 (Issue templates are coming in a near-term update; for now, free-form is fine.)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# ios-macos-template
+# apple-shipkit
 
-[![CI](https://github.com/indiagrams/ios-macos-template/actions/workflows/pr.yml/badge.svg)](https://github.com/indiagrams/ios-macos-template/actions/workflows/pr.yml)
+[![CI](https://github.com/indiagrams/apple-shipkit/actions/workflows/pr.yml/badge.svg)](https://github.com/indiagrams/apple-shipkit/actions/workflows/pr.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Swift 5.9](https://img.shields.io/badge/Swift-5.9-orange.svg)](https://swift.org)
 
-> **v1.0.0 released** — [release notes](https://github.com/indiagrams/ios-macos-template/releases/tag/v1.0.0). The "Use this template" button is live; fork it and ship.
+> **v1.0.0 released** — [release notes](https://github.com/indiagrams/apple-shipkit/releases/tag/v1.0.0). The "Use this template" button is live; fork it and ship.
 
 Opinionated boilerplate for iOS + macOS apps.
 Distilled from production iOS + macOS apps shipping on the App Store —
@@ -64,7 +64,7 @@ The template ships with a working `HelloApp` stub that builds green on both iOS 
 **Missing some?** Run `bin/preflight.sh` first — it checks every prereq and walks you through installing the missing ones:
 
 ```bash
-git clone https://github.com/indiagrams/ios-macos-template.git /tmp/preflight \
+git clone https://github.com/indiagrams/apple-shipkit.git /tmp/preflight \
   && bash /tmp/preflight/bin/preflight.sh \
   && rm -rf /tmp/preflight
 ```
@@ -75,7 +75,7 @@ Apple side: see [`docs/APPLE-PREREQS.md`](docs/APPLE-PREREQS.md) for Team ID, Ap
 
 ```bash
 # 1. Fork from template
-gh repo create my-app --template indiagrams/ios-macos-template --public --clone && cd my-app
+gh repo create my-app --template indiagrams/apple-shipkit --public --clone && cd my-app
 
 # 2. Scaffold .bootstrap.env (auto-fills GH_ORG/GH_APP_REPO from your origin remote)
 make init

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-This policy covers `ios-macos-template` itself — the build, release, and CI
+This policy covers `apple-shipkit` itself — the build, release, and CI
 scaffolding that downstream consumer apps inherit. Apps derived from this
 template ship their own `SECURITY.md` and own their own disclosure process;
 this file is for vulnerabilities in the template's scaffolding, not in any

--- a/Tuist.swift
+++ b/Tuist.swift
@@ -1,4 +1,4 @@
-// Tuist.swift — top-level Tuist 4 configuration for the ios-macos-template.
+// Tuist.swift — top-level Tuist 4 configuration for the apple-shipkit.
 //
 // Lives at repo root (Tuist 4 default; pre-4.0 used Tuist/Config.swift).
 // Companion to app/Project.swift; both ship alongside app/project.yml so

--- a/bin/preflight.sh
+++ b/bin/preflight.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# bin/preflight.sh — verify + auto-install prereqs for ios-macos-template forks.
+# bin/preflight.sh — verify + auto-install prereqs for apple-shipkit forks.
 #
 # Idempotent. Run repeatedly; only acts on what's missing.
 #
@@ -154,7 +154,7 @@ cat <<'EOF'
 
     2. Quickstart from a fresh fork:
 
-         gh repo create my-app --template indiagrams/ios-macos-template --public --clone && cd my-app
+         gh repo create my-app --template indiagrams/apple-shipkit --public --clone && cd my-app
          bin/rename.sh YourApp com.your-org.yourapp 'Your App' --email=you@example.com
          make bootstrap
          make check

--- a/bin/refork-smoketest.sh
+++ b/bin/refork-smoketest.sh
@@ -132,7 +132,7 @@ else
 fi
 
 echo "=== 5/5: re-fork smoketest from template ==="
-gh repo create "$APP_REPO" --template "$ORG/ios-macos-template" --public --clone -- --quiet 2>&1 | tail -1
+gh repo create "$APP_REPO" --template "$ORG/apple-shipkit" --public --clone -- --quiet 2>&1 | tail -1
 mv ios-macos-smoketest ../ios-macos-smoketest
 echo "  fresh fork at ../ios-macos-smoketest"
 

--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# bin/rename.sh — fork-rename script for the ios-macos-template.
+# bin/rename.sh — fork-rename script for the apple-shipkit.
 #
 # Substitutes 5 identity surfaces + 1 derived value, renames file paths,
 # regenerates xcodeproj. Atomic (all-or-nothing via reset-hard rollback),
@@ -25,7 +25,7 @@
 #
 # Optional flags:
 #   --slug=OWNER/REPO   GitHub org/repo slug; substitutes
-#                       indiagrams/ios-macos-template across README.md +
+#                       indiagrams/apple-shipkit across README.md +
 #                       CONTRIBUTING.md. If omitted, auto-derives from
 #                       `git remote get-url origin`. MUST NOT contain
 #                       newline or '|'.
@@ -330,7 +330,7 @@ trap 'rollback' EXIT
 # native and reliable. Carry-forward.
 #
 # Why -F on com.example.helloapp / maintainers@indiagram.com /
-# indiagrams/ios-macos-template (MEDIUM-1):
+# indiagrams/apple-shipkit (MEDIUM-1):
 # Without -F, the literal `.` in these patterns is regex any-char.
 # `git grep -nw -e com.example.helloapp` would match `comXexampleXhelloapp`
 # (none exist in tree, but the principle is wrong). -F treats the
@@ -385,7 +385,7 @@ sed_escape_replacement() {
 
 # The DISPLAY_NAME placeholder (HIGH-6 closure). Chosen so it does NOT
 # contain HelloApp, com.example.helloapp, maintainers@indiagram.com,
-# <year>, indiagrams/ios-macos-template — none of the broad sweeps
+# <year>, indiagrams/apple-shipkit — none of the broad sweeps
 # will mutate it. Verified zero hits in current tree.
 DISPLAY_PLACEHOLDER='__GSD_DISPLAY_PLACEHOLDER__'
 
@@ -429,11 +429,11 @@ apply_substitutions() {
         ok "email substituted in $f"
       done
 
-  # Step D: indiagrams/ios-macos-template -> $SLUG (escaped — HIGH-7)
-  step "Substituting indiagrams/ios-macos-template -> $SLUG"
-  { git grep -lw -F -e 'indiagrams/ios-macos-template' -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null || true; } \
+  # Step D: indiagrams/apple-shipkit -> $SLUG (escaped — HIGH-7)
+  step "Substituting indiagrams/apple-shipkit -> $SLUG"
+  { git grep -lw -F -e 'indiagrams/apple-shipkit' -- . "${PATHSPEC_EXCLUSIONS[@]}" 2>/dev/null || true; } \
     | while read -r f; do
-        sed -i '' "s|indiagrams/ios-macos-template|$escaped_slug|g" "$f"
+        sed -i '' "s|indiagrams/apple-shipkit|$escaped_slug|g" "$f"
         ok "GitHub slug substituted in $f"
       done
 
@@ -685,7 +685,7 @@ HelloApp||HelloApp -> $APP_NAME (broad sweep)
 com.example.helloapp|F|com.example.helloapp -> $BUNDLE_ID
 maintainers@indiagram.com|F|maintainers@indiagram.com -> $EMAIL
 <year>||<year> -> $(date +%Y)
-indiagrams/ios-macos-template|F|indiagrams/ios-macos-template -> $SLUG
+indiagrams/apple-shipkit|F|indiagrams/apple-shipkit -> $SLUG
 EOF
 
   echo

--- a/bin/verify-rename.sh
+++ b/bin/verify-rename.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# bin/verify-rename.sh — forker self-check for the ios-macos-template rename.
+# bin/verify-rename.sh — forker self-check for the apple-shipkit rename.
 #
 # Greps tracked files for the 4 original-template identity literals
 # (APP_NAME, BUNDLE_ID, EMAIL, SLUG) and exits 0 silent if none remain,
@@ -77,7 +77,7 @@ git rev-parse --is-inside-work-tree >/dev/null 2>&1 || \
 APP_NAME_ORIG="HelloApp"
 BUNDLE_ID_ORIG="com.example.helloapp"
 EMAIL_ORIG="maintainers@indiagram.com"
-SLUG_ORIG="indiagrams/ios-macos-template"
+SLUG_ORIG="indiagrams/apple-shipkit"
 YEAR_ORIG="<year>"
 
 # check_surface LABEL LITERAL

--- a/ci/test-rename.sh
+++ b/ci/test-rename.sh
@@ -145,7 +145,7 @@ check_zero "HelloApp" NW
 check_zero "com.example.helloapp" F
 check_zero "maintainers@indiagram.com" F
 check_zero "<year>"
-check_zero "indiagrams/ios-macos-template" F
+check_zero "indiagrams/apple-shipkit" F
 
 # Positive assertions: new identifiers present
 test "$(git grep -cw -e "$TEST_APP" -- . ':!.planning' ':!LICENSE' \

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -1,7 +1,7 @@
 # Pre-Public-Flip Secret + Identifier Audit
 
 This runbook documents how to re-run the secret + identifier audit before each
-major release of this `ios-macos-template` source repo. It is the last verification
+major release of this `apple-shipkit` source repo. It is the last verification
 gate before flipping visibility public (M5 P3) and before tagging v1.0.0+ releases
 (M5 P4 onward).
 

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -10,7 +10,7 @@ the ones Apple and GitHub deliberately don't expose to APIs.
 
 ```bash
 # 1. Fork from template
-gh repo create my-app --template indiagrams/ios-macos-template --public --clone
+gh repo create my-app --template indiagrams/apple-shipkit --public --clone
 cd my-app
 
 # 2. Scaffold .bootstrap.env from the example, auto-filling GH_ORG/GH_APP_REPO

--- a/docs/MIGRATING-TO-TUIST.md
+++ b/docs/MIGRATING-TO-TUIST.md
@@ -27,8 +27,8 @@ is the only section you really need.
 > manifests (`Tuist.swift` + `app/Project.swift` alongside
 > `app/project.yml`) and CI verifies both stay in sync on every PR
 > via the 6-job matrix (3 XcodeGen + 3 Tuist parity). Tracked in
-> [#34](https://github.com/indiagrams/ios-macos-template/issues/34) +
-> [#38](https://github.com/indiagrams/ios-macos-template/issues/38).
+> [#34](https://github.com/indiagrams/apple-shipkit/issues/34) +
+> [#38](https://github.com/indiagrams/apple-shipkit/issues/38).
 >
 > Validated end-to-end against this repo: a throwaway clone, ran
 > `bin/switch-to-tuist.sh`, then `make check` / `make check-sim` /
@@ -328,7 +328,7 @@ the script already covers. No edit required.
 ## Step 4 — Validate end-to-end
 
 The acceptance criterion for this migration (per
-[issue #34](https://github.com/indiagrams/ios-macos-template/issues/34))
+[issue #34](https://github.com/indiagrams/apple-shipkit/issues/34))
 is "`make check` passing post-migration on a fresh fork." Run all
 three signal paths:
 

--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -1,6 +1,6 @@
 # Principles
 
-How `ios-macos-template` is run. The short version: opinionated where it
+How `apple-shipkit` is run. The short version: opinionated where it
 matters (build, release, security), permissive where it doesn't (your app
 code, your icons, your copy).
 

--- a/docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md
+++ b/docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md
@@ -9,7 +9,7 @@ ship with what `xcode-select --install` already provides.
 > remains [fastlane](../fastlane/Fastfile) (`fastlane release tag:vX.Y.Z`).
 > This doc shows the equivalent commands you'd run if you replaced
 > fastlane with Apple's own tools — useful as a recipe, a reference, or a
-> migration plan. Tracked in [#35](https://github.com/indiagrams/ios-macos-template/issues/35).
+> migration plan. Tracked in [#35](https://github.com/indiagrams/apple-shipkit/issues/35).
 
 ## Why this exists
 

--- a/docs/SMOKE-TEST.md
+++ b/docs/SMOKE-TEST.md
@@ -12,7 +12,7 @@ Before starting:
 - **Homebrew** (`brew --version` ≥ 4.x)
 - **Xcode CLI** (`xcodebuild -version` returns valid output)
 - **`git config user.name` + `user.email`** set (rename produces a commit; identity must be configured)
-- **`is_template=true`** on the source repo (`gh api repos/indiagrams/ios-macos-template --jq '.is_template'` returns `true`). The template flag is set during M4 P4 and persists. M5 P3 will inherit it when flipping visibility public.
+- **`is_template=true`** on the source repo (`gh api repos/indiagrams/apple-shipkit --jq '.is_template'` returns `true`). The template flag is set during M4 P4 and persists. M5 P3 will inherit it when flipping visibility public.
 - **Working tree clean** in your local checkout; smoke-test clone goes into a sibling directory
 
 ## Procedure
@@ -23,7 +23,7 @@ The smoke test creates a real public repo (`indiagrams/ios-macos-smoke-test`), r
 # 1. From this repo's parent directory, create a smoke-test repo from the template.
 cd ..
 SMOKE_REPO="indiagrams/ios-macos-smoke-test"
-SOURCE_REPO="indiagrams/ios-macos-template"
+SOURCE_REPO="indiagrams/apple-shipkit"
 SMOKE_DIR_ABS="$(pwd)/$(basename "$SMOKE_REPO")"
 
 gh repo create "$SMOKE_REPO" \
@@ -153,7 +153,7 @@ rm -f ../bootstrap.log ../check.log ../setup-github.log ../smoke-cleanup.log
 ## Cross-org verification
 
 The smoke test above validates the same-org template-fork path
-(`indiagrams/ios-macos-template` → `indiagrams/ios-macos-smoke-test`).
+(`indiagrams/apple-shipkit` → `indiagrams/ios-macos-smoke-test`).
 The cross-org verification adds two coverage axes — a different org
 (`prakashrj/`) and the no-arg auto-detect form of `bin/setup-github.sh` —
 to confirm the script has no hardcoded org assumptions. Run this before
@@ -182,13 +182,13 @@ gh repo view prakashrj/ios-macos-cross-org-test 2>&1 | grep -q 'Could not resolv
 cd ..
 INDIAGRAMS_DIR_ABS="$(pwd)/ios-macos-smoke-test"
 gh repo create indiagrams/ios-macos-smoke-test \
-  --template indiagrams/ios-macos-template \
+  --template indiagrams/apple-shipkit \
   --public --clone
 sleep 5
 ( cd "$INDIAGRAMS_DIR_ABS" && git checkout HEAD -- . 2>/dev/null || true )
 
 # 2. Run setup-github.sh (explicit form, same-org). Verify protection.
-cd ios-macos-template
+cd apple-shipkit
 bin/setup-github.sh indiagrams/ios-macos-smoke-test
 sleep 2
 gh api repos/indiagrams/ios-macos-smoke-test/branches/main/protection \
@@ -216,7 +216,7 @@ sleep 2
 
 # 5. Run setup-github.sh (explicit form, cross-org). Verify protection +
 #    state-vector.
-cd ios-macos-template
+cd apple-shipkit
 bin/setup-github.sh prakashrj/ios-macos-cross-org-test
 sleep 2
 gh api repos/prakashrj/ios-macos-cross-org-test/branches/main/protection \
@@ -228,7 +228,7 @@ gh api repos/prakashrj/ios-macos-cross-org-test \
 # 6. No-arg auto-detect form: run setup-github.sh from inside the
 #    cross-org clone with no arguments.
 cd "$CROSS_ORG_DIR_ABS"
-"$(pwd)/../ios-macos-template/bin/setup-github.sh"   # no args
+"$(pwd)/../apple-shipkit/bin/setup-github.sh"   # no args
 cd -
 
 # 7. Cleanup (trap-on-EXIT in the orchestration; this is the manual form):


### PR DESCRIPTION
The project outgrew its original name. What started as a boilerplate Xcode project for iOS + macOS is now a full release-engineering template (Fastlane CI/local pipeline, continuous-validation smoketest, 12-entry gotcha catalog, config-driven bootstrap, 2×2 CI matrix). The differentiator is release engineering, not the project file. **`apple-shipkit`** captures that and stays platform-scope broad enough for visionOS/watchOS/tvOS later.

## What changed
- GitHub repo already renamed (this commit's parent is the new HEAD).
- Every tracked `indiagrams/ios-macos-template` reference → `apple-shipkit` across README, CONTRIBUTING, docs/, bin/, ci/, Tuist.swift, SECURITY.md, CHANGELOG.md meta.
- **Critical**: `bin/rename.sh`'s `ORIG_SLUG` and `bin/verify-rename.sh`'s `SLUG_ORIG` updated together so the fork-rename script still works.

## What's preserved
- GitHub auto-redirects `indiagrams/ios-macos-template/*` indefinitely. Existing forks, commit links, PR backlinks keep working.
- The smoketest stays at `indiagrams/ios-macos-smoketest` — its identity is "downstream smoketest fork", not tied to the upstream name.
- CHANGELOG entries themselves are historical and unchanged; only the meta-prose at the top references the current name.

## Verified
- Zero stale `ios-macos-template` hits in tracked files (excluding `.planning/`)
- `bin/rename.sh` hard-coded slug consistent with new name
