### PR TITLE
feat(canary): explicitly pass platforms=ios,macos to release.yml

### DIFF
--- a/.github/workflows/canary-trigger.yml
+++ b/.github/workflows/canary-trigger.yml
@@ -30,6 +30,11 @@ on:
         required: false
         type: boolean
         default: false
+      platforms:
+        description: 'Platforms to ship (comma-separated subset of ios,macos). Threaded to release.yml as the platforms input.'
+        required: false
+        type: string
+        default: 'ios,macos'
 
 permissions:
   contents: read
@@ -69,6 +74,7 @@ jobs:
       TARGET_REF: main
       GH_TOKEN: ${{ secrets.SMOKETEST_DISPATCH_PAT }}
       GENERATOR: ${{ matrix.generator }}
+      PLATFORMS: ${{ inputs.platforms || 'ios,macos' }}
 
     steps:
       - name: Verify dispatch PAT is set
@@ -95,13 +101,14 @@ jobs:
         run: |
           dry_run='${{ inputs.dry_run }}'
           dry_run="${dry_run:-false}"
-          echo "Dispatching ${TARGET_REPO} ${TARGET_WORKFLOW} on ref=${TARGET_REF} dry_run=${dry_run} generator=${GENERATOR}"
+          echo "Dispatching ${TARGET_REPO} ${TARGET_WORKFLOW} on ref=${TARGET_REF} dry_run=${dry_run} generator=${GENERATOR} platforms=${PLATFORMS}"
           gh workflow run "${TARGET_WORKFLOW}" \
             --repo "${TARGET_REPO}" \
             --ref "${TARGET_REF}" \
             -f version='' \
             -f "dry_run=${dry_run}" \
-            -f "generator=${GENERATOR}"
+            -f "generator=${GENERATOR}" \
+            -f "platforms=${PLATFORMS}"
 
       - name: Locate the dispatched run
         id: locate


### PR DESCRIPTION
Threads `platforms` through canary-trigger → release.yml dispatch instead of leaving it empty (which relied on fastlane's default).

## Effect on weekly runs
- 2 cells (xcodegen + tuist) — unchanged
- 4 TestFlight builds (2 .ipa + 2 .pkg) — unchanged
- ~14 min wall time — unchanged
- **Coverage gained**: PLATFORMS plumbing (canary input → release.yml input → PLATFORMS env → Fastfile gating) now exercised explicitly each Monday rather than relying on the empty/default fallback.

## Manual override
`gh workflow run canary-trigger.yml -F platforms=ios -F dry_run=true` now works for ad-hoc PLATFORMS=ios testing without committing to a weekly run.

## Validation
- `actionlint` clean
- `YAML.load_file` parses; new `platforms` input present in on.workflow_dispatch.inputs