### PR TITLE
feat: bin/rename.sh --platforms flag + platform-aware stub subtitle

### DIFF
--- a/bin/lib/bootstrap.rb
+++ b/bin/lib/bootstrap.rb
@@ -379,7 +379,8 @@ module Bootstrap
         "bin/rename.sh",
         config["APP_NAME"], config["BUNDLE_ID"], config["DISPLAY_NAME"],
         "--email=#{config['APP_EMAIL']}",
-        "--generator=#{config['GENERATOR']}"
+        "--generator=#{config['GENERATOR']}",
+        "--platforms=#{config.platforms.join(',')}"
       ]
       Sh.run!(*args)
       Sh.run!("bin/verify-rename.sh")
@@ -563,6 +564,16 @@ module Bootstrap
 
     private
 
+    # Human-readable label of the active platforms — for display in the
+    # ASC creation hint. Mirrors bin/rename.sh's PLATFORMS_LABEL.
+    def platforms_label
+      ios   = config.ios?
+      macos = config.macos?
+      return "iOS + macOS" if ios && macos
+      return "iOS"         if ios
+      return "macOS"       if macos
+      "iOS + macOS"  # defensive: shouldn't happen given Config.validate_platforms!
+    end
     def asc_creation_msg
       <<~MSG
         ASC App record for #{config['BUNDLE_ID']} not found.
@@ -571,7 +582,7 @@ module Bootstrap
         record once via the web UI:
 
           1. Open https://appstoreconnect.apple.com/apps  →  + (New App)
-          2. Platforms:        iOS + macOS
+          2. Platforms:        #{platforms_label}
              Name:             #{config['ASC_APP_NAME'].to_s.empty? ? config['DISPLAY_NAME'] : config['ASC_APP_NAME']}
              Primary Language: English (U.S.)
              Bundle ID:        #{config['BUNDLE_ID']}

--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -6,7 +6,7 @@
 # idempotent (silent no-op on re-run with same args), pre-flight-gated.
 #
 # Usage:
-#   bin/rename.sh APP_NAME BUNDLE_ID DISPLAY_NAME --email=EMAIL [--slug=OWNER/REPO] [--year=YYYY] [--generator=tuist|xcodegen] [--dry-run] [--force]
+#   bin/rename.sh APP_NAME BUNDLE_ID DISPLAY_NAME --email=EMAIL [--slug=OWNER/REPO] [--year=YYYY] [--generator=tuist|xcodegen] [--platforms=ios|macos|ios,macos] [--dry-run] [--force]
 #   bin/rename.sh -h                                # print this usage
 #   bin/rename.sh --help                            # alias for -h
 #
@@ -120,6 +120,7 @@ EMAIL=""
 SLUG=""
 YEAR_ARG=""
 GENERATOR="xcodegen"   # default; --generator=tuist|xcodegen overrides (#38)
+PLATFORMS="ios,macos"  # default; --platforms=ios|macos|ios,macos overrides (matches .bootstrap.env PLATFORMS)
 DRY_RUN=0
 FORCE=0
 
@@ -160,6 +161,12 @@ parse_args() {
         [ $# -ge 2 ] || fail "--generator requires a value (e.g. --generator=tuist)"
         case "$2" in -*) fail "--generator value cannot start with '-' (got '$2')";; esac
         GENERATOR="$2"; shift 2 ;;
+      --platforms=*)
+        PLATFORMS="${1#--platforms=}"; shift ;;
+      --platforms)
+        [ $# -ge 2 ] || fail "--platforms requires a value (e.g. --platforms=ios)"
+        case "$2" in -*) fail "--platforms value cannot start with '-' (got '$2')";; esac
+        PLATFORMS="$2"; shift 2 ;;
       -*)
         fail "unknown flag '$1' — run with -h for usage" ;;
       *)
@@ -245,6 +252,20 @@ validate_args() {
     *) fail "invalid --generator '$GENERATOR' — must be 'tuist' or 'xcodegen' (default: xcodegen)" ;;
   esac
   ok "--generator '$GENERATOR' valid"
+
+  # Gate 5e: --platforms ⊆ {ios, macos}, comma-separated, non-empty.
+  # Computes PLATFORMS_LABEL — the human-readable label baked into the
+  # SwiftUI stub's subtitle ("iOS template" / "macOS template" /
+  # "iOS + macOS template"). Mirrors .bootstrap.env's PLATFORMS field.
+  # Default 'ios,macos' set at file scope.
+  PLATFORMS_LABEL=""
+  case "$PLATFORMS" in
+    ios)              PLATFORMS_LABEL="iOS template" ;;
+    macos)            PLATFORMS_LABEL="macOS template" ;;
+    ios,macos|macos,ios) PLATFORMS_LABEL="iOS + macOS template" ;;
+    *) fail "invalid --platforms '$PLATFORMS' — must be 'ios', 'macos', 'ios,macos', or 'macos,ios' (default: ios,macos)" ;;
+  esac
+  ok "--platforms '$PLATFORMS' valid (label: '$PLATFORMS_LABEL')"
 }
 
 # ── Reset-hard rollback (REQ-7; HIGH-1 closure — replaces broken stash) ───
@@ -461,6 +482,14 @@ apply_substitutions() {
   if [ -f app/Shared/ContentView.swift ]; then
     sed -i '' "s|Text(\"HelloApp\")|Text(\"$DISPLAY_PLACEHOLDER\")|g" app/Shared/ContentView.swift
     ok "DISPLAY placeholder set in app/Shared/ContentView.swift"
+    # Platform label: "iOS + macOS template" → "$PLATFORMS_LABEL" (one of
+    # "iOS template" / "macOS template" / "iOS + macOS template"). Driven
+    # by --platforms (default ios,macos preserves the byte-for-byte
+    # unchanged path on default-flow forks). One-shot direct substitution
+    # — no placeholder mechanism needed since this string only appears at
+    # one site in the source tree.
+    sed -i '' "s|Text(\"iOS + macOS template\")|Text(\"$PLATFORMS_LABEL\")|g" app/Shared/ContentView.swift
+    ok "platform label set in app/Shared/ContentView.swift ('$PLATFORMS_LABEL')"
   fi
 
   if [ -f app/UITests/AppStoreScreenshotTests.swift ]; then

--- a/ci/test-rename.sh
+++ b/ci/test-rename.sh
@@ -414,6 +414,68 @@ ok "--generator=tuist: make check exit 0 (Tuist-driven build green)"
 
 step "--generator=tuist end-to-end: PASSED"
 
+# ── --platforms substitution (PLATFORMS-aware stub label) ─────────────────
+#
+# bin/rename.sh's --platforms flag substitutes the SwiftUI stub's subtitle
+# in app/Shared/ContentView.swift. Verify the 3 valid values produce the
+# expected literal in the source, plus the invalid case fails loudly.
+#
+# No make check here — the substitution is a pure-text edit; if the input
+# tree compiled, the output (with a different string literal) compiles.
+# The earlier `make check` phases above prove the pipeline; this phase
+# just verifies the right string lands.
+
+step "--platforms substitution"
+
+# Reset to clean main; the prior --generator=tuist phase left a tuist-shaped
+# tree, so reset all the way back.
+git reset --hard --quiet HEAD
+git clean -fd --quiet
+
+run_platform_case() {
+  local label="$1"
+  local platforms_arg="$2"
+  local expected_substring="$3"
+
+  # Spawn a sibling tmpdir clone so we don't accumulate state across cases.
+  local case_dir
+  case_dir="$(mktemp -d -t test-rename-platforms-XXXXXX)"
+  git clone --no-hardlinks --quiet "$REPO_ROOT" "$case_dir"
+  ( cd "$case_dir" && git checkout --quiet -B main HEAD )
+
+  ( cd "$case_dir" && bin/rename.sh "$TEST_APP" "$TEST_BUNDLE" "$TEST_DISPLAY" \
+      --email=test@example.com --slug=test/myapp $platforms_arg ) >/dev/null \
+      || fail "--platforms case '$label' ($platforms_arg): bin/rename.sh exited non-zero"
+
+  grep -qF "$expected_substring" "$case_dir/app/Shared/ContentView.swift" || \
+    fail "--platforms case '$label': ContentView.swift missing expected literal '$expected_substring'
+Got:
+$(grep -E 'Text\("' "$case_dir/app/Shared/ContentView.swift")"
+  ok "--platforms=$label → ContentView.swift contains '$expected_substring'"
+
+  rm -rf "$case_dir"
+}
+
+run_platform_case "ios"       "--platforms=ios"       'Text("iOS template")'
+run_platform_case "macos"     "--platforms=macos"     'Text("macOS template")'
+run_platform_case "ios,macos" "--platforms=ios,macos" 'Text("iOS + macOS template")'
+run_platform_case "default"   ""                      'Text("iOS + macOS template")'
+
+# Invalid value must fail loud.
+bad_dir=$(mktemp -d -t test-rename-platforms-bad-XXXXXX)
+git clone --no-hardlinks --quiet "$REPO_ROOT" "$bad_dir"
+( cd "$bad_dir" && git checkout --quiet -B main HEAD )
+set +e
+( cd "$bad_dir" && bin/rename.sh "$TEST_APP" "$TEST_BUNDLE" "$TEST_DISPLAY" \
+    --email=test@example.com --slug=test/myapp --platforms=tvos ) >/dev/null 2>&1
+bad_exit=$?
+set -e
+test "$bad_exit" -ne 0 || fail "--platforms=tvos should have failed with non-zero exit; got $bad_exit"
+ok "--platforms=tvos rejected with non-zero exit ($bad_exit)"
+rm -rf "$bad_dir"
+
+step "--platforms substitution: PASSED"
+
 # ── Done ──────────────────────────────────────────────────────────────────
 
 step "ci/test-rename.sh: all assertions passed"


### PR DESCRIPTION
Closes the screenshot-review gap: an iOS-only fork was getting 'iOS + macOS template' baked into ContentView.swift's subtitle, then shipping that to TestFlight.

## What changes
- `bin/rename.sh` gains `--platforms=ios|macos|ios,macos|macos,ios` (default `ios,macos`)
- Substitutes `Text("iOS + macOS template")` → `Text("<label>")` in app/Shared/ContentView.swift at rename time
- `bin/lib/bootstrap.rb`: RenameStub threads PLATFORMS into the rename invocation; VerifyAscApp's ASC-creation hint becomes platform-aware (was hardcoded `Platforms: iOS + macOS`)
- `ci/test-rename.sh` gets a phase covering all 4 happy paths + invalid

## Verified
4 fresh clones tested locally:
- `--platforms=ios` → `Text("iOS template")` ✓
- `--platforms=macos` → `Text("macOS template")` ✓
- `--platforms=ios,macos` → `Text("iOS + macOS template")` ✓
- (default) → `Text("iOS + macOS template")` ✓ (preserves backward compat)
- `--platforms=tvos` → exit 1 with clear error ✓

## Pair with
[smoketest sync](https://github.com/indiagrams/ios-macos-smoketest/pulls) — bin/lib/bootstrap.rb byte-equivalence invariant maintained.