### PR TITLE
docs(readme): constrain screenshot widths (iOS shot was too big)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 
 > **Goal of this README:** if you've never shipped an iOS or Mac app before, by the end of it you will have one running on your phone via TestFlight. About 30–60 minutes of focused time, $99/year for Apple Developer Program, a Mac.
 
-![HelloApp template running on iOS Simulator — hammer icon, "HelloApp" title, and 'Rename me' instruction visible](docs/screenshots/ios-home.png)
-
-![HelloApp template running natively on macOS — same hammer icon, title, and rename instruction](docs/screenshots/macos-home.png)
+<p align="center">
+  <img src="docs/screenshots/ios-home.png"   alt="HelloApp template running on iOS Simulator — hammer icon, 'HelloApp' title, and 'Rename me' instruction visible" width="260">
+  &nbsp;&nbsp;
+  <img src="docs/screenshots/macos-home.png" alt="HelloApp template running natively on macOS — same hammer icon, title, and rename instruction"                       width="500">
+</p>
 
 That's the starter app you'll customize into yours.
 


### PR DESCRIPTION
iOS home screenshot is 1206×2622. At GitHub README width it stretched to ~1500px tall, dominating the viewport.

Replaces the bare `![](path)` markdown with HTML `<img>` tags inside a centered `<p>` wrapper:
- iOS → width=260px (compact phone preview)
- macOS → width=500px (landscape, natural-ish)

Both visible without scrolling now. Source PNGs unchanged.