### PR TITLE
feat(app): 2026 baseline — accessibility, localization, struct cleanup

### DIFF
--- a/app/Project.swift
+++ b/app/Project.swift
@@ -60,6 +60,7 @@ let iosTarget = Target.target(
     resources: [
         "iOS/Assets.xcassets",
         "Shared/PrivacyInfo.xcprivacy",
+        "Shared/Localizable.xcstrings",
     ],
     entitlements: .file(path: "iOS/HelloApp.entitlements"),
     settings: .settings(base: [
@@ -121,6 +122,7 @@ let macTarget = Target.target(
     resources: [
         "macOS/Assets.xcassets",
         "Shared/PrivacyInfo.xcprivacy",
+        "Shared/Localizable.xcstrings",
     ],
     entitlements: .file(path: "macOS/HelloApp.entitlements"),
     scripts: [macIconScript],

--- a/app/Shared/ContentView.swift
+++ b/app/Shared/ContentView.swift
@@ -8,8 +8,12 @@ struct ContentView: View {
                 .scaledToFit()
                 .frame(width: 80, height: 80)
                 .foregroundStyle(.tint)
+                // Decorative — the title text below carries the meaning. Mark
+                // hidden so VoiceOver doesn't announce "hammer-and-wrench, image".
+                .accessibilityHidden(true)
             Text("HelloApp")
                 .font(.largeTitle.bold())
+                .accessibilityAddTraits(.isHeader)
             Text("iOS + macOS template")
                 .font(.headline)
                 .foregroundStyle(.secondary)
@@ -21,6 +25,10 @@ struct ContentView: View {
         }
         .padding()
         .frame(minWidth: 320, minHeight: 240)
+        // Single accessibility identifier scoped to the whole stub UI so UI
+        // tests can match the screen without depending on visible text
+        // (which varies once forks localize).
+        .accessibilityIdentifier("HelloApp.stub")
     }
 }
 

--- a/app/Shared/HelloApp.swift
+++ b/app/Shared/HelloApp.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 @main
-struct HelloAppApp: App {
+struct HelloAppMain: App {
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/app/Shared/Localizable.xcstrings
+++ b/app/Shared/Localizable.xcstrings
@@ -1,0 +1,39 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "HelloApp" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HelloApp"
+          }
+        }
+      }
+    },
+    "iOS + macOS template" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iOS + macOS template"
+          }
+        }
+      }
+    },
+    "Rename me. Run `bin/rename.sh --help`." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rename me. Run `bin/rename.sh --help`."
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}


### PR DESCRIPTION
Three bundled improvements from the v1.2 audit:

## 1. Accessibility scaffolding (ContentView.swift)
- `Image(systemName: "hammer.fill")` → `.accessibilityHidden(true)` (decorative)
- Title `Text("HelloApp")` → `.accessibilityAddTraits(.isHeader)` (screen role)
- Stub gets `.accessibilityIdentifier("HelloApp.stub")` (UI tests match by id, not visible text — survives localization)

Instills the right defaults for first-time iOS devs.

## 2. Localization scaffolding (Localizable.xcstrings)
- New `app/Shared/Localizable.xcstrings` with the 3 starter strings pre-keyed in English
- Wired into both XcodeGen + Tuist bundles
- Verified locally: both generators include the file in Resources phase on both iOS + macOS targets

Forks adding new languages just open the catalog in Xcode → add localizations.

## 3. `HelloAppApp` struct → `HelloAppMain`
Apple's @main convention produces `<AppName>App` to avoid collision with the App protocol. After `bin/rename.sh` runs, that becomes `MyAppApp` — awkward double-suffix. `HelloAppMain` post-rename produces `MyAppMain` which is unambiguous.

Trade-off: drifts from Apple's default Xcode template convention. Forks that prefer the Apple convention can rename back in one line.

## Verified locally
- xcodegen + tuist both regenerate clean
- swiftlint --strict passes
- Both PrivacyInfo.xcprivacy (#90) and Localizable.xcstrings ship together → 2026 Apple submission baseline now represented in the starter