### PR TITLE
feat(canary): post to Discord webhook on failure

### DIFF
--- a/.github/workflows/canary-trigger.yml
+++ b/.github/workflows/canary-trigger.yml
@@ -169,3 +169,28 @@ jobs:
           done
           echo "::error::Dispatched run did not complete within 50 minutes (${RUN_URL})"
           exit 1
+
+      - name: Notify Discord on failure
+        if: failure()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_CANARY_WEBHOOK }}
+          GENERATOR: ${{ matrix.generator }}
+          RUN_URL: ${{ steps.locate.outputs.run_url }}
+          TRIGGER_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DISCORD_WEBHOOK:-}" ]; then
+            echo "DISCORD_CANARY_WEBHOOK secret unset — skipping Discord notification."
+            echo "(Optional: configure the secret to route canary failures to a Discord channel.)"
+            exit 0
+          fi
+          # Discord webhook expects {"content": "..."} or {"embeds": [...]}.
+          # Keep payload simple — links speak louder than prose for diagnosis.
+          payload=$(jq -nc \
+            --arg gen   "${GENERATOR}"        \
+            --arg run   "${RUN_URL:-(unknown)}"     \
+            --arg trig  "${TRIGGER_URL}"            \
+            '{ content: ":rotating_light: **Canary failed** — generator=\($gen)\nSmoketest run: \($run)\nTrigger run: \($trig)" }')
+          curl -fsSL -X POST -H 'Content-Type: application/json' -d "${payload}" "${DISCORD_WEBHOOK}" \
+            && echo "Posted Discord notification." \
+            || echo "::warning::Discord notification failed (webhook URL may be invalid; check secret). Continuing."


### PR DESCRIPTION
Surfaced by the v1.2 audit. `canary-trigger.yml`'s failure path emits `::error::` annotations that surface only in the Actions tab. README:506-510 advertises Discord as a first-class community surface, but canary failures never reach Discord.

## What's added
A final `if: failure()` step on each matrix cell that POSTs a one-line failure notification to a Discord webhook. The URL comes from a new optional secret `DISCORD_CANARY_WEBHOOK`.

## Behavior
- secret unset → step exits 0 with a hint
- secret set → POST `{content: 'Canary failed — generator=X ...'}` with smoketest + trigger run links
- POST fails → `::warning::` and continue (don't compound failure)

## Setup for forks
Set the `DISCORD_CANARY_WEBHOOK` repo secret to a Discord channel webhook URL. No code change needed.

No sensitive context in payload (no secret echo, no env dump) — just generator name + two URLs.