### PR TITLE
feat(ci): wire swiftlint into PR + commit .swiftlint.yml config

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,6 +43,21 @@ jobs:
           echo "Resolved PLATFORMS=$platforms"
           echo "do_ios=$(echo "$platforms" | grep -qw 'ios'   && echo true || echo false)"   >> "$GITHUB_OUTPUT"
           echo "do_macos=$(echo "$platforms" | grep -qw 'macos' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+  # Lints all Swift sources against .swiftlint.yml at the repo root.
+  # `--strict` treats warnings as errors so the signal is binary.
+  # Excluded paths (Tuist Derived, fastlane SnapshotHelper, build outputs)
+  # are configured in .swiftlint.yml itself, not here.
+  swiftlint:
+    name: swiftlint
+    runs-on: macos-15
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: install swiftlint
+        run: brew install swiftlint
+      - name: lint
+        run: swiftlint --strict --reporter github-actions-logging
+
   # iOS device build is the primary signal — it uses the iphoneos SDK and the
   # real entitlements pathway. Catches bugs the Simulator doesn't (SDK header
   # drift, missing device-only APIs, wrong xcframework slice, etc.).

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,36 @@
+# SwiftLint configuration for apple-shipkit forks.
+#
+# Goal: catch obvious code-style issues without overconstraining a starter
+# template. Forks should tighten this as their codebase grows (enable rules
+# from `opt_in_rules`, lower line_length, etc.).
+#
+# Run locally:    swiftlint
+# Run on PR:      .github/workflows/pr.yml job `swiftlint`
+# Strict mode:    swiftlint --strict   (treats warnings as errors)
+
+# Sources that ship with the template but are not fork-authored. SwiftLint
+# shouldn't gate fork PRs on these.
+excluded:
+  - app/Derived                                # Tuist-generated sources
+  - app/UITests/SnapshotHelper.swift           # fastlane-shipped, do not modify
+  - app/MacOSUITests/SnapshotHelper.swift      # ditto (if present)
+  - .build
+  - DerivedData
+  - vendor
+
+# Rules disabled because they conflict with conventions used in template
+# infrastructure code (Tuist DSL, icon pixel-coord helpers, etc.). Forks
+# can re-enable any of these in their own .swiftlint.yml after they
+# rewrite or remove the offending file.
+disabled_rules:
+  - comma                                # fights Tuist DSL's settings tuples
+  - trailing_comma                       # Tuist convention allows trailing
+  - identifier_name                      # pixel-coord vars (tL, bR) in icon code
+  - non_optional_string_data_conversion  # one-off legacy pattern in scripts
+
+line_length:
+  warning: 140
+  error: 200
+
+# Default rules kept enabled. The full default set is documented at:
+# https://realm.github.io/SwiftLint/rule-directory.html

--- a/ci/gen-macos-icons.swift
+++ b/ci/gen-macos-icons.swift
@@ -31,7 +31,8 @@ import CoreImage.CIFilterBuiltins
 
 let argv = CommandLine.arguments
 guard argv.count == 4 else {
-  FileHandle.standardError.write("usage: swift ci/gen-macos-icons.swift <source-1024.png> <appiconset-dir> <output.icns>\n".data(using: .utf8)!)
+  let usage = "usage: swift ci/gen-macos-icons.swift <source-1024.png> <appiconset-dir> <output.icns>\n"
+  FileHandle.standardError.write(usage.data(using: .utf8)!)
   exit(2)
 }
 let sourceURL    = URL(fileURLWithPath: argv[1])
@@ -44,7 +45,8 @@ guard let nsImage = NSImage(contentsOf: sourceURL),
   exit(1)
 }
 guard cgSource.width >= 1024 && cgSource.height >= 1024 else {
-  FileHandle.standardError.write("source must be ≥1024×1024 (got \(cgSource.width)×\(cgSource.height))\n".data(using: .utf8)!)
+  let msg = "source must be ≥1024×1024 (got \(cgSource.width)×\(cgSource.height))\n"
+  FileHandle.standardError.write(msg.data(using: .utf8)!)
   exit(1)
 }
 let ciSource = CIImage(cgImage: cgSource)


### PR DESCRIPTION
Surfaced by the v1.2 audit. `swiftlint` was in `Brewfile` but invoked by zero callsites — installed-but-unused, while the README + SCOPE.md implied lint signal was active.

## Changes

| File | Purpose |
|---|---|
| `.swiftlint.yml` (new) | Starter ruleset; excludes Tuist-generated + fastlane-shipped sources; disables 4 default rules that fight infrastructure code |
| `.github/workflows/pr.yml` | New `swiftlint` job runs `swiftlint --strict` with github-actions-logging reporter |
| `ci/gen-macos-icons.swift` | One real line-length violation fixed (extract usage string to local `let`) |

## Why `--strict`
Treats warnings as errors → binary signal. Either CI is green or it's not. Forks can relax to non-strict in their own .swiftlint.yml.

## Verified
`swiftlint --strict` exits 0 on current main with this config.