### PR TITLE
docs(readme): add 'Why this exists' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ That's the starter app you'll customize into yours.
 
 ---
 
+## Why this exists
+
+I'm a first-time iOS developer. I haven't shipped my own app yet — that's still ahead of me. But before writing a feature of my actual app, I spent days researching what Apple actually requires to publish.
+
+It turns out to be a lot. Bundle ID conventions. Three kinds of signing certificates with a 3-cert team cap. Provisioning profiles. App Store Connect API keys. Fastlane setup. Match for CI signing. Private certs repo. Branch protection settings. Version-bumping rituals. Screenshot dimension requirements per device family. Metadata field length limits. A dozen Apple-side gotchas that only surface in TestFlight.
+
+I automated or documented every requirement I encountered. That's what this template is — the boring prep work, done.
+
+Fork it. Run `make doctor` (tells you what's still missing on your machine and your Apple account). Run `make bootstrap-fork` (walks the 17-step setup until your fork can ship). Run `make ship` (signed build to TestFlight). You bring the app; I've handled the path from "I have an idea" to "App Store Connect accepted my upload."
+
+A public canary fork ([`indiagrams/ios-macos-smoketest`](https://github.com/indiagrams/ios-macos-smoketest)) real-ships to TestFlight every Monday on both xcodegen and tuist generators, so Apple-side regressions surface upstream before they hit your fork. The catalog of gotchas it has surfaced lives in [`docs/CONTINUOUS-VALIDATION.md`](docs/CONTINUOUS-VALIDATION.md).
+
+---
+
 ## What you'll learn to do
 
 By the end of this guide:


### PR DESCRIPTION
Adds a 150-word framing block between the screenshots and the 'What you'll learn to do' outline. Conveys, in honest first-person:

- First-time iOS developer; haven't shipped my own app yet
- Spent days researching every Apple submission requirement
- Automated or documented every one of them
- The template is the boring prep work, done
- The weekly canary is the proof the automation actually ships

## Why this lives where it does
The existing README opens with the *what* (Goal blockquote → screenshots → 'What you'll learn to do' list). Strong for someone already convinced to invest 30 min; weaker for someone scanning to decide whether to invest at all. This section gives them a 30-second emotional + credibility hook before they scroll into the bash blocks.

## Things this deliberately does NOT claim
- 'Battle-tested' / 'production-proven' (I haven't shipped my own customer-facing app yet)
- 'Months' of research (would be over-claiming — 'days' is the truth and is enough effort to justify the extraction)
- Generic superlatives ('easiest way to ship', etc.)

## Things it can honestly claim and does
- Real signed builds reach TestFlight VALID state every Monday (canary-verified, including [run 25443684225](https://github.com/indiagrams/apple-shipkit/actions/runs/25443684225) earlier today: 4 binaries VALID across xcodegen + tuist × iOS + macOS)
- Idempotent end-to-end via `make doctor / bootstrap-fork / ship`
- A growing catalog of Apple-side gotchas in `docs/CONTINUOUS-VALIDATION.md`