### PR TITLE
fix(release): install tuist before switch-to-tuist in generator override

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,12 @@ jobs:
               ;;
             tuist)
               if [ -f app/project.yml ]; then
+                # bin/switch-to-tuist.sh's preflight requires tuist on PATH.
+                # `make bootstrap` would install it via Brewfile, but that runs
+                # AFTER this step. Install eagerly here; brew is idempotent so
+                # the later `make bootstrap` will skip the redundant install.
+                echo "Installing tuist (required by switch-to-tuist.sh preflight)"
+                brew install --cask tuist
                 echo "Switching workspace to tuist via bin/switch-to-tuist.sh"
                 ./bin/switch-to-tuist.sh
               else


### PR DESCRIPTION
Caught by e2e on #62. switch-to-tuist.sh preflight needs tuist on PATH; `make bootstrap` runs later. Install via `brew install --cask tuist` inline. Pairs with smoketest sync PR.