### PR TITLE
fix(setup-github): define REPO_ROOT before $REPO_ROOT references

### DIFF
--- a/bin/setup-github.sh
+++ b/bin/setup-github.sh
@@ -27,6 +27,9 @@
 
 set -euo pipefail
 
+# Resolve repo root from this script's location (bin/setup-github.sh → repo root).
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
 step() { printf '\n==> %s\n' "$*"; }
 ok()   { printf '    ✓ %s\n' "$*"; }
 fail() { printf '    ✗ %s\n' "$*" >&2; exit 1; }


### PR DESCRIPTION
Surfaced by the v1.2 audit. `bin/setup-github.sh` references `$REPO_ROOT/.bootstrap.env` on line 85+ but the script never defined `REPO_ROOT`, and the script runs under `set -u` (line 28). `make setup-github` therefore fails on first run in any fork that uses .bootstrap.env — which is all of them.

Fix: one-line definition immediately after `set -euo pipefail`, using the same `$(cd "$(dirname "$0")/.." && pwd)` pattern as bin/preflight.sh and bin/rename.sh.