### PR TITLE
chore(ci): SHA-pin ruby/setup-ruby (third-party action)

### DIFF
--- a/.github/workflows/bootstrap-doctor-matrix.yml
+++ b/.github/workflows/bootstrap-doctor-matrix.yml
@@ -88,7 +88,7 @@ jobs:
           cp template/.bootstrap.env.example smoketest/
 
       - name: Set up Ruby + bundler cache (in smoketest)
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           ruby-version: '3.3'
           bundler-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
           xcrun --show-sdk-path --sdk iphoneos
 
       - name: Set up Ruby + bundler cache
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           # Pinned here so local dev keeps using whatever ruby you have while
           # CI runs on a maintained release. 3.3 is fastlane-tested and ships


### PR DESCRIPTION
Surfaced by the v1.2 audit. Tag-pinned third-party actions can be rewritten by their maintainer at any time → supply-chain risk. GitHub's security guidance recommends SHA-pinning third-party actions specifically.

## Change
`ruby/setup-ruby@v1` → `ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0` in both files that use it (release.yml + bootstrap-doctor-matrix.yml).

The comment retains the version string so future bumps have a starting point.

## Why not also actions/*?
First-party `actions/*` is covered by GitHub's own security infrastructure. SHA-pinning them is best-practice but lower priority; the audit explicitly flagged third-party only.