### PR TITLE
docs: reconcile step count (17 in CI, 11 in local) across all surfaces

### DIFF
--- a/bin/lib/bootstrap.rb
+++ b/bin/lib/bootstrap.rb
@@ -2,7 +2,9 @@
 
 # Shared library for `bin/doctor.rb` (read-only) and `bin/bootstrap-fork.rb`
 # (idempotent driver). Reads `.bootstrap.env`, validates config, exposes a
-# pipeline of 14 steps. Each step has a `check` (returns bool, no side effects)
+# pipeline of 19 step classes. CI mode runs 17 steps with default
+# PLATFORMS=ios,macos; local mode runs 11. Each step has a `check`
+# (returns bool, no side effects)
 # and a `do_it` (idempotent: safe to re-run on partial state).
 #
 # Doctor mode just calls every `check` and reports.

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -96,7 +96,9 @@ actual secret bytes. The dotenv itself is low-blast-radius.
 
 ## What `make bootstrap-fork` does
 
-15 steps, in order. Each step has a `check` (no side effects) and a `do_it`.
+The pipeline has 19 step classes. CI mode (`RELEASE_MODE=ci`, the default) runs
+17 with default `PLATFORMS=ios,macos`; local mode runs 11. Each step has a
+`check` (no side effects) and a `do_it`.
 A step is skipped if its desired state is already reached, so re-running after
 a partial failure picks up where you left off.
 


### PR DESCRIPTION
Three user-facing surfaces disagreed:

| File | Claimed |
|---|---|
| `bin/lib/bootstrap.rb:5` | 14 steps |
| `docs/BOOTSTRAP.md:99` | 15 steps |
| `README.md:255,279` | 17 steps |

Authoritative count from `PIPELINE` constant: **19 step classes**, filtered to 17 in CI mode (default) and 11 in local mode by `Runner#initialize`. README's '17' was already canonical (matches CI default); aligning the other two surfaces.

Surfaced by the v1.2 audit.