### PR TITLE
feat(ci): add canary-trigger.yml — weekly dispatch of smoketest release

### DIFF
--- a/.github/workflows/canary-trigger.yml
+++ b/.github/workflows/canary-trigger.yml
@@ -1,0 +1,142 @@
+name: canary-trigger
+
+# Weekly canary release of indiagrams/ios-macos-smoketest, driven from upstream.
+#
+# Why this lives here (apple-shipkit) instead of in the smoketest itself:
+#   The smoketest is a "living reference implementation" that fresh forks copy.
+#   Putting an active `schedule:` cron in the smoketest's release.yml would
+#   make it diverge from a fresh fork's shape. The trigger logically belongs
+#   with the upstream maintainer (where the goal-setting happens); the actual
+#   ship still happens on the smoketest (where the credentials, bundle ID,
+#   ASC app record, and certs live).
+#
+# Failure semantics:
+#   This workflow polls the dispatched run to completion and inherits its
+#   conclusion. If the smoketest's release goes red, this workflow goes red,
+#   so the failure surfaces on apple-shipkit's Actions tab — where the
+#   maintainer is watching.
+#
+# Secret required:
+#   SMOKETEST_DISPATCH_PAT — fine-grained PAT scoped to indiagrams/ios-macos-smoketest
+#                            with `Actions: Read and write` only.
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'   # Mondays 09:00 UTC (2h after bootstrap-doctor-matrix)
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dispatch with dry_run=true on the smoketest (build+sign only, no upload, no tag)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: canary-trigger
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    env:
+      TARGET_REPO: indiagrams/ios-macos-smoketest
+      TARGET_WORKFLOW: release.yml
+      TARGET_REF: main
+      GH_TOKEN: ${{ secrets.SMOKETEST_DISPATCH_PAT }}
+
+    steps:
+      - name: Verify dispatch PAT is set
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::SMOKETEST_DISPATCH_PAT secret is not set on this repo."
+            echo "Mint a fine-grained PAT scoped to ${TARGET_REPO} with Actions: Read and write,"
+            echo "then store it as SMOKETEST_DISPATCH_PAT."
+            exit 1
+          fi
+          echo "PAT present (${#GH_TOKEN} chars)"
+
+      - name: Capture dispatch baseline timestamp
+        id: baseline
+        run: |
+          # Used to filter the runs list — we look for runs created strictly
+          # after this point. Runner UTC vs api.github.com is NTP-synced to
+          # within seconds, well inside our 5s poll window.
+          baseline=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          echo "baseline=${baseline}" >> "${GITHUB_OUTPUT}"
+          echo "Baseline (only runs created after this count): ${baseline}"
+
+      - name: Dispatch smoketest release
+        run: |
+          dry_run='${{ inputs.dry_run }}'
+          dry_run="${dry_run:-false}"
+          echo "Dispatching ${TARGET_REPO} ${TARGET_WORKFLOW} on ref=${TARGET_REF} dry_run=${dry_run}"
+          gh workflow run "${TARGET_WORKFLOW}" \
+            --repo "${TARGET_REPO}" \
+            --ref "${TARGET_REF}" \
+            -f version='' \
+            -f "dry_run=${dry_run}"
+
+      - name: Locate the dispatched run
+        id: locate
+        env:
+          BASELINE: ${{ steps.baseline.outputs.baseline }}
+        run: |
+          # Poll up to 60s for the dispatched run to register. release.yml has
+          # `concurrency: group: release` so a queued state is normal — the
+          # run is still created, just not executing yet.
+          for i in $(seq 1 12); do
+            run_id=$(gh run list \
+              --repo "${TARGET_REPO}" \
+              --workflow "${TARGET_WORKFLOW}" \
+              --event workflow_dispatch \
+              --limit 1 \
+              --json databaseId,createdAt \
+              --jq ".[0] | select(.createdAt > \"${BASELINE}\") | .databaseId" \
+              || true)
+            if [ -n "${run_id}" ] && [ "${run_id}" != "null" ]; then
+              run_url="https://github.com/${TARGET_REPO}/actions/runs/${run_id}"
+              echo "Found dispatched run: ${run_url}"
+              {
+                echo "run_id=${run_id}"
+                echo "run_url=${run_url}"
+              } >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+            echo "No run yet (attempt ${i}/12), sleeping 5s..."
+            sleep 5
+          done
+          echo "::error::Dispatched workflow but could not locate the resulting run within 60s."
+          exit 1
+
+      - name: Wait for dispatched run to finish
+        env:
+          RUN_ID: ${{ steps.locate.outputs.run_id }}
+          RUN_URL: ${{ steps.locate.outputs.run_url }}
+        run: |
+          echo "Tailing run: ${RUN_URL}"
+          # Up to 50 minutes (release pipeline typically completes in 5-7m;
+          # 50m absorbs any GitHub Actions queue backpressure).
+          for i in $(seq 1 100); do
+            payload=$(gh run view "${RUN_ID}" --repo "${TARGET_REPO}" --json status,conclusion)
+            status=$(echo "${payload}" | jq -r '.status')
+            conclusion=$(echo "${payload}" | jq -r '.conclusion // ""')
+            ts=$(date -u +%H:%M:%S)
+            echo "[${ts}] poll ${i}/100 — status=${status} conclusion=${conclusion:-pending}"
+            if [ "${status}" = "completed" ]; then
+              if [ "${conclusion}" = "success" ]; then
+                echo "::notice::Smoketest release succeeded: ${RUN_URL}"
+                exit 0
+              else
+                echo "::error::Smoketest release concluded with: ${conclusion} (${RUN_URL})"
+                exit 1
+              fi
+            fi
+            sleep 30
+          done
+          echo "::error::Dispatched run did not complete within 50 minutes (${RUN_URL})"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,11 @@ name: release
 # match, Apple's signing infra, or ASC API faster than quarterly manual
 # releases would.
 #
-# The downstream reference smoketest (indiagrams/ios-macos-smoketest) runs
-# this workflow with the schedule active. Patterns + fixes here were
-# validated end-to-end against macos-15 in that fork before landing in this
-# template.
+# The downstream reference smoketest (indiagrams/ios-macos-smoketest) is
+# canary-validated weekly via apple-shipkit's own canary-trigger.yml workflow,
+# which dispatches this release.yml on the smoketest each Monday 09:00 UTC.
+# Patterns + fixes here were validated end-to-end against macos-15 in that
+# fork before landing in this template.
 #
 # Required GH Secrets (all 7 must be set before the workflow can succeed):
 #   MATCH_PASSWORD                  — match encryption passphrase


### PR DESCRIPTION
## What
- Adds `.github/workflows/canary-trigger.yml` — fires Mon 09:00 UTC + manual dispatch, calls `gh workflow run release.yml -R indiagrams/ios-macos-smoketest`, polls the resulting run, inherits its conclusion.
- Updates `release.yml`'s header comment to reflect the new architecture.

## Pair with
- `indiagrams/ios-macos-smoketest#10` (already merged) — restored fresh-fork shape by re-commenting the schedule.

## Architecture

```
                                  ┌──────────────────────────────┐
   Mon 07:00 UTC ─────────────────│ apple-shipkit                │
   bootstrap-doctor-matrix.yml    │  bootstrap-doctor-matrix.yml │  read-only
                                  └──────────────────────────────┘  doctor sweep
                                            │
                                            │ 2h gap (allow upstream regression
                                            │  to surface before downstream ships)
                                            ▼
   Mon 09:00 UTC ─────────────────┌──────────────────────────────┐
   canary-trigger.yml             │ apple-shipkit                │
                                  │  canary-trigger.yml          │  ← dispatcher
                                  └──────────────────────────────┘
                                            │
                                            │ gh workflow run release.yml
                                            ▼
                                  ┌──────────────────────────────┐
                                  │ indiagrams/ios-macos-smoketest│  ← real shipper
                                  │  release.yml                 │  builds, signs,
                                  │                              │  uploads to TF
                                  └──────────────────────────────┘
                                            │
                                            │ canary-trigger polls
                                            │ + inherits conclusion
                                            ▼
                                  apple-shipkit Actions tab
                                  (red if smoketest's release went red)
```

## Required follow-up

This PR introduces a new secret requirement on this repo:

**`SMOKETEST_DISPATCH_PAT`** — fine-grained PAT scoped to `indiagrams/ios-macos-smoketest` with `Actions: Read and write` only.

Until that's set, scheduled runs fail at the first step with a clear error. Manual dispatches do too. The workflow body has a `Verify dispatch PAT is set` step that exits 1 with usage instructions if the secret is missing.

## Validation

- `actionlint` clean on `canary-trigger.yml` (`exit=0`)
- `release.yml` parses (pre-existing shellcheck warning on the Xcode picker is unrelated)
- E2E test plan after merge (gated on PAT availability):
  1. Set `SMOKETEST_DISPATCH_PAT` on this repo
  2. `gh workflow run canary-trigger.yml -R indiagrams/apple-shipkit -F dry_run=true`
  3. Confirm a smoketest `release.yml` run starts within 60s
  4. Confirm the canary-trigger run inherits the dispatched run's conclusion

## Why dry_run was added as a workflow_dispatch input

Lets the maintainer fire a no-upload smoke test on demand without burning a TestFlight build number. The cron path always uses `dry_run=false`.
