### PR TITLE
chore: drop stale 'Renaming the stub' cross-refs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # ci/local-check.sh --fast automatically via lefthook.
 #
 # The stub app is named "HelloApp" with bundle id "com.example.helloapp".
-# Rename for your project: see README.md → "Renaming the stub".
+# Rename for your project: run `bin/rename.sh --help`.
 
 .PHONY: all go bootstrap check check-ios check-macos check-sim build generate icons screenshots release-dryrun setup-github phase-checklist milestone-checklist help init doctor bootstrap-fork ship verify
 

--- a/app/Shared/ContentView.swift
+++ b/app/Shared/ContentView.swift
@@ -13,7 +13,7 @@ struct ContentView: View {
             Text("iOS + macOS template")
                 .font(.headline)
                 .foregroundStyle(.secondary)
-            Text("Rename me. See README.md → \"Renaming the stub\".")
+            Text("Rename me. Run `bin/rename.sh --help`.")
                 .font(.footnote)
                 .foregroundStyle(.tertiary)
                 .multilineTextAlignment(.center)

--- a/ci/bump-asc-version.rb
+++ b/ci/bump-asc-version.rb
@@ -11,7 +11,7 @@
 #
 # Configuration:
 #   APP_BUNDLE_ID env var — defaults to "com.example.helloapp" (rename for your
-#   project; see README.md → "Renaming the stub").
+#   project; rename via bin/rename.sh).
 
 require 'spaceship'
 require 'base64'


### PR DESCRIPTION
Surfaced by the v1.2 audit. The README's 'Renaming the stub' section was removed during the v1.1 rewrite, but three places still pointed at it:

| File | Damage |
|---|---|
| `app/Shared/ContentView.swift:16` | **User-visible in the starter app** — every fork's first build shows 'See README.md → "Renaming the stub"' which doesn't exist |
| `Makefile:7` | Comment |
| `ci/bump-asc-version.rb:14` | Comment |

Replaces section-title cross-refs with stable references to the actual command (`bin/rename.sh --help`).