### PR TITLE
feat: PLATFORMS pipeline gating (PR 2/3)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,10 +12,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Reads .bootstrap.env's PLATFORMS field (defaults to 'ios,macos' if unset).
+  # Subsequent jobs gate themselves on the resulting outputs so iOS-only forks
+  # don't waste runner minutes on macOS builds, etc.
+  config:
+    name: read .bootstrap.env
+    runs-on: ubuntu-latest
+    outputs:
+      do_ios:   ${{ steps.parse.outputs.do_ios }}
+      do_macos: ${{ steps.parse.outputs.do_macos }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: parse
+        run: |
+          set -euo pipefail
+          # Default PLATFORMS=ios,macos if not present in .bootstrap.env
+          # (e.g. the upstream apple-shipkit template itself, which has no
+          # .bootstrap.env on main).
+          if [ -f .bootstrap.env ]; then
+            platforms=$(awk -F= '/^PLATFORMS[[:space:]]*=/ { gsub(/^[[:space:]"'\'']+|[[:space:]"'\'']+$/, "", $2); print $2; exit }' .bootstrap.env)
+          else
+            platforms=""
+          fi
+          [ -z "$platforms" ] && platforms="ios,macos"
+          echo "Resolved PLATFORMS=$platforms"
+          echo "do_ios=$(echo "$platforms" | grep -qw 'ios'   && echo true || echo false)"   >> "$GITHUB_OUTPUT"
+          echo "do_macos=$(echo "$platforms" | grep -qw 'macos' && echo true || echo false)" >> "$GITHUB_OUTPUT"
   # iOS device build is the primary signal — it uses the iphoneos SDK and the
   # real entitlements pathway. Catches bugs the Simulator doesn't (SDK header
   # drift, missing device-only APIs, wrong xcframework slice, etc.).
   app-ios-device:
+    needs: config
+    if: needs.config.outputs.do_ios == 'true'
     name: app (iOS device)
     runs-on: macos-15
     timeout-minutes: 30
@@ -45,6 +73,8 @@ jobs:
 
   # iOS Simulator — backup signal (different SDK + xcframework slice).
   app-ios-sim:
+    needs: config
+    if: needs.config.outputs.do_ios == 'true'
     name: app (iOS Simulator)
     runs-on: macos-15
     timeout-minutes: 30
@@ -73,6 +103,8 @@ jobs:
             2>&1 | xcbeautify --renderer github-actions
 
   app-macos:
+    needs: config
+    if: needs.config.outputs.do_macos == 'true'
     name: app (macOS)
     runs-on: macos-15
     timeout-minutes: 30
@@ -108,6 +140,8 @@ jobs:
   # commands as the XcodeGen jobs above. Keeps both manifests in sync
   # on every PR — drift fails CI immediately.
   app-tuist-ios-device:
+    needs: config
+    if: needs.config.outputs.do_ios == 'true'
     name: app (Tuist iOS device)
     runs-on: macos-15
     timeout-minutes: 30
@@ -141,6 +175,8 @@ jobs:
             2>&1 | xcbeautify --renderer github-actions
 
   app-tuist-ios-sim:
+    needs: config
+    if: needs.config.outputs.do_ios == 'true'
     name: app (Tuist iOS Simulator)
     runs-on: macos-15
     timeout-minutes: 30
@@ -174,6 +210,8 @@ jobs:
             2>&1 | xcbeautify --renderer github-actions
 
   app-tuist-macos:
+    needs: config
+    if: needs.config.outputs.do_macos == 'true'
     name: app (Tuist macOS)
     runs-on: macos-15
     timeout-minutes: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,11 @@ on:
         required: false
         type: string
         default: ''
+      platforms:
+        description: 'Platforms to ship (comma-separated subset of ios,macos). Empty = use repo default. Mirrors .bootstrap.env PLATFORMS.'
+        required: false
+        type: string
+        default: ''
   # workflow_dispatch only by default. Two ways to enable weekly releases:
   #   A. Self-schedule: configure all 7 GH Secrets above and uncomment the
   #      schedule block below. Until secrets are set, cron runs would fail
@@ -204,6 +209,9 @@ jobs:
           # per ASC upload — required when CFBundleShortVersionString repeats
           # (e.g. two cron runs in the same ISO week, or manual re-dispatch).
           RELEASE_BUILD_NUMBER: ${{ github.run_number }}
+          # PLATFORMS gates which targets the release lane builds + uploads.
+          # Empty input → fastlane defaults to 'ios,macos' (current behavior).
+          PLATFORMS: ${{ inputs.platforms }}
         # dry_run is workflow_dispatch-only (cron runs always go full path).
         # When true: build + sign succeed, pilot upload + tag push are skipped.
         # The release lane reads skip_upload / skip_tag from its options hash.

--- a/bin/setup-github.sh
+++ b/bin/setup-github.sh
@@ -77,21 +77,41 @@ ok "squash-only merge, auto-delete head branches, auto-merge enabled"
 
 step "Branch protection on main"
 
-# Use a heredoc JSON body — gh api -F doesn't gracefully nest the required_status_checks
-# array of objects. Required check names must match the job 'name:' attributes
-# in .github/workflows/pr.yml.
-PROTECTION_JSON=$(cat <<'JSON'
+# Derive the required-checks list from .bootstrap.env's PLATFORMS field.
+# Defaults to 'ios,macos' if the file or field is absent. The PR workflow
+# (.github/workflows/pr.yml) only runs the iOS jobs when do_ios=true and
+# the macOS jobs when do_macos=true, so the required checks must match.
+PLATFORMS_VAL=""
+if [ -f "$REPO_ROOT/.bootstrap.env" ]; then
+  PLATFORMS_VAL=$(awk -F= '/^PLATFORMS[[:space:]]*=/ { gsub(/^[[:space:]"\047]+|[[:space:]"\047]+$/, "", $2); print $2; exit }' "$REPO_ROOT/.bootstrap.env")
+fi
+[ -z "$PLATFORMS_VAL" ] && PLATFORMS_VAL="ios,macos"
+
+CHECKS=()
+if echo "$PLATFORMS_VAL" | grep -qw 'ios'; then
+  CHECKS+=( "app (iOS device)" "app (iOS Simulator)" "app (Tuist iOS device)" "app (Tuist iOS Simulator)" )
+fi
+if echo "$PLATFORMS_VAL" | grep -qw 'macos'; then
+  CHECKS+=( "app (macOS)" "app (Tuist macOS)" )
+fi
+
+if [ ${#CHECKS[@]} -eq 0 ]; then
+  echo "ERROR: PLATFORMS=$PLATFORMS_VAL produced no required checks. Must include 'ios', 'macos', or both." >&2
+  exit 1
+fi
+
+echo "  → required CI checks (PLATFORMS=$PLATFORMS_VAL):"
+for c in "${CHECKS[@]}"; do echo "    - $c"; done
+
+# Build the JSON checks array from $CHECKS. printf %s\\n + jq -Rs build the
+# array — keeps it simple without arity-counting.
+CHECKS_JSON=$(printf '%s\n' "${CHECKS[@]}" | jq -R '{context: .}' | jq -s '.')
+
+PROTECTION_JSON=$(cat <<JSON
 {
   "required_status_checks": {
     "strict": true,
-    "checks": [
-      { "context": "app (iOS device)" },
-      { "context": "app (iOS Simulator)" },
-      { "context": "app (macOS)" },
-      { "context": "app (Tuist iOS device)" },
-      { "context": "app (Tuist iOS Simulator)" },
-      { "context": "app (Tuist macOS)" }
-    ]
+    "checks": $CHECKS_JSON
   },
   "enforce_admins": true,
   "required_pull_request_reviews": {

--- a/bin/ship.rb
+++ b/bin/ship.rb
@@ -36,7 +36,7 @@ force   = ARGV.include?("--force")
 if config.local_mode?
   tag = "v#{Time.now.utc.strftime('%Y.%V.%H%M')}"
   puts Bootstrap::UI.bold("Running fastlane release locally — tag #{tag}")
-  env = Bootstrap.asc_env(config)
+  env = Bootstrap.asc_env(config).merge("PLATFORMS" => config.platforms.join(","))
   args = ["bundle", "exec", "fastlane", "release", "tag:#{tag}"]
   args << "skip_upload:true" if dry_run == "true"
 
@@ -77,10 +77,12 @@ def head_already_tagged?(repo)
   match ? [match["name"], head_sha] : nil
 end
 
-def trigger_new_run(repo, dry_run)
-  puts Bootstrap::UI.bold("Triggering release.yml on #{repo} (dry_run=#{dry_run})…")
+def trigger_new_run(repo, dry_run, platforms)
+  puts Bootstrap::UI.bold("Triggering release.yml on #{repo} (dry_run=#{dry_run}, platforms=#{platforms})…")
   out, ok = Bootstrap::Sh.run("gh", "workflow", "run", "release.yml", "--ref", "main",
-                              "-f", "dry_run=#{dry_run}", "--repo", repo)
+                              "-f", "dry_run=#{dry_run}",
+                              "-f", "platforms=#{platforms}",
+                              "--repo", repo)
   Bootstrap::UI.fail!("gh workflow run failed:\n#{out}") unless ok
 
   sleep 5
@@ -113,7 +115,7 @@ unless force
   end
 end
 
-run_id ||= trigger_new_run(repo, dry_run)
+run_id ||= trigger_new_run(repo, dry_run, config.platforms.join(","))
 run_url = "https://github.com/#{repo}/actions/runs/#{run_id}"
 puts "  → #{run_url}"
 puts

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -301,7 +301,17 @@ platform :ios do
     version   = tag.sub(/^v/, "")
     dry_run   = skip_upload || skip_tag
 
-    UI.header("Release #{tag}#{dry_run ? " [DRY RUN]" : ""}")
+    # PLATFORMS gates which targets get built/signed/uploaded.
+    # Set via .bootstrap.env's PLATFORMS field (defaults to 'ios,macos').
+    # Threaded into this lane via release.yml's `PLATFORMS` env var (CI mode)
+    # or bin/ship.rb's local-mode env (local mode). Empty/unset → both.
+    raw_platforms = (ENV["PLATFORMS"].to_s.strip.empty? ? "ios,macos" : ENV["PLATFORMS"])
+    active_platforms = raw_platforms.split(",").map(&:strip).reject(&:empty?)
+    do_ios   = active_platforms.include?("ios")
+    do_macos = active_platforms.include?("macos")
+    UI.user_error!("PLATFORMS must include at least one of 'ios' or 'macos' (got #{raw_platforms.inspect})") unless do_ios || do_macos
+
+    UI.header("Release #{tag}#{dry_run ? " [DRY RUN]" : ""} — platforms: #{active_platforms.join('+')}")
 
     # When fastlane/Matchfile exists, sync signing material from your certs
     # repo BEFORE invoking xcodebuild — this is what enables CI signing without
@@ -319,52 +329,73 @@ platform :ios do
     sh_env            = {}
 
     if matchfile_present
-      UI.message("Step 1/5: syncing signing material via match (iOS + macOS + installer)…")
-      match(type: "appstore", app_identifier: APP_IDENTIFIER, readonly: true,
-            platform: "ios", api_key: asc_api_key)
-      match(type: "appstore", app_identifier: APP_IDENTIFIER, readonly: true,
-            platform: "macos", api_key: asc_api_key)
-      # macOS .pkg requires a separate "Mac Installer Distribution" cert
-      # (productbuild signs the .pkg installer wrapper with this — distinct
-      # from the Apple Distribution cert that signs the .app inside).
-      match(type: "mac_installer_distribution", app_identifier: APP_IDENTIFIER,
-            readonly: true, platform: "macos", skip_provisioning_profiles: true,
-            api_key: asc_api_key)
+      bits = []
+      bits << "iOS"               if do_ios
+      bits << "macOS"             if do_macos
+      bits << "macOS installer"   if do_macos
+      UI.message("Step 1/5: syncing signing material via match (#{bits.join(' + ')})…")
+      if do_ios
+        match(type: "appstore", app_identifier: APP_IDENTIFIER, readonly: true,
+              platform: "ios", api_key: asc_api_key)
+      end
+      if do_macos
+        match(type: "appstore", app_identifier: APP_IDENTIFIER, readonly: true,
+              platform: "macos", api_key: asc_api_key)
+        # macOS .pkg requires a separate "Mac Installer Distribution" cert
+        # (productbuild signs the .pkg installer wrapper with this — distinct
+        # from the Apple Distribution cert that signs the .app inside).
+        match(type: "mac_installer_distribution", app_identifier: APP_IDENTIFIER,
+              readonly: true, platform: "macos", skip_provisioning_profiles: true,
+              api_key: asc_api_key)
+      end
 
       # match's profile names include a timestamp suffix per generation
       # (e.g. "match AppStore com.example.helloapp 1778027568") — read from
       # the env vars match emits at runtime; do NOT hardcode.
-      ios_profile_name   = ENV["sigh_#{APP_IDENTIFIER}_appstore_profile-name"]
-      macos_profile_name = ENV["sigh_#{APP_IDENTIFIER}_appstore_macos_profile-name"]
-      UI.user_error!("match didn't set sigh_#{APP_IDENTIFIER}_appstore_profile-name — did the iOS match call run?") unless ios_profile_name
-      UI.user_error!("match didn't set sigh_#{APP_IDENTIFIER}_appstore_macos_profile-name — did the macOS match call run?") unless macos_profile_name
-      sh_env = {
-        "RELEASE_IOS_PROFILE_NAME"   => ios_profile_name,
-        "RELEASE_MACOS_PROFILE_NAME" => macos_profile_name,
-        "RELEASE_BUNDLE_ID"          => APP_IDENTIFIER,
-      }
+      sh_env = { "RELEASE_BUNDLE_ID" => APP_IDENTIFIER }
+      if do_ios
+        ios_profile_name = ENV["sigh_#{APP_IDENTIFIER}_appstore_profile-name"]
+        UI.user_error!("match didn't set sigh_#{APP_IDENTIFIER}_appstore_profile-name — did the iOS match call run?") unless ios_profile_name
+        sh_env["RELEASE_IOS_PROFILE_NAME"] = ios_profile_name
+      end
+      if do_macos
+        macos_profile_name = ENV["sigh_#{APP_IDENTIFIER}_appstore_macos_profile-name"]
+        UI.user_error!("match didn't set sigh_#{APP_IDENTIFIER}_appstore_macos_profile-name — did the macOS match call run?") unless macos_profile_name
+        sh_env["RELEASE_MACOS_PROFILE_NAME"] = macos_profile_name
+      end
     else
       UI.message("Step 1/5: no fastlane/Matchfile — skipping match sync. Using local Xcode-managed signing.")
     end
 
-    UI.message("Step 2/5: building signed iOS .ipa + macOS .pkg for v#{version}…")
-    sh(sh_env, "cd #{repo_root} && ci/local-release-check.sh #{tag} --sign-ios --sign-macos")
+    sign_flags = []
+    sign_flags << "--sign-ios"   if do_ios
+    sign_flags << "--sign-macos" if do_macos
+    UI.message("Step 2/5: building signed artifacts (#{sign_flags.join(' ')}) for v#{version}…")
+    sh(sh_env, "cd #{repo_root} && ci/local-release-check.sh #{tag} #{sign_flags.join(' ')}")
 
     ipa_path = File.join(repo_root, "build", IPA_NAME_PATTERN % version)
     pkg_path = File.join(repo_root, "build", PKG_NAME_PATTERN % version)
-    UI.user_error!("IPA missing at #{ipa_path}") unless File.exist?(ipa_path)
-    UI.user_error!("pkg missing at #{pkg_path}") unless File.exist?(pkg_path)
+    if do_ios
+      UI.user_error!("IPA missing at #{ipa_path}") unless File.exist?(ipa_path)
+    end
+    if do_macos
+      UI.user_error!("pkg missing at #{pkg_path}") unless File.exist?(pkg_path)
+    end
 
     api_key = asc_api_key
 
     if skip_upload
-      UI.important("Step 3/5: Skipping iOS TestFlight upload (skip_upload:true)")
-      UI.important("Step 4/5: Skipping macOS TestFlight upload (skip_upload:true)")
+      UI.important("Step 3/5: Skipping iOS TestFlight upload (skip_upload:true)")  if do_ios
+      UI.important("Step 4/5: Skipping macOS TestFlight upload (skip_upload:true)") if do_macos
     else
-      UI.message("Step 3/5: Uploading iOS .ipa to TestFlight…")
-      pilot(api_key: api_key, ipa: ipa_path, skip_waiting_for_build_processing: true)
-      UI.message("Step 4/5: Uploading macOS .pkg to TestFlight…")
-      pilot(api_key: api_key, pkg: pkg_path, skip_waiting_for_build_processing: true)
+      if do_ios
+        UI.message("Step 3/5: Uploading iOS .ipa to TestFlight…")
+        pilot(api_key: api_key, ipa: ipa_path, skip_waiting_for_build_processing: true)
+      end
+      if do_macos
+        UI.message("Step 4/5: Uploading macOS .pkg to TestFlight…")
+        pilot(api_key: api_key, pkg: pkg_path, skip_waiting_for_build_processing: true)
+      end
     end
 
     if skip_tag
@@ -374,7 +405,7 @@ platform :ios do
       sh("cd #{repo_root} && git tag #{tag} && git push origin #{tag}")
     end
 
-    UI.success("#{tag} is live on TestFlight (iOS + macOS).")
+    UI.success("#{tag} is live on TestFlight (#{active_platforms.join(' + ')}).")
   end
 
   desc "Capture App Store screenshots (iOS + macOS via ci/take-screenshots.sh)"


### PR DESCRIPTION
**PR 2 of 3** — runtime gating of which platforms get built/signed/uploaded.

Builds on PR #66 (foundation: Config + Step PLATFORMS framework). This PR threads PLATFORMS through the actual release pipeline + PR build matrix + branch protection.

## Surfaces touched
- `fastlane/Fastfile` — release lane gates match calls, sign flags, uploads on do_ios/do_macos (read from ENV['PLATFORMS'])
- `.github/workflows/release.yml` — new `platforms` workflow_dispatch input → `PLATFORMS` env on fastlane step
- `bin/ship.rb` — passes platforms input to gh workflow run (CI) / merges PLATFORMS env into fastlane invocation (local)
- `.github/workflows/pr.yml` — new `config` job reads .bootstrap.env's PLATFORMS; the 6 platform-specific build jobs gate on do_ios/do_macos
- `bin/setup-github.sh` — derives required-status-checks list from .bootstrap.env (PLATFORMS=ios → 4 checks; macos → 2; both → 6)

## Backward compat
Every default path preserves current behavior. Verified locally:
- Fastfile: ENV['PLATFORMS'] empty → both
- release.yml: empty input → empty PLATFORMS env → fastlane defaults to both
- pr.yml: missing .bootstrap.env → defaults to ios,macos → all 6 jobs run
- setup-github.sh: missing .bootstrap.env → 6 checks (current behavior)

## Validation
- Ruby syntax: Fastfile + ship.rb both clean
- YAML parse: pr.yml + release.yml both clean
- Bash syntax + shellcheck: setup-github.sh clean
- actionlint: clean (existing SC2012 on Xcode picker is pre-existing)
- Manual test of setup-github.sh's bash logic: PLATFORMS=ios → 4 checks; macos → 2; ios,macos → 6

## Pair with
[smoketest sync PR](https://github.com/indiagrams/ios-macos-smoketest/pulls) — release.yml byte-equivalence invariant maintained.

## Not yet
- README + docs/BOOTSTRAP.md updates (PR 3, separate)
- E2E test via canary-trigger (will run after merge with explicit `-F platforms=ios` to verify gating fires)