### PR TITLE
fix(ci): install tuist as a cask in bootstrap-doctor-matrix.yml

### DIFF
--- a/.github/workflows/bootstrap-doctor-matrix.yml
+++ b/.github/workflows/bootstrap-doctor-matrix.yml
@@ -89,7 +89,8 @@ jobs:
       - name: Install xcodegen + tuist (so BrewBootstrap step's `which` checks pass)
         run: |
           # Idempotent — brew skips already-installed.
-          brew install xcodegen tuist 2>&1 | tail -3
+          brew install xcodegen 2>&1 | tail -3
+          brew install --cask tuist 2>&1 | tail -3
 
       - name: Materialize secrets to mode-0600 files outside the workspace
         env:


### PR DESCRIPTION
Surfaced by the v1.2 audit. `brew install xcodegen tuist` treats tuist as a formula, but tuist is distributed as a **cask** everywhere else in the repo (Brewfile, pr.yml × 3 jobs, release.yml). The doctor matrix's tuist cells were silently broken because of this mismatch.

Splits into two lines matching the rest of the repo's pattern. `brew install --cask tuist` is idempotent.