### PR TITLE
feat(canary): test both xcodegen + tuist every Monday

### DIFF
--- a/.github/workflows/canary-trigger.yml
+++ b/.github/workflows/canary-trigger.yml
@@ -48,12 +48,27 @@ jobs:
     if: github.repository == 'indiagrams/apple-shipkit'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      # Run both generators every Monday so distribution-signing regressions
+      # specific to one generator surface here. fail-fast=false ensures the
+      # tuist cell still runs if xcodegen fails (or vice versa) — useful when
+      # one cell breaks and you want to know if the other does too.
+      # max-parallel=1 forces sequential dispatch so the timestamp-based
+      # locate step in each cell finds an unambiguous "dispatched-after-our-baseline"
+      # run. The dispatched release.yml's concurrency:group:release would
+      # serialize anyway, but explicit serialization keeps the trigger logic
+      # simpler.
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        generator: [xcodegen, tuist]
 
     env:
       TARGET_REPO: indiagrams/ios-macos-smoketest
       TARGET_WORKFLOW: release.yml
       TARGET_REF: main
       GH_TOKEN: ${{ secrets.SMOKETEST_DISPATCH_PAT }}
+      GENERATOR: ${{ matrix.generator }}
 
     steps:
       - name: Verify dispatch PAT is set
@@ -76,16 +91,17 @@ jobs:
           echo "baseline=${baseline}" >> "${GITHUB_OUTPUT}"
           echo "Baseline (only runs created after this count): ${baseline}"
 
-      - name: Dispatch smoketest release
+      - name: Dispatch smoketest release (${{ matrix.generator }})
         run: |
           dry_run='${{ inputs.dry_run }}'
           dry_run="${dry_run:-false}"
-          echo "Dispatching ${TARGET_REPO} ${TARGET_WORKFLOW} on ref=${TARGET_REF} dry_run=${dry_run}"
+          echo "Dispatching ${TARGET_REPO} ${TARGET_WORKFLOW} on ref=${TARGET_REF} dry_run=${dry_run} generator=${GENERATOR}"
           gh workflow run "${TARGET_WORKFLOW}" \
             --repo "${TARGET_REPO}" \
             --ref "${TARGET_REF}" \
             -f version='' \
-            -f "dry_run=${dry_run}"
+            -f "dry_run=${dry_run}" \
+            -f "generator=${GENERATOR}"
 
       - name: Locate the dispatched run
         id: locate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ on:
         required: false
         type: boolean
         default: false
+      generator:
+        description: 'Generator override (xcodegen | tuist | empty for repo default). Used by canary-trigger to exercise both generators against the same Apple identity.'
+        required: false
+        type: string
+        default: ''
   # workflow_dispatch only by default. Two ways to enable weekly releases:
   #   A. Self-schedule: configure all 7 GH Secrets above and uncomment the
   #      schedule block below. Until secrets are set, cron runs would fail
@@ -110,6 +115,47 @@ jobs:
           ruby-version: '3.3'
           # bundler-cache restores vendor/bundle keyed on Gemfile.lock SHA.
           bundler-cache: true
+
+      - name: Apply generator override (if requested)
+        # When workflow_dispatch supplies a `generator` input that differs from
+        # the repo's current generator (detected via app/project.yml presence),
+        # mutate the workspace BEFORE `make bootstrap` so the project gets
+        # generated with the requested tool. This is a workspace-only mutation
+        # — nothing is pushed back. Lets canary-trigger.yml exercise both
+        # generators against the same Apple identity without maintaining
+        # parallel branches.
+        #
+        # Empty input → no-op (preserves manual `make ship` behavior).
+        if: inputs.generator != ''
+        env:
+          REQUESTED_GENERATOR: ${{ inputs.generator }}
+        run: |
+          set -euo pipefail
+          case "$REQUESTED_GENERATOR" in
+            xcodegen)
+              if [ -f app/project.yml ]; then
+                echo "Repo is already in xcodegen shape (app/project.yml present); no-op."
+              else
+                echo "::error::generator=xcodegen requested but repo is in tuist shape." \
+                  "No bin/switch-to-xcodegen.sh exists. To run with xcodegen, the repo" \
+                  "must already be xcodegen-shaped on the dispatched ref."
+                exit 1
+              fi
+              ;;
+            tuist)
+              if [ -f app/project.yml ]; then
+                echo "Switching workspace to tuist via bin/switch-to-tuist.sh"
+                ./bin/switch-to-tuist.sh
+              else
+                echo "Repo is already in tuist shape (no app/project.yml); no-op."
+              fi
+              ;;
+            *)
+              echo "::error::Invalid generator='$REQUESTED_GENERATOR'." \
+                "Must be 'xcodegen', 'tuist', or empty."
+              exit 1
+              ;;
+          esac
 
       - name: Bootstrap toolchain (xcodegen via Homebrew)
         run: make bootstrap


### PR DESCRIPTION
## What
- `release.yml`: adds `generator` workflow_dispatch input. Empty = no-op (preserves manual `make ship` behavior). `tuist` triggers `bin/switch-to-tuist.sh` BEFORE `make bootstrap` so the project is generated with tuist instead of xcodegen.
- `canary-trigger.yml`: converts single dispatch job → matrix on `generator: [xcodegen, tuist]` with `max-parallel: 1` and `fail-fast: false`.

## Why
The canary at 09:00 UTC was only exercising the smoketest's default config (`xcodegen + ci`). Tuist-specific distribution-signing regressions slipped through. This closes that gap: every Monday now tests both generators against the same Apple identity, sequentially.

## Per-Monday cost
- Wall time: ~14m (2× 7m sequential ships)
- TestFlight build numbers: 2 (one per generator)
- macos-15 runner minutes: ~14m
- Apple cert quota: unchanged (same identity reused)

## Implementation tradeoff
The "switch to tuist for one run" is a **workspace-only mutation** — `bin/switch-to-tuist.sh` rewrites Makefile/Brewfile/ci/local-check.sh/etc. inside the runner's checkout but never pushes back. The smoketest's `main` stays in xcodegen shape. Alternative architectures considered:

| Approach | Cost | Drawback |
|---|---|---|
| Workspace mutation (this PR) | ~14m wall | switch-to-tuist must be reliable; no inverse script for the reverse case |
| Two branches (`main` xcodegen, `tuist` branch) | maintenance of dual branches | constant sync drift |
| Two smoketest forks | duplicate ASC app + bundle ID + certs | high overhead |

Workspace mutation is the cheapest viable option.

## Edge cases handled in `Apply generator override`
- `generator=''` (empty default) → no-op
- `generator=xcodegen` + repo currently xcodegen → no-op
- `generator=xcodegen` + repo currently tuist → ERROR (no inverse script exists)
- `generator=tuist` + repo currently xcodegen → run `bin/switch-to-tuist.sh`
- `generator=tuist` + repo currently tuist → no-op (idempotent)
- `generator=invalid` → ERROR

## Pair with
`indiagrams/ios-macos-smoketest#12` — release.yml synced verbatim (byte-equivalence invariant maintained).

## Validation
- `actionlint` clean on canary-trigger.yml; release.yml has only the pre-existing SC2012 warning on the Xcode picker
- `YAML.load_file` confirms inputs and matrix strategy parsed correctly
- E2E test plan after merge: `gh workflow run canary-trigger.yml -F dry_run=true` — confirms both cells dispatch and inherit success.
