### PR TITLE
feat: bin/switch-to-xcodegen.sh — inverse of switch-to-tuist.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,10 +141,19 @@ jobs:
               if [ -f app/project.yml ]; then
                 echo "Repo is already in xcodegen shape (app/project.yml present); no-op."
               else
-                echo "::error::generator=xcodegen requested but repo is in tuist shape." \
-                  "No bin/switch-to-xcodegen.sh exists. To run with xcodegen, the repo" \
-                  "must already be xcodegen-shaped on the dispatched ref."
-                exit 1
+                if [ -x ./bin/switch-to-xcodegen.sh ]; then
+                  # bin/switch-to-xcodegen.sh's preflight requires xcodegen on PATH.
+                  # `make bootstrap` would install it via Brewfile, but that runs
+                  # AFTER this step. Install eagerly here; brew is idempotent.
+                  echo "Installing xcodegen (required by switch-to-xcodegen.sh preflight)"
+                  brew install xcodegen
+                  echo "Switching workspace to xcodegen via bin/switch-to-xcodegen.sh"
+                  ./bin/switch-to-xcodegen.sh
+                else
+                  echo "::error::generator=xcodegen requested but repo is in tuist shape" \
+                    "and bin/switch-to-xcodegen.sh is not available on the dispatched ref."
+                  exit 1
+                fi
               fi
               ;;
             tuist)

--- a/bin/switch-to-tuist.sh
+++ b/bin/switch-to-tuist.sh
@@ -18,10 +18,9 @@
 #        stays compatible with the XcodeGen one on every PR.
 #
 #   Factoring the surgery out of bin/rename.sh into a standalone script
-#   keeps both call-sites testable in isolation. The
-#   `--generator=xcodegen` direction (the default) does nothing — no
-#   matching switch-to-xcodegen.sh exists yet because no audience for
-#   that direction has surfaced.
+#   keeps both call-sites testable in isolation. The inverse direction
+#   is bin/switch-to-xcodegen.sh (added later for the canary-trigger
+#   `generator=xcodegen` override against tuist-permanent forks).
 #
 # Usage:
 #   bin/switch-to-tuist.sh                       # apply the switch

--- a/bin/switch-to-xcodegen.sh
+++ b/bin/switch-to-xcodegen.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+# bin/switch-to-xcodegen.sh — convert a fork from Tuist back to XcodeGen.
+#
+# Inverse of bin/switch-to-tuist.sh. Restores app/project.yml from git
+# history (the most recent commit that contained it) and reverses the
+# Brewfile / Makefile / ci/* / .github/workflows/pr.yml mutations
+# switch-to-tuist.sh applied.
+#
+# Two callers (mirroring switch-to-tuist.sh):
+#   1. A maintainer who switched to Tuist and now wants to switch back.
+#      `bin/switch-to-xcodegen.sh` from the repo root applies the inverse.
+#   2. The release.yml `Apply generator override` step on a tuist-shaped
+#      fork that's dispatched with `generator=xcodegen` — the canary path
+#      for testing the xcodegen pipeline against a tuist-permanent fork.
+#
+# Usage:
+#   bin/switch-to-xcodegen.sh                       # apply the switch
+#   bin/switch-to-xcodegen.sh --dry-run             # preview without modifying
+#   bin/switch-to-xcodegen.sh --force               # bypass clean-tree + on-main gates
+#   bin/switch-to-xcodegen.sh -h | --help           # print this header
+#
+# Pre-flight gates (canonical order; mirrors switch-to-tuist.sh):
+#   1. `xcodegen` on PATH (fail with install hint)
+#   2. `app/Project.swift` present (else: PR #1 not landed)
+#   3. `app/project.yml` exists somewhere in git history (else: this fork
+#       was never xcodegen-shaped — restore manually from upstream)
+#   4. Idempotency dispatch:
+#        case 0 = already-xcodegen (silent exit 0)
+#        case 1 = partial state (fail unless --force)
+#        case 2 = pre-switch state (proceed)
+#   5. Working tree clean (override via --force)
+#   6. On `main` branch (override via --force)
+#
+# Atomic rollback (parity with switch-to-tuist.sh):
+#   Pre-flight Gate 5 (clean tree) ensures HEAD == working tree
+#   pre-mutation. Any failure during the mutation phase triggers an
+#   ERR/EXIT/INT/TERM trap that runs `git reset --hard HEAD` +
+#   `git clean -fd` (NOT -fdx — forker's .env.local is precious).
+#   MUTATION_STARTED guards the destructive-op path.
+#
+# Idempotency:
+#   Re-running on an already-xcodegen tree (project.yml present +
+#   Brewfile has `brew "xcodegen"`) is a silent exit 0 — no stdout,
+#   no rollback, no side effects.
+#
+# Constraints (parity with switch-to-tuist.sh):
+#   - bash 3.2+ (macOS default); no bash 4+ features
+#   - BSD-portable sed (sed -i '', | delimiter)
+#   - No new external dependencies (git, bash, sed, awk, find)
+
+set -euo pipefail
+
+step() { printf '\n==> %s\n' "$*"; }
+ok()   { printf '    ✓ %s\n' "$*"; }
+fail() { printf '    ✗ %s\n' "$*" >&2; exit 1; }
+
+print_usage() {
+  sed -n '2,/^set -euo pipefail$/{ /^set -euo pipefail$/!p; }' "$0" | sed 's/^# \{0,1\}//'
+}
+
+# ── Argument parsing ──────────────────────────────────────────────────────
+DRY_RUN=0
+FORCE=0
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help) print_usage; exit 0 ;;
+    --dry-run) DRY_RUN=1 ;;
+    --force)   FORCE=1 ;;
+    *) fail "unknown flag '$arg' — run with -h for usage" ;;
+  esac
+done
+
+# ── Resolve repo root ─────────────────────────────────────────────────────
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT" || fail "could not cd to repo root ($REPO_ROOT)"
+
+# ── Mutation guard for the rollback trap ──────────────────────────────────
+ROLLBACK_DONE=0
+MUTATION_STARTED=0
+
+rollback() {
+  [ "$ROLLBACK_DONE" = "1" ] && return 0
+  ROLLBACK_DONE=1
+
+  [ "$MUTATION_STARTED" = "1" ] || return 0
+
+  printf '    ✗ rolling back to pre-switch state...\n' >&2
+  if git reset --hard HEAD --quiet 2>/dev/null; then
+    git clean -fd --quiet 2>/dev/null || true
+    printf '    ✗ rolled back to pre-switch state.\n' >&2
+  else
+    printf '    ✗ git reset --hard HEAD failed; manual recovery required.\n' >&2
+    printf '    ✗ inspect: git status; git log --oneline -5\n' >&2
+  fi
+}
+
+trap 'rollback' ERR
+trap 'rollback' INT TERM
+trap 'rollback' EXIT
+
+# ── Idempotency dispatch ──────────────────────────────────────────────────
+# Returns:
+#   0 = already-xcodegen (caller silent-exits 0)
+#   1 = partial state (caller fails unless --force)
+#   2 = pre-switch (tuist) state (caller proceeds)
+check_idempotency() {
+  local has_yml=0 has_swift=0 brewfile_has_xcodegen=0
+  [ -f "app/project.yml" ] && has_yml=1
+  [ -f "app/Project.swift" ] && has_swift=1
+  if [ -f "Brewfile" ] && grep -q '^brew "xcodegen"' Brewfile 2>/dev/null; then
+    brewfile_has_xcodegen=1
+  fi
+
+  # Already-xcodegen: project.yml present, Project.swift present (template
+  # default), Brewfile has brew "xcodegen". The "pre-switch-to-tuist" /
+  # "post-switch-to-xcodegen" shape — same thing.
+  if [ "$has_yml" = "1" ] && [ "$has_swift" = "1" ] && [ "$brewfile_has_xcodegen" = "1" ]; then
+    return 0
+  fi
+
+  # Pre-switch (tuist state): project.yml absent, Project.swift present,
+  # Brewfile lacks brew "xcodegen".
+  if [ "$has_yml" = "0" ] && [ "$has_swift" = "1" ] && [ "$brewfile_has_xcodegen" = "0" ]; then
+    return 2
+  fi
+
+  # Anything else is partial state.
+  return 1
+}
+
+# ── Pre-flight gate functions ─────────────────────────────────────────────
+gate_xcodegen_present() {
+  command -v xcodegen >/dev/null 2>&1 || \
+    fail "xcodegen not found — install with 'brew install xcodegen' (or run 'make bootstrap')"
+  ok "xcodegen on PATH ($(xcodegen --version 2>/dev/null | head -1))"
+}
+
+gate_project_swift_present() {
+  [ -f "app/Project.swift" ] || \
+    fail "app/Project.swift missing — unexpected pre-switch state (was the repo ever Tuist-shaped?)"
+  [ -f "Tuist.swift" ] || \
+    fail "Tuist.swift missing — unexpected pre-switch state (was the repo ever Tuist-shaped?)"
+  ok "Tuist manifests present (Tuist.swift + app/Project.swift)"
+}
+
+# Find the most recent commit whose tree contained app/project.yml.
+# Result stored in PROJECT_YML_SHA (global) for use by the restore mutation.
+PROJECT_YML_SHA=""
+gate_project_yml_in_history() {
+  # --diff-filter=AM excludes Deletion commits — we want a SHA whose tree
+  # CONTAINS app/project.yml, not the SHA that deleted it.
+  PROJECT_YML_SHA=$(git log --all --diff-filter=AM --pretty=format:'%H' -- app/project.yml 2>/dev/null | head -1 || true)
+  if [ -z "$PROJECT_YML_SHA" ]; then
+    fail "app/project.yml not found in git history — this fork was never xcodegen-shaped.
+   Restoring manually requires fetching project.yml from indiagrams/apple-shipkit/main:
+     curl -fsSL https://raw.githubusercontent.com/indiagrams/apple-shipkit/main/app/project.yml > app/project.yml"
+  fi
+  ok "app/project.yml found in commit ${PROJECT_YML_SHA:0:8}"
+}
+
+gate_clean_tree() {
+  if [ "$FORCE" = "1" ]; then
+    ok "working-tree gate skipped (--force)"
+    return 0
+  fi
+  if [ "$(git status --short | wc -l | tr -d ' ')" != "0" ]; then
+    fail "working tree not clean — commit, stash, or remove untracked files (or pass --force)"
+  fi
+  ok "working tree clean"
+}
+
+gate_on_main() {
+  local BRANCH
+  BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  if [ "$BRANCH" != "main" ] && [ "$FORCE" != "1" ]; then
+    fail "not on main branch (currently: $BRANCH) — pass --force to override"
+  fi
+  ok "branch check: $BRANCH (force=$FORCE)"
+}
+
+# ── Mutations ─────────────────────────────────────────────────────────────
+# Each step is independently idempotent. The ordered set brings any tuist
+# tree to the xcodegen state; running again on an xcodegen tree is no-op
+# (handled at the idempotency-dispatch level, not per-step).
+
+mutate_restore_project_yml() {
+  step "Restoring app/project.yml from git history (commit ${PROJECT_YML_SHA:0:8})"
+  if [ -f "app/project.yml" ]; then
+    ok "app/project.yml already present (no restore needed)"
+    return 0
+  fi
+  git show "$PROJECT_YML_SHA:app/project.yml" > app/project.yml
+  git add app/project.yml
+  ok "app/project.yml restored from $PROJECT_YML_SHA"
+}
+
+mutate_brewfile() {
+  step "Editing Brewfile (add brew \"xcodegen\")"
+  if [ ! -f "Brewfile" ]; then
+    fail "Brewfile missing — unexpected repo state"
+  fi
+  if grep -q '^brew "xcodegen"' Brewfile; then
+    ok "Brewfile: brew \"xcodegen\" already present"
+    return 0
+  fi
+  # Insert before the cask tuist line if it exists; else append at end.
+  # Keeps the alphabetical-ish ordering switch-to-tuist.sh removed from.
+  if grep -q '^brew "--cask", "tuist"' Brewfile; then
+    # BSD sed: \n inside replacement needs to be a literal backslash-newline.
+    sed -i '' $'/^brew "--cask", "tuist"/i\\\nbrew "xcodegen"\n' Brewfile
+  else
+    printf 'brew "xcodegen"\n' >> Brewfile
+  fi
+  ok "Brewfile: brew \"xcodegen\" line added"
+}
+
+mutate_makefile() {
+  step "Editing Makefile (tuist generate --no-open → xcodegen generate)"
+  if [ ! -f "Makefile" ]; then
+    fail "Makefile missing — unexpected repo state"
+  fi
+  sed -i '' 's|cd app && tuist generate --no-open|cd app \&\& xcodegen generate|g' Makefile
+  sed -i '' 's|Regenerate HelloApp.xcodeproj from app/Project.swift|Regenerate HelloApp.xcodeproj from app/project.yml|g' Makefile
+  ok "Makefile: tuist generate --no-open → xcodegen generate"
+}
+
+mutate_local_check() {
+  step "Editing ci/local-check.sh (tuist → xcodegen)"
+  if [ ! -f "ci/local-check.sh" ]; then
+    fail "ci/local-check.sh missing — unexpected repo state"
+  fi
+  sed -i '' 's|require_cmd tuist|require_cmd xcodegen|g' ci/local-check.sh
+  sed -i '' 's|step "app: tuist generate"|step "app: xcodegen generate"|g' ci/local-check.sh
+  sed -i '' 's|( cd app && tuist generate --no-open >/dev/null )|( cd app \&\& xcodegen generate >/dev/null )|g' ci/local-check.sh
+  ok "ci/local-check.sh: tuist generate --no-open → xcodegen generate"
+}
+
+mutate_local_release_check() {
+  step "Editing ci/local-release-check.sh (tuist → xcodegen)"
+  if [ ! -f "ci/local-release-check.sh" ]; then
+    fail "ci/local-release-check.sh missing — unexpected repo state"
+  fi
+  sed -i '' 's|step "tuist generate"|step "xcodegen generate"|g' ci/local-release-check.sh
+  sed -i '' 's|( cd app && tuist generate --no-open >/dev/null )|( cd app \&\& xcodegen generate >/dev/null )|g' ci/local-release-check.sh
+  ok "ci/local-release-check.sh: tuist generate --no-open → xcodegen generate"
+}
+
+mutate_pr_workflow() {
+  step "Editing .github/workflows/pr.yml (3 jobs: tuist → xcodegen)"
+  if [ ! -f ".github/workflows/pr.yml" ]; then
+    fail ".github/workflows/pr.yml missing — unexpected repo state"
+  fi
+  sed -i '' 's|name: install xcbeautify + tuist|name: install xcbeautify + xcodegen|g' .github/workflows/pr.yml
+  sed -i '' 's|run: brew install xcbeautify && brew install --cask tuist|run: brew install xcbeautify xcodegen|g' .github/workflows/pr.yml
+  sed -i '' 's|run: tuist generate --no-open|run: xcodegen generate|g' .github/workflows/pr.yml
+  ok ".github/workflows/pr.yml: tuist generate --no-open → xcodegen generate (3 jobs)"
+}
+
+# ── --dry-run preview ─────────────────────────────────────────────────────
+print_dry_run_plan() {
+  step "DRY RUN — no files will be modified"
+  echo
+  echo "Would restore:"
+  echo "  app/project.yml  (from git commit ${PROJECT_YML_SHA:0:8})"
+  echo
+  echo "Would edit:"
+  echo "  Brewfile                       (add 'brew \"xcodegen\"' line)"
+  echo "  Makefile                       (cd app && tuist generate --no-open → cd app && xcodegen generate)"
+  echo "  ci/local-check.sh              (require_cmd / step / tuist invocation)"
+  echo "  ci/local-release-check.sh      (step + tuist invocation)"
+  echo "  .github/workflows/pr.yml       (3 jobs: install + generate steps)"
+  echo
+  echo "Mutation count preview:"
+  printf '  %-40s %d hit(s)\n' "Brewfile brew \"--cask\", \"tuist\"" \
+    "$(grep -c '^brew "--cask", "tuist"' Brewfile 2>/dev/null || true)"
+  printf '  %-40s %d hit(s)\n' "Makefile tuist generate --no-open" \
+    "$(grep -c 'tuist generate --no-open' Makefile 2>/dev/null || true)"
+  printf '  %-40s %d hit(s)\n' "ci/local-check.sh tuist" \
+    "$(grep -c 'tuist' ci/local-check.sh 2>/dev/null || true)"
+  printf '  %-40s %d hit(s)\n' "ci/local-release-check.sh tuist" \
+    "$(grep -c 'tuist' ci/local-release-check.sh 2>/dev/null || true)"
+  printf '  %-40s %d hit(s)\n' ".github/workflows/pr.yml tuist" \
+    "$(grep -c 'tuist' .github/workflows/pr.yml 2>/dev/null || true)"
+  echo
+  ok "dry run complete — re-run without --dry-run to apply"
+}
+
+# ── Main orchestration ────────────────────────────────────────────────────
+main() {
+  set +e
+  check_idempotency
+  IDEMPOT=$?
+  set -e
+
+  case "$IDEMPOT" in
+    0)
+      if [ "$DRY_RUN" = "1" ]; then
+        step "DRY RUN — already-xcodegen state detected"
+        ok "no changes would be applied (already on XcodeGen)"
+      fi
+      # Real run on already-xcodegen tree: silent exit 0. Disarm traps.
+      trap - ERR EXIT INT TERM
+      exit 0
+      ;;
+    1)
+      step "Pre-flight"
+      step "Idempotency check"
+      if [ "$FORCE" = "1" ]; then
+        ok "partial state detected; --force bypass enabled — proceeding"
+      else
+        fail "partial switch-to-xcodegen state detected — restore manually or pass --force"
+      fi
+      ;;
+    2)
+      step "Pre-flight"
+      step "Idempotency check"
+      ok "pre-switch (tuist) state confirmed — proceeding"
+      ;;
+  esac
+
+  # Pre-flight gates
+  gate_xcodegen_present
+  gate_project_swift_present
+  gate_project_yml_in_history
+
+  if [ "$DRY_RUN" != "1" ]; then
+    gate_clean_tree
+    gate_on_main
+  else
+    ok "clean-tree + on-main gates skipped on --dry-run path"
+  fi
+
+  step "All pre-flight gates passed"
+
+  if [ "$DRY_RUN" = "1" ]; then
+    print_dry_run_plan
+    trap - ERR EXIT INT TERM
+    exit 0
+  fi
+
+  # Mutation phase: arm rollback's destructive-op path.
+  MUTATION_STARTED=1
+  mutate_restore_project_yml
+  mutate_brewfile
+  mutate_makefile
+  mutate_local_check
+  mutate_local_release_check
+  mutate_pr_workflow
+
+  trap - ERR EXIT INT TERM
+
+  step "Switch to XcodeGen complete"
+  ok "next: run 'cd app && xcodegen generate' then 'make check'"
+}
+
+main "$@"

--- a/ci/test-switch-to-xcodegen.sh
+++ b/ci/test-switch-to-xcodegen.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# ci/test-switch-to-xcodegen.sh — gate + integration test for bin/switch-to-xcodegen.sh.
+#
+# Mirrors ci/test-switch-to-tuist.sh's structure, exercising the inverse
+# direction:
+#   - clone main to tmpdir
+#   - apply switch-to-tuist.sh + commit (fixture: tree is now tuist-shaped)
+#   - run switch-to-xcodegen.sh and verify:
+#     * --dry-run produces a plan + leaves the tree clean
+#     * forced-failure rollback restores the tuist state
+#     * real run produces an xcodegen-shaped tree
+#     * idempotency: a second run is a silent no-op
+#     * `xcodegen generate` succeeds on the result
+#     * `make check` is green on the result
+#
+# Runs against a fresh clone of REPO_ROOT in a tmpdir so the running tree
+# is unaffected. Total budget ~3 min (xcodegen build dominates).
+#
+# Usage:
+#   ci/test-switch-to-xcodegen.sh   # run from repo root
+#
+# Exit 0 = green; non-zero = a gate behaved unexpectedly.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK_DIR=""
+
+step() { printf '\n==> %s\n' "$*"; }
+ok()   { printf '    ✓ %s\n' "$*"; }
+fail() { printf '    ✗ %s\n' "$*" >&2; exit 1; }
+
+cleanup() {
+  if [ -n "$WORK_DIR" ] && [ -d "$WORK_DIR" ]; then
+    rm -rf "$WORK_DIR"
+  fi
+}
+trap 'cleanup' EXIT INT TERM
+
+# ── Pre-flight ────────────────────────────────────────────────────────────
+step "Pre-flight"
+cd "$REPO_ROOT"
+test -x bin/switch-to-xcodegen.sh || fail "bin/switch-to-xcodegen.sh not executable in $REPO_ROOT"
+test -x bin/switch-to-tuist.sh    || fail "bin/switch-to-tuist.sh not executable (needed to set up fixture)"
+test -f app/project.yml           || fail "app/project.yml missing — unexpected pre-test state"
+test -f app/Project.swift         || fail "app/Project.swift missing — PR #1 not landed?"
+command -v git      >/dev/null || fail "git not on PATH"
+command -v xcodegen >/dev/null || fail "xcodegen not on PATH — install via 'brew install xcodegen'"
+command -v tuist    >/dev/null || fail "tuist not on PATH — install via 'brew install --cask tuist'"
+command -v make     >/dev/null || fail "make not on PATH"
+ok "tools present"
+
+# ── Clone + set up fixture (apply switch-to-tuist + commit) ──────────────
+step "Clone REPO_ROOT to tmpdir + flip to tuist fixture"
+WORK_DIR="$(mktemp -d -t test-switch-to-xcodegen-XXXXXX)"
+git clone --no-hardlinks --quiet "$REPO_ROOT" "$WORK_DIR"
+( cd "$WORK_DIR" && git checkout --quiet -B main HEAD )
+( cd "$WORK_DIR" && bin/switch-to-tuist.sh >/dev/null ) || fail "fixture setup: switch-to-tuist.sh failed"
+( cd "$WORK_DIR" && git add -A && git commit --quiet -m "Switch to Tuist (test fixture)" )
+test ! -f "$WORK_DIR/app/project.yml" || fail "fixture: app/project.yml should be removed after switch-to-tuist"
+ok "fixture: tree is now tuist-shaped (and committed)"
+
+# ── --dry-run leaves the tree clean ──────────────────────────────────────
+step "--dry-run produces plan + leaves tree clean"
+STATUS_BEFORE=$(cd "$WORK_DIR" && git status --short | sort)
+set +e
+DR_OUT=$(cd "$WORK_DIR" && bin/switch-to-xcodegen.sh --dry-run 2>&1)
+DR_EXIT=$?
+set -e
+STATUS_AFTER=$(cd "$WORK_DIR" && git status --short | sort)
+
+test "$DR_EXIT" -eq 0 || fail "--dry-run exited $DR_EXIT (expected 0); output: $DR_OUT"
+echo "$DR_OUT" | grep -q "DRY RUN" || fail "--dry-run output missing 'DRY RUN'; got: $DR_OUT"
+echo "$DR_OUT" | grep -q "Would restore" || fail "--dry-run output missing 'Would restore'; got: $DR_OUT"
+echo "$DR_OUT" | grep -q "Would edit" || fail "--dry-run output missing 'Would edit'; got: $DR_OUT"
+test "$STATUS_BEFORE" = "$STATUS_AFTER" || \
+  fail "--dry-run modified the tree:
+BEFORE: $STATUS_BEFORE
+AFTER:  $STATUS_AFTER"
+ok "--dry-run printed plan + tree unchanged"
+
+# ── Forced-failure rollback (chmod 000 trick) ─────────────────────────────
+step "Forced-failure rollback (chmod 000 Brewfile)"
+chmod 000 "$WORK_DIR/Brewfile"
+set +e
+( cd "$WORK_DIR" && bin/switch-to-xcodegen.sh >/dev/null 2>&1 )
+RB_EXIT=$?
+set -e
+chmod 644 "$WORK_DIR/Brewfile" 2>/dev/null || true
+
+test "$RB_EXIT" -ne 0 || fail "rollback test: forced failure should exit non-zero (got $RB_EXIT)"
+DIRTY=$(cd "$WORK_DIR" && git status --short | wc -l | tr -d ' ')
+test "$DIRTY" = "0" || \
+  fail "rollback test: working tree not clean after rollback (got $DIRTY entries):
+$(cd "$WORK_DIR" && git status --short)"
+test ! -f "$WORK_DIR/app/project.yml" || \
+  fail "rollback test: app/project.yml shouldn't be present (we're in tuist-fixture state)"
+ok "forced-failure rollback restored pre-switch (tuist) state (exit $RB_EXIT)"
+
+# ── Real switch ───────────────────────────────────────────────────────────
+step "Real switch (clean run)"
+( cd "$WORK_DIR" && bin/switch-to-xcodegen.sh ) || fail "bin/switch-to-xcodegen.sh failed on clean tree"
+
+test -f "$WORK_DIR/app/project.yml" || fail "post-switch: app/project.yml missing"
+test -f "$WORK_DIR/app/Project.swift" || fail "post-switch: app/Project.swift missing"
+test -f "$WORK_DIR/Tuist.swift" || fail "post-switch: Tuist.swift missing"
+
+grep -q '^brew "xcodegen"' "$WORK_DIR/Brewfile" || \
+  fail "post-switch: Brewfile missing 'brew \"xcodegen\"'"
+grep -q 'cd app && xcodegen generate' "$WORK_DIR/Makefile" || \
+  fail "post-switch: Makefile missing 'cd app && xcodegen generate'"
+! grep -q 'cd app && tuist generate --no-open' "$WORK_DIR/Makefile" || \
+  fail "post-switch: Makefile still has 'cd app && tuist generate --no-open'"
+grep -q 'require_cmd xcodegen' "$WORK_DIR/ci/local-check.sh" || \
+  fail "post-switch: ci/local-check.sh missing 'require_cmd xcodegen'"
+! grep -q 'require_cmd tuist' "$WORK_DIR/ci/local-check.sh" || \
+  fail "post-switch: ci/local-check.sh still has 'require_cmd tuist'"
+grep -q 'run: xcodegen generate' "$WORK_DIR/.github/workflows/pr.yml" || \
+  fail "post-switch: .github/workflows/pr.yml missing 'run: xcodegen generate'"
+! grep -q 'run: tuist generate --no-open' "$WORK_DIR/.github/workflows/pr.yml" || \
+  fail "post-switch: .github/workflows/pr.yml still has 'run: tuist generate --no-open'"
+ok "all 6 mutation surfaces verified post-switch"
+
+# ── Idempotency: second run is silent no-op ───────────────────────────────
+step "Idempotency: second run is silent no-op"
+( cd "$WORK_DIR" && git add -A && git commit --quiet -m "Switch to XcodeGen (test fixture commit)" )
+STATUS_BEFORE=$(cd "$WORK_DIR" && git status --short | sort)
+set +e
+OUT=$(cd "$WORK_DIR" && bin/switch-to-xcodegen.sh 2>&1)
+EXIT=$?
+set -e
+STATUS_AFTER=$(cd "$WORK_DIR" && git status --short | sort)
+
+test "$EXIT" -eq 0 || fail "second run exit $EXIT (expected 0 silent no-op); output: $OUT"
+test -z "$OUT" || fail "second run was not silent (expected empty stdout, got):
+$OUT"
+test "$STATUS_BEFORE" = "$STATUS_AFTER" || \
+  fail "second run modified the tree:
+BEFORE: $STATUS_BEFORE
+AFTER:  $STATUS_AFTER"
+ok "second run was silent no-op (exit 0; status unchanged; stdout empty)"
+
+# ── Integration: xcodegen generate succeeds on the switched tree ─────────
+step "Integration: xcodegen generate on switched tree"
+( cd "$WORK_DIR/app" && xcodegen generate >/dev/null 2>&1 ) || \
+  fail "xcodegen generate failed on switched tree"
+test -d "$WORK_DIR/app/HelloApp.xcodeproj" || \
+  fail "xcodegen generate did not produce app/HelloApp.xcodeproj"
+ok "xcodegen generate produces app/HelloApp.xcodeproj"
+
+# ── Integration: make check green on the switched tree ────────────────────
+step "Integration: make check (iOS device build) on switched tree"
+bash -euo pipefail <<BASH
+cd "$WORK_DIR"
+set +e
+make check 2>&1 | tee .test-switch-make-check.log
+EXIT=\${PIPESTATUS[0]}
+set -e
+test "\$EXIT" -eq 0 || { echo "ERROR: make check failed with exit \$EXIT"; exit 1; }
+BASH
+ok "make check exit 0 on switched tree"
+
+# ── Done ──────────────────────────────────────────────────────────────────
+step "ci/test-switch-to-xcodegen.sh: all assertions passed"
+ok "tmpdir cleanup will run via EXIT trap"


### PR DESCRIPTION
Adds the missing inverse of `bin/switch-to-tuist.sh`. Two callers benefit:

1. A maintainer who switched to Tuist and now wants to switch back manually: `bin/switch-to-xcodegen.sh`.
2. The canary-trigger flow on a tuist-permanent fork dispatched with `generator=xcodegen`: release.yml's override step now invokes the script (was: error out with 'no inverse exists').

## How it restores app/project.yml
Walks git history with `git log --diff-filter=AM` to find the most recent commit whose tree *contains* app/project.yml (NOT the deletion commit), then `git show <SHA>:app/project.yml > app/project.yml`.

If the fork was never xcodegen-shaped (no project.yml anywhere in history — e.g. a pure-tuist fork created by hand), fails loud with manual recovery instructions (`curl` from indiagrams/apple-shipkit/main).

## Mirrors switch-to-tuist.sh
Same structure: pre-flight gates, 3-case idempotency dispatch (already-applied / partial / pre-switch), atomic rollback via `git reset --hard`, MUTATION_STARTED guard, --dry-run + --force flags.

## Tests
`ci/test-switch-to-xcodegen.sh` (mirrors `ci/test-switch-to-tuist.sh`):
  - Pre-flight: tools present
  - Fixture: clone, apply switch-to-tuist, commit
  - --dry-run leaves tree clean
  - Forced-failure rollback (chmod 000 Brewfile) restores tuist state
  - Real switch: 6 mutation surfaces verified
  - Idempotency: second run silent no-op (exit 0, empty stdout)
  - Integration: `xcodegen generate` succeeds
  - Integration: `make check` (iOS device build) green

All 6 phases pass locally; verified against this branch's HEAD.

## Companion change in release.yml
The `Apply generator override` step's `generator=xcodegen` branch now installs xcodegen + invokes `bin/switch-to-xcodegen.sh` if the tree is tuist-shaped. Mirrors the existing tuist branch's pattern.

Existing canary-trigger flow against the smoketest is unchanged: the smoketest's main is xcodegen-shaped, so generator=xcodegen is no-op.

## Pair with
Already-merged smoketest #19 — Fastfile sync from upstream (closed the divergence preventing PLATFORMS gating from activating on the smoketest).