### PR TITLE
chore(ci): gate apple-shipkit-specific workflows on github.repository

### DIFF
--- a/.github/workflows/bootstrap-doctor-matrix.yml
+++ b/.github/workflows/bootstrap-doctor-matrix.yml
@@ -39,6 +39,11 @@ permissions:
 
 jobs:
   doctor:
+    # Skip on forks: this workflow references indiagrams/ios-macos-smoketest
+    # by hardcoded path and uses secrets configured only on this repo. On any
+    # other repo it would fail at the secrets-write step or produce meaningless
+    # results. Skipped runs surface as a single grey check, not red errors.
+    if: github.repository == 'indiagrams/apple-shipkit'
     runs-on: macos-15
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/canary-trigger.yml
+++ b/.github/workflows/canary-trigger.yml
@@ -40,6 +40,12 @@ concurrency:
 
 jobs:
   dispatch:
+    # Skip on forks: this workflow dispatches release.yml on
+    # indiagrams/ios-macos-smoketest using SMOKETEST_DISPATCH_PAT — both
+    # specific to this repo. Forks have neither the target repo permissions
+    # nor the secret, so a fork run would fail at the PAT-verify step.
+    # Skipped runs surface as a single grey check, not red errors.
+    if: github.repository == 'indiagrams/apple-shipkit'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 


### PR DESCRIPTION
## What
One-line fork guard on each of:
- `.github/workflows/bootstrap-doctor-matrix.yml`
- `.github/workflows/canary-trigger.yml`

```yaml
jobs:
  doctor:    # or: dispatch:
    if: github.repository == 'indiagrams/apple-shipkit'
    ...
```

## Why
Both workflows hardcode `indiagrams/ios-macos-smoketest` as the target and depend on secrets (`SMOKETEST_DISPATCH_PAT`, the 7 Apple secrets) configured only on this repo. Forks inherit the workflow files but can't meaningfully run them.

GitHub's default policy disables Actions + scheduled triggers on new forks, which protects most forkers — but a forker who enables both would see broken red runs on their Actions tab. Gating at the job level converts that into a clean "Skipped" check.

## Not gated (intentional)
- `release.yml` — this IS the canonical example forks should use. Its schedule is commented out and it self-protects via the `secrets:` requirement (clean failure when not set).
- `pr.yml`, `verify-rename.yml` — generic, useful on forks.

## Validation
- `YAML.load_file` confirms `jobs.doctor.if` and `jobs.dispatch.if` parsed correctly to the literal string check
- `actionlint` clean on both files
- E2E re-verify on this repo planned post-merge: `gh workflow run canary-trigger.yml -F dry_run=true` to confirm the guard doesn't break the happy path on `indiagrams/apple-shipkit`.
