### PR TITLE
docs: PLATFORMS field walkthrough + Step 6 callout (PR 3/3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,9 @@ GENERATOR=xcodegen                          # xcodegen | tuist
 # How releases run: ci = GitHub Actions builds + ships; local = your laptop ships
 RELEASE_MODE=local                          # local is easier for first-time. Switch to ci later.
 
+# Which platforms you ship: ios, macos, or both. Default 'ios,macos'.
+PLATFORMS=ios,macos                         # 'ios' or 'macos' to ship just one
+
 # Apple credentials (from Steps 3 + 4)
 FASTLANE_TEAM_ID=A1B2C3D4E5                 # from Step 3
 ASC_API_KEY_ID=ABC1234567                   # from Step 4 — Key ID
@@ -223,6 +226,8 @@ ASC_APP_NAME='My Cool App'                   # what shows on the App Store
 > **Pick BUNDLE_ID carefully.** It's the unique fingerprint of your app, and you can't change it later without losing your TestFlight history. If you own a domain, use it (`com.yourdomain.appname`). If you don't, `com.yourgithubusername.appname` is fine.
 
 > **Why two modes?** `RELEASE_MODE=local` signs from your laptop using certs in your Keychain — easy first-run, no server config needed. `RELEASE_MODE=ci` runs the full pipeline on GitHub Actions every time you push a tag — more setup, but it means you can ship from any machine. Start with `local`. You can switch later.
+
+> **Why pick a platform subset?** If you're shipping an iPhone-only app and don't care about Mac, set `PLATFORMS=ios` — `make doctor` will stop probing for the Mac Installer cert, `make ship` skips the macOS .pkg build/upload, and CI on PRs will run 4 jobs instead of 6 (saving ~2-4 min/PR of macOS runner time). Same in reverse for `PLATFORMS=macos`. Switchable later: change the value, re-run `make bootstrap-fork`.
 
 ---
 

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -51,6 +51,20 @@ The same `fastlane/Fastfile` drives both — the release lane gates the `match` 
 
 You can switch modes later by editing `RELEASE_MODE` and re-running `make bootstrap-fork`. Going `local → ci`: bootstrap will set up the certs repo + secrets. Going `ci → local`: bootstrap won't tear down the existing certs repo (you'd remove that manually); CI just stops running.
 
+
+## Platforms
+
+`.bootstrap.env` has a `PLATFORMS` field that gates which targets get built, signed, and uploaded. Three valid values:
+
+| Value | Effect |
+|---|---|
+| `ios` | Ship iPhone/iPad only. `make doctor` skips the Mac Installer cert probe + the macOS .icns regeneration. `make ship` skips the macOS .pkg build + upload. PR CI runs 4 jobs (no `app (macOS)` / `app (Tuist macOS)`). Branch protection requires 4 checks. |
+| `macos` | Ship Mac only. Skips iOS provisioning profile checks + iOS .ipa upload. PR CI runs 2 jobs. Branch protection requires 2 checks. |
+| `ios,macos` | Default. Ships both, current behavior. |
+
+Switchable later: change the value in `.bootstrap.env`, re-run `make bootstrap-fork`, and the relevant pieces of the pipeline (de)activate. No tree mutation; the unused-platform code stays in the repo, just inert. (If you want a *clean tree* with the unused platform's files deleted, that's a different choice — delete `app/iOS/` or `app/macOS/` manually + adjust the relevant scheme references; the template doesn't ship a one-shot strip script for this.)
+
+Default: if `PLATFORMS` is unset or empty in `.bootstrap.env`, the bootstrap pipeline treats it as `ios,macos`. Forks created before this field existed (or forks that never edit it) preserve their existing both-platforms behavior.
 ## Config reference
 
 `.bootstrap.env` is gitignored. Its values are mostly non-secret config
@@ -78,6 +92,7 @@ actual secret bytes. The dotenv itself is low-blast-radius.
 | `ICON_1024_PATH` (optional) | Path to your 1024×1024 PNG. If set, replaces the template hammer icon and runs `make icons` | Designer artifact |
 | `ASC_APP_SKU` (optional) | Documentation hint for the manual ASC App creation step | Any unique string |
 | `ASC_APP_NAME` (optional) | Documentation hint — defaults to `DISPLAY_NAME` | The human-readable name you want shown in the App Store |
+| `PLATFORMS` (optional) | Subset of `ios,macos` that controls which targets ship. Defaults to both if unset. See [Platforms](#platforms) above | You decide |
 
 ## What `make bootstrap-fork` does
 


### PR DESCRIPTION
**PR 3 of 3** — closes the PLATFORMS feature work.

- PR #66 ✅ Config + Step framework
- PR #67 ✅ Pipeline gating (Fastfile, release.yml, pr.yml, setup-github.sh)
- **This PR**: README + BOOTSTRAP.md docs

## What
- README Step 6 walkthrough adds `PLATFORMS=ios,macos` line + 'Why pick a platform subset?' callout
- docs/BOOTSTRAP.md gets a 'Platforms' section + PLATFORMS row in the config-reference table

## No code changes