### PR TITLE
docs(readme): drop 'haven't shipped my own app yet' clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ That's the starter app you'll customize into yours.
 
 ## Why this exists
 
-I'm a first-time iOS developer — I haven't shipped my own app yet. But before writing a feature of it, I spent days researching what Apple requires to publish: signing certificates, fastlane match for CI signing, ASC API keys, metadata specs, branch protection, and a dozen Apple-side gotchas that only surface in TestFlight.
+I'm a first-time iOS developer. Before writing a feature of my actual app, I spent days researching what Apple requires to publish: signing certificates, fastlane match for CI signing, ASC API keys, metadata specs, branch protection, and a dozen Apple-side gotchas that only surface in TestFlight.
 
 I automated or documented every requirement I encountered. That's what this template is — the boring prep work, done.
 


### PR DESCRIPTION
Removes the 'I haven't shipped my own app yet' admission from the 'Why this exists' section. The clause invited the very 'how do you know?' critique it was trying to preempt, and the 'first-time iOS developer' framing alone carries the empathy/peer signal without the defensive hedge.

Plus: the line will go false in the near term as the author ships. Removing it now means we don't need to add an 'I hadn't shipped when I wrote this' workaround later.

Grammar fix included: 'before writing a feature of it' becomes 'before writing a feature of my actual app' (restores the antecedent that the deleted clause was carrying).