### PR TITLE
chore(ci): least-privilege permissions on pr.yml + serialize doctor matrix

### DIFF
--- a/.github/workflows/bootstrap-doctor-matrix.yml
+++ b/.github/workflows/bootstrap-doctor-matrix.yml
@@ -37,6 +37,14 @@ on:
 permissions:
   contents: read
 
+# Serialize per-ref runs. Cron-triggered runs share group `bootstrap-doctor-main`
+# with any push/dispatch on main; PR-triggered runs use the PR ref so they can
+# proceed in parallel with cron. cancel-in-progress: true keeps PR-only runs
+# fresh; cron runs effectively never overlap (they take ~5min, fire weekly).
+concurrency:
+  group: bootstrap-doctor-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   doctor:
     # Skip on forks: this workflow references indiagrams/ios-macos-smoketest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,11 @@ on:
   push:
     branches: [main, master]
 
+# Least-privilege token. The PR jobs only need to read the repo;
+# nothing here writes back to the repo, posts comments, or pushes tags.
+permissions:
+  contents: read
+
 # Cancel an older run for the same PR / branch when a new push lands.
 concurrency:
   group: pr-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Two metadata-only workflow tweaks from the v1.2 audit:

1. **pr.yml**: add `permissions: { contents: read }` (matches `verify-rename.yml` and `bootstrap-doctor-matrix.yml`). PR jobs don't write to the repo; least-privilege is the right default.
2. **bootstrap-doctor-matrix.yml**: add `concurrency` block. Triggers are cron + dispatch + PR-on-paths; without serialization all three could overlap and run 3× the 4-cell matrix simultaneously.

No functional change to job logic.