### PR TITLE
chore: rewrite release.yml UNCOMMENT block to canonical A/B text

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,14 @@ on:
         required: false
         type: boolean
         default: false
-  # UNCOMMENT after configuring all 7 GH Secrets above. Until then, manual
-  # workflow_dispatch is the only trigger; cron runs would fail with clear
-  # "secret not set" errors that are noisy on your Actions tab.
+  # workflow_dispatch only by default. Two ways to enable weekly releases:
+  #   A. Self-schedule: configure all 7 GH Secrets above and uncomment the
+  #      schedule block below. Until secrets are set, cron runs would fail
+  #      noisily with "secret not set" errors on your Actions tab.
+  #   B. Upstream canary dispatcher: rely on apple-shipkit's canary-trigger.yml
+  #      (which dispatches this workflow weekly against the
+  #      indiagrams/ios-macos-smoketest fork) and leave the block below
+  #      commented out. This is the path the smoketest itself uses.
   # schedule:
   #   - cron: '0 9 * * 1'   # Mondays 09:00 UTC
 


### PR DESCRIPTION
## What
Rewrites the `# UNCOMMENT after configuring secrets...` comment block to a clearer A/B note explaining the two paths a forker can take.

## Why
The previous text described only path A (self-schedule). Since adding `canary-trigger.yml` (#59), there's a second supported path (B): rely on upstream's canary dispatcher.

This PR also pairs with `indiagrams/ios-macos-smoketest#11`, which copies this updated `release.yml` verbatim into the smoketest. Net effect: the two `release.yml` files become byte-for-byte identical.

## Behavior
None changed. Comment-only.

## Validation
- `actionlint` exit 0 (the pre-existing SC2012 note on the Xcode picker is unrelated)
- `YAML.load_file` parses cleanly
- `diff -q` between this file and the smoketest's pair-PR copy: silent (identical)
