### PR TITLE
feat(app): add HelloAppTests + HelloAppMacOSTests unit-test targets

### DIFF
--- a/app/MacOSTests/HelloAppMacOSTests.swift
+++ b/app/MacOSTests/HelloAppMacOSTests.swift
@@ -1,0 +1,18 @@
+// Stub unit tests for the macOS app. Forks should add real tests here.
+//
+// Run via:
+//   xcodebuild test -project app/HelloApp.xcodeproj \
+//     -scheme HelloApp-macOS -destination 'platform=macOS'
+//
+// CI runs this on every PR via .github/workflows/pr.yml.
+
+import XCTest
+
+final class HelloAppMacOSTests: XCTestCase {
+    func testSmoke() {
+        // Sanity: the unit-test target compiles, links, and the test bundle
+        // launches under xcodebuild test. Replace with real assertions as
+        // your fork adds logic worth testing.
+        XCTAssertEqual(2 + 2, 4)
+    }
+}

--- a/app/Project.swift
+++ b/app/Project.swift
@@ -164,6 +164,36 @@ let macUITestTarget = Target.target(
     ])
 )
 
+// MARK: - Unit test targets (sanity tests; forks should add real tests here)
+
+let iosUnitTestTarget = Target.target(
+    name: "HelloAppTests",
+    destinations: [.iPhone, .iPad],
+    product: .unitTests,
+    bundleId: "com.example.helloapp.tests",
+    deploymentTargets: .iOS("17.0"),
+    infoPlist: .default,
+    sources: ["Tests/**"],
+    dependencies: [.target(name: "HelloApp-iOS")],
+    settings: .settings(base: [
+        "TEST_TARGET_NAME": "HelloApp-iOS",
+    ])
+)
+
+let macUnitTestTarget = Target.target(
+    name: "HelloAppMacOSTests",
+    destinations: [.mac],
+    product: .unitTests,
+    bundleId: "com.example.helloapp.mactests",
+    deploymentTargets: .macOS("14.0"),
+    infoPlist: .default,
+    sources: ["MacOSTests/**"],
+    dependencies: [.target(name: "HelloApp-macOS")],
+    settings: .settings(base: [
+        "TEST_TARGET_NAME": "HelloApp-macOS",
+    ])
+)
+
 // MARK: - Schemes
 
 let iosScheme: Scheme = .scheme(
@@ -175,7 +205,7 @@ let iosScheme: Scheme = .scheme(
     // per-target SWIFT_STRICT_CONCURRENCY=minimal override can't suppress.
     buildAction: .buildAction(targets: ["HelloApp-iOS"]),
     testAction: .targets(
-        ["HelloAppUITests"],
+        ["HelloAppUITests", "HelloAppTests"],
         configuration: .debug
     ),
     runAction: .runAction(configuration: .debug, executable: "HelloApp-iOS"),
@@ -187,7 +217,7 @@ let macScheme: Scheme = .scheme(
     shared: true,
     buildAction: .buildAction(targets: ["HelloApp-macOS"]),
     testAction: .targets(
-        ["HelloAppMacOSUITests"],
+        ["HelloAppMacOSUITests", "HelloAppMacOSTests"],
         configuration: .debug
     ),
     runAction: .runAction(configuration: .debug, executable: "HelloApp-macOS"),
@@ -203,6 +233,6 @@ let project = Project(
         developmentRegion: "en"
     ),
     settings: .settings(base: baseSettings, defaultSettings: .recommended),
-    targets: [iosTarget, macTarget, iosUITestTarget, macUITestTarget],
+    targets: [iosTarget, macTarget, iosUITestTarget, macUITestTarget, iosUnitTestTarget, macUnitTestTarget],
     schemes: [iosScheme, macScheme]
 )

--- a/app/Tests/HelloAppTests.swift
+++ b/app/Tests/HelloAppTests.swift
@@ -1,0 +1,18 @@
+// Stub unit tests for the iOS app. Forks should add real tests here.
+//
+// Run via:
+//   xcodebuild test -project app/HelloApp.xcodeproj \
+//     -scheme HelloApp-iOS -destination 'platform=iOS Simulator,name=iPhone 16 Plus,OS=latest'
+//
+// CI runs this on every PR via .github/workflows/pr.yml.
+
+import XCTest
+
+final class HelloAppTests: XCTestCase {
+    func testSmoke() {
+        // Sanity: the unit-test target compiles, links, and the test bundle
+        // launches under xcodebuild test. Replace with real assertions as
+        // your fork adds logic worth testing.
+        XCTAssertEqual(2 + 2, 4)
+    }
+}

--- a/app/project.yml
+++ b/app/project.yml
@@ -130,6 +130,20 @@ targets:
     dependencies:
       - target: HelloApp-iOS
 
+
+# ─── Unit-test target (sanity tests; forks should add real tests here) ─────
+  HelloAppTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: Tests
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.example.helloapp.tests
+        TEST_TARGET_NAME: HelloApp-iOS
+        GENERATE_INFOPLIST_FILE: YES
+    dependencies:
+      - target: HelloApp-iOS
 # ─── macOS UITest target (drives App Store screenshot capture) ─────────────
   HelloAppMacOSUITests:
     type: bundle.ui-testing
@@ -144,6 +158,20 @@ targets:
     dependencies:
       - target: HelloApp-macOS
 
+# ─── macOS unit-test target ─────────────────────────────────────────────
+  HelloAppMacOSTests:
+    type: bundle.unit-test
+    platform: macOS
+    sources:
+      - path: MacOSTests
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.example.helloapp.mactests
+        TEST_TARGET_NAME: HelloApp-macOS
+        GENERATE_INFOPLIST_FILE: YES
+    dependencies:
+      - target: HelloApp-macOS
+
 # ─── Schemes ──────────────────────────────────────────────────────────
 schemes:
   HelloApp-iOS:
@@ -151,6 +179,7 @@ schemes:
       targets:
         HelloApp-iOS: all
         HelloAppUITests: [test]
+        HelloAppTests: [test]
     run:
       config: Debug
       executable: HelloApp-iOS
@@ -158,6 +187,7 @@ schemes:
       config: Debug
       targets:
         - HelloAppUITests
+        - HelloAppTests
     archive:
       config: Release
 
@@ -166,6 +196,7 @@ schemes:
       targets:
         HelloApp-macOS: all
         HelloAppMacOSUITests: [test]
+        HelloAppMacOSTests: [test]
     run:
       config: Debug
       executable: HelloApp-macOS
@@ -173,5 +204,6 @@ schemes:
       config: Debug
       targets:
         - HelloAppMacOSUITests
+        - HelloAppMacOSTests
     archive:
       config: Release


### PR DESCRIPTION
Surfaced by the v1.2 audit. UI test targets existed (driven by screenshot capture), but **no unit-test target was defined for either iOS or macOS**. The template instills muscle memory for first-time iOS devs — ships-with-zero-unit-tests was the wrong default.

## What's added

| File | Purpose |
|---|---|
| `app/Tests/HelloAppTests.swift` | iOS unit-test stub (XCTest) |
| `app/MacOSTests/HelloAppMacOSTests.swift` | macOS unit-test stub (XCTest) |
| `HelloAppTests` target | iOS unit-test target in project.yml + Project.swift |
| `HelloAppMacOSTests` target | macOS unit-test target in project.yml + Project.swift |

## Schemes wired

- `HelloApp-iOS` testAction → [HelloAppUITests, **HelloAppTests**]
- `HelloApp-macOS` testAction → [HelloAppMacOSUITests, **HelloAppMacOSTests**]

## CI signal coverage

PR's xcodebuild test commands (#87) now exercise both UI tests and unit tests on both XcodeGen + Tuist generators. Forks that add unit tests under `Tests/` or `MacOSTests/` get them run automatically.

## Why XCTest, not Swift Testing
Avoids `@testable import` for now → keeps the main app's strict-concurrency=complete uncomplicated. Forks can migrate as their tests grow.