### PR TITLE
docs(readme): halve 'Why this exists' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,11 @@ That's the starter app you'll customize into yours.
 
 ## Why this exists
 
-I'm a first-time iOS developer. I haven't shipped my own app yet — that's still ahead of me. But before writing a feature of my actual app, I spent days researching what Apple actually requires to publish.
-
-It turns out to be a lot. Bundle ID conventions. Three kinds of signing certificates with a 3-cert team cap. Provisioning profiles. App Store Connect API keys. Fastlane setup. Match for CI signing. Private certs repo. Branch protection settings. Version-bumping rituals. Screenshot dimension requirements per device family. Metadata field length limits. A dozen Apple-side gotchas that only surface in TestFlight.
+I'm a first-time iOS developer — I haven't shipped my own app yet. But before writing a feature of it, I spent days researching what Apple requires to publish: signing certificates, fastlane match for CI signing, ASC API keys, metadata specs, branch protection, and a dozen Apple-side gotchas that only surface in TestFlight.
 
 I automated or documented every requirement I encountered. That's what this template is — the boring prep work, done.
 
-Fork it. Run `make doctor` (tells you what's still missing on your machine and your Apple account). Run `make bootstrap-fork` (walks the 17-step setup until your fork can ship). Run `make ship` (signed build to TestFlight). You bring the app; I've handled the path from "I have an idea" to "App Store Connect accepted my upload."
-
-A public canary fork ([`indiagrams/ios-macos-smoketest`](https://github.com/indiagrams/ios-macos-smoketest)) real-ships to TestFlight every Monday on both xcodegen and tuist generators, so Apple-side regressions surface upstream before they hit your fork. The catalog of gotchas it has surfaced lives in [`docs/CONTINUOUS-VALIDATION.md`](docs/CONTINUOUS-VALIDATION.md).
+A public canary fork ([`indiagrams/ios-macos-smoketest`](https://github.com/indiagrams/ios-macos-smoketest)) real-ships to TestFlight every Monday on both xcodegen and tuist generators, so Apple-side regressions surface upstream. Catalog at [`docs/CONTINUOUS-VALIDATION.md`](docs/CONTINUOUS-VALIDATION.md).
 
 ---
 


### PR DESCRIPTION
Tightens the framing block introduced in #78 from 206 → ~110 words.

## What's cut
- **The long inventory of 14 requirements** \u2014 collapsed into one line of the first paragraph with 6 representative examples. Six is enough to convey 'it's a lot'; the full catalog lives in BOOTSTRAP.md and the rest of the README.
- **The 'Fork it. Run make doctor / bootstrap-fork / ship' paragraph** \u2014 dropped entirely. The next section ('What you'll learn to do') and the Quickstart already explain this flow with more depth.

## What's preserved
- First-time-shipper identity + 'haven't shipped yet' honesty (the credibility angle the section exists for)
- The 'I automated or documented every requirement' thesis
- 'The boring prep work, done' tagline
- Canary fork mention + catalog link

## Why
Reader scanning to decide whether to invest 30 min should get the framing in 30 seconds, then land on 'What you'll learn to do' without scrolling fatigue. The original was already pulling its weight; this is just sharpening it.