### PR TITLE
feat(ci): run xcodebuild test on PR (was build-only)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -93,15 +93,19 @@ jobs:
         working-directory: app
         run: xcodegen generate
 
-      - name: build iOS Simulator (unsigned)
+      - name: test iOS Simulator (unsigned)
         run: |
           set -o pipefail
-          xcodebuild build \
+          # `xcodebuild test` runs the scheme's Test action, which the
+          # XcodeGen manifest (app/project.yml) wires to the HelloAppUITests
+          # target. Test action requires a concrete simulator destination
+          # (generic/* doesn't work).
+          xcodebuild test \
             -project app/HelloApp.xcodeproj \
             -scheme HelloApp-iOS \
             -configuration Debug \
             -sdk iphonesimulator \
-            -destination 'generic/platform=iOS Simulator' \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Plus,OS=latest' \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
@@ -123,14 +127,14 @@ jobs:
         working-directory: app
         run: xcodegen generate
 
-      - name: build macOS (unsigned)
+      - name: test macOS (unsigned)
         run: |
           set -o pipefail
-          xcodebuild build \
+          xcodebuild test \
             -project app/HelloApp.xcodeproj \
             -scheme HelloApp-macOS \
             -configuration Debug \
-            -destination 'generic/platform=macOS' \
+            -destination 'platform=macOS' \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
@@ -200,15 +204,15 @@ jobs:
         working-directory: app
         run: tuist generate --no-open
 
-      - name: build iOS Simulator (unsigned)
+      - name: test iOS Simulator (unsigned)
         run: |
           set -o pipefail
-          xcodebuild build \
+          xcodebuild test \
             -project app/HelloApp.xcodeproj \
             -scheme HelloApp-iOS \
             -configuration Debug \
             -sdk iphonesimulator \
-            -destination 'generic/platform=iOS Simulator' \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Plus,OS=latest' \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
@@ -235,14 +239,14 @@ jobs:
         working-directory: app
         run: tuist generate --no-open
 
-      - name: build macOS (unsigned)
+      - name: test macOS (unsigned)
         run: |
           set -o pipefail
-          xcodebuild build \
+          xcodebuild test \
             -project app/HelloApp.xcodeproj \
             -scheme HelloApp-macOS \
             -configuration Debug \
-            -destination 'generic/platform=macOS' \
+            -destination 'platform=macOS' \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \


### PR DESCRIPTION
Surfaced by the v1.2 audit. The XcodeGen + Tuist manifests both define UI test targets wired under the scheme's Test action, but the PR workflow's 6 jobs all ran `xcodebuild build` only. The test scaffolding was silently dead code on the PR critical path.

## Changes (4 of 6 jobs converted, build → test)
| Job | Before | After |
|---|---|---|
| `app (iOS Simulator)` | `xcodebuild build` | `xcodebuild test` |
| `app (macOS)` | `xcodebuild build` | `xcodebuild test` |
| `app (Tuist iOS Simulator)` | `xcodebuild build` | `xcodebuild test` |
| `app (Tuist macOS)` | `xcodebuild build` | `xcodebuild test` |

## Left unchanged
`app (iOS device)` + `app (Tuist iOS device)` use `generic/platform=iOS` which can't run tests. Stay build-only — they're the SDK-validation signal.

## Destination changes
- iOS sim: `generic/platform=iOS Simulator` → `platform=iOS Simulator,name=iPhone 16 Plus,OS=latest` (matches fastlane Snapfile)
- macOS: `generic/platform=macOS` → `platform=macOS` (test action doesn't accept generic on macOS)

## Required-check names preserved
The job-output names ("app (iOS Simulator)" etc.) match branch protection's required check list → no branch protection update needed.

Test signal now includes `HelloAppUITests.testAppLaunches` + the macOS counterpart; future tests added under those targets get exercised automatically.