### PR TITLE
docs(dx): comparison-to-alternatives + rollback + no-CI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,27 @@ If something isn't on this list, [open an issue](https://github.com/indiagrams/a
 
 ---
 
+## When to use this (vs alternatives)
+
+apple-shipkit is **release-engineering scaffolding** — the path from
+`Use this template` to a signed TestFlight build. It deliberately doesn't
+pick a UI framework, networking stack, or persistence layer. Different
+tradeoff from other iOS starters:
+
+| You want… | Use | Why |
+|---|---|---|
+| Pipeline (signing + CI + TestFlight + ASC submission) prewired | **apple-shipkit** | What this template focuses on. Fastlane + match + GitHub Actions + canary continuous validation. |
+| UI architecture + screens + sample data | [`ios-project-template`](https://github.com/messeb/ios-project-template), [`ios-mvp-template`](https://github.com/onl1ner/ios-mvp-template), or `SwiftPlate` | These ship app scaffolding (MVVM/MVP/Coordinator). You'd bring fastlane/CI yourself. |
+| Generate a fresh project from a manifest | `tuist scaffold` | Generates project files. No signing, no CI, no release wiring. |
+| Subscription bundle (RevenueCat + paywall + IAP) | [RevenueCat Quickstart](https://www.revenuecat.com/docs/getting-started/quickstart) | apple-shipkit is intentionally framework-agnostic; bring your own monetization. |
+| Bare `gh repo create` from a Swift project you already have | _no template needed_ | apple-shipkit is for people who don't have the project yet, or who do but want fastlane/CI/match prewired. |
+
+Mix-and-match is fine. Many people start with apple-shipkit for the
+release pipeline, then drop in a UI template's screens or a RevenueCat
+paywall on top.
+
+---
+
 ## Going deeper (advanced)
 
 Once you're past the first ship, these docs cover the rest:
@@ -384,6 +405,8 @@ Once you're past the first ship, these docs cover the rest:
 - **[docs/MIGRATING-TO-TUIST.md](docs/MIGRATING-TO-TUIST.md)** — switching from XcodeGen to Tuist after fork.
 - **[docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md](docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md)** — same archive/export flow without fastlane (uses `xcrun altool` + `notarytool` + ASC API directly).
 - **[docs/PRINCIPLES.md](docs/PRINCIPLES.md)** — design decisions behind the template's structure.
+- **[docs/ROLLBACK.md](docs/ROLLBACK.md)** — undoing a TestFlight build, a git tag, or a partial bootstrap-fork.
+- **[docs/NO-CI.md](docs/NO-CI.md)** — running the template in local-only mode (no GitHub Actions, no GH Secrets, no match).
 
 ---
 

--- a/docs/NO-CI.md
+++ b/docs/NO-CI.md
@@ -1,0 +1,118 @@
+# Local-only mode (no GitHub Actions)
+
+If your fork ships from your laptop, not from CI, you can disable the GitHub Actions release pipeline entirely.
+
+## What changes in local-only mode
+
+| | CI mode (default) | Local-only mode |
+|---|---|---|
+| Where you run `make ship` | GitHub Actions runner | Your Mac |
+| Code signing | fastlane match against private certs repo | Local Keychain (Xcode "Automatically manage signing") |
+| Required GH Secrets | 7 (ASC API key, match password, etc.) | 0 |
+| Bootstrap pipeline length | 17 steps | 11 steps |
+| Branch protection | 6 required CI checks | None (set yourself if you want) |
+
+Local-only mode is appropriate for:
+
+- **Solo indie shipping** — you trust your own laptop, no team workflow
+- **Personal apps** — no need to gate merges on CI
+- **Apps where match overhead exceeds benefit** — single dev, single machine, occasional ships
+
+CI mode is the right default for everyone else (multi-dev, security-sensitive, or any case where local laptop drift would be a liability).
+
+## How to enable local-only mode
+
+### 1. Set RELEASE_MODE in `.bootstrap.env`
+
+```bash
+# .bootstrap.env
+RELEASE_MODE=local
+APP_NAME=YourApp
+APP_BUNDLE_ID=com.yourorg.yourapp
+FASTLANE_TEAM_ID=ABCD1234567
+ASC_API_KEY_ID=...
+ASC_API_KEY_ISSUER_ID=...
+ASC_API_KEY_P8_PATH=~/.config/secrets/AuthKey_XXX.p8
+ASC_APP_SKU=YOURAPP_SKU
+ASC_APP_NAME=Your App Display Name
+# CI-only fields (CERTS_REPO, MATCH_PASSWORD, etc.) — leave unset or omit
+```
+
+`make doctor` will detect `RELEASE_MODE=local` and skip the 6 CI-only steps (CreateCertsRepo, GHSecrets, BootstrapCerts, MintInstaller, EditMatchfile, etc.).
+
+### 2. Disable the PR + release workflows
+
+You have two options:
+
+**A. Delete the workflows**
+
+```bash
+rm .github/workflows/pr.yml
+rm .github/workflows/release.yml
+git add .github/workflows
+git commit -m "chore: remove CI workflows for local-only mode"
+git push
+```
+
+You lose the PR-time build/test signal, but `make ship` still works locally because it shells into `ci/local-release-check.sh` directly (no Actions dependency).
+
+**B. Keep them but turn off branch protection**
+
+Branch protection requires the 6 CI checks to pass before merging. Without CI, those checks never run → PRs can never merge. Disable via:
+
+```bash
+gh api -X DELETE repos/$YOUR_ORG/$YOUR_REPO/branches/main/protection
+```
+
+Or in the GitHub web UI: Settings → Branches → main → Delete rule.
+
+### 3. Skip `make setup-github`
+
+`bin/setup-github.sh` configures the 6 required CI checks. In local-only mode, don't run it (or remove it from your `make all` target).
+
+## What `make ship` does in local-only mode
+
+The same `make ship` command works on your Mac as on CI. It:
+
+1. Reads `.bootstrap.env`
+2. Reads `RELEASE_MODE=local` → uses Xcode-managed signing instead of match
+3. Runs `ci/local-release-check.sh` to archive + export iOS .ipa + macOS .pkg
+4. Runs `fastlane pilot` to upload to TestFlight
+5. Pushes a `vYYYY.WW.<run_number>` tag
+
+`<run_number>` in local mode is sourced from a local counter (`fastlane/.local_run_number`) since there's no GitHub `${{ github.run_number }}` to use.
+
+## Bootstrap.env minimum for local-only
+
+The minimum to reach a green `make doctor` in local mode:
+
+```bash
+RELEASE_MODE=local
+APP_NAME=YourApp
+APP_BUNDLE_ID=com.yourorg.yourapp
+FASTLANE_TEAM_ID=ABCD1234567
+ASC_API_KEY_ID=...
+ASC_API_KEY_ISSUER_ID=...
+ASC_API_KEY_P8_PATH=~/.config/secrets/AuthKey_XXX.p8
+ASC_APP_SKU=YOURAPP
+ASC_APP_NAME=Your App Display Name
+PLATFORMS=ios,macos
+```
+
+(Same as CI mode minus the certs/match fields.)
+
+## When to switch back to CI mode
+
+You'll want CI mode if any of these become true:
+
+- A second human starts contributing
+- You ship from multiple machines
+- You want PR-time test signal
+- You want the weekly canary pattern to validate Apple-side state
+
+The switch is reversible: change `RELEASE_MODE=ci`, run `make bootstrap-fork` (the now-active CI-only steps will run), restore the workflows + branch protection.
+
+## See also
+
+- [`docs/BOOTSTRAP.md`](BOOTSTRAP.md) — full `.bootstrap.env` reference (RELEASE_MODE table at the top)
+- [`bin/lib/bootstrap.rb`](../bin/lib/bootstrap.rb) — `Step::MODES` constant tells you which steps are CI-only / local-only / both

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -1,0 +1,82 @@
+# Rollback / Undo
+
+What to do if a `make ship` lands a build you didn't mean to ship, or if `make bootstrap-fork` fails partway through.
+
+## Roll back a TestFlight build
+
+TestFlight builds can't be deleted, but you can mark them expired (invisible to testers) and replace them. Two paths:
+
+### Via App Store Connect web UI (fastest)
+
+1. https://appstoreconnect.apple.com → My Apps → your app
+2. TestFlight tab → iOS or macOS sidebar → Builds
+3. Click the build you want to retire → "Expire" button (top-right) → confirm
+4. Push a fresh build via `make ship` (CalVer auto-bumps to a new version)
+
+### Via fastlane
+
+```bash
+bundle exec fastlane run testflight_expire build_number:<N>
+```
+
+Where `<N>` is the integer build number visible in ASC (e.g. `21`, not the full `v2026.19.21` tag).
+
+## Roll back a git tag
+
+If you pushed a tag and need to invalidate it (e.g. you noticed a secret leak post-push):
+
+```bash
+# Remove the tag locally + on origin
+git tag -d v2026.19.X
+git push --delete origin v2026.19.X
+```
+
+The tag's TestFlight build is still in ASC — handle that separately via the steps above.
+
+## Roll back a partial bootstrap-fork
+
+If `make bootstrap-fork` fails on step N of 17, the pipeline is **idempotent** — re-running picks up where it left off:
+
+```bash
+make doctor          # see which step is the next pending one
+make bootstrap-fork  # resumes from that step
+```
+
+If a specific step keeps failing and you want to skip it (rare; usually means upstream Apple/GH state is wrong):
+
+1. Read the step's `check` and `do_it` methods in `bin/lib/bootstrap.rb`
+2. Either fix the upstream state manually (e.g. delete the conflicting bundle ID in Apple Developer portal, then re-run), or
+3. If the step is genuinely optional for your fork, delete it from the `PIPELINE` constant in `bin/lib/bootstrap.rb`. Don't skip it silently — leave a comment explaining why.
+
+## Reset a fork to a clean slate
+
+If you want to nuke a fork's Apple-side state and start over (e.g. you used the wrong bundle ID and want to free it up):
+
+```bash
+# 1. Delete the ASC App record (web UI; ASC API forbids DELETE)
+#    https://appstoreconnect.apple.com → your app → App Information → Delete
+
+# 2. Free the bundle ID
+#    https://developer.apple.com/account/resources/identifiers/list
+#    Click bundle ID → bottom of page → Delete
+
+# 3. Optionally: clear the certs repo
+git -C path/to/your-certs-repo log  # see what's in it
+# fastlane match nuke distribution --readonly false   # nukes distro certs
+# fastlane match nuke development --readonly false    # nukes dev certs
+
+# 4. Re-run from a clean state
+make bootstrap-fork
+```
+
+**Caution:** `match nuke` revokes certificates Apple-side. If your other apps share this team, they'll need to re-mint. Only do this if you're sure no other app depends on these certs.
+
+## Reset the smoketest fork (maintainer-only)
+
+For canary-related rollback see `bin/refork-smoketest.sh` — destructive E2E that recreates the smoketest fork from scratch.
+
+## See also
+
+- [`docs/CONTINUOUS-VALIDATION.md`](CONTINUOUS-VALIDATION.md) — the catalog of Apple-side gotchas the canary has surfaced
+- [`docs/BOOTSTRAP.md`](BOOTSTRAP.md) — full `.bootstrap.env` reference
+- [`bin/lib/bootstrap.rb`](../bin/lib/bootstrap.rb) — the 19-step pipeline source


### PR DESCRIPTION
Three DX gaps from the v1.2 audit:

## 1. README → 'When to use this (vs alternatives)' section
5-row comparison table that positions apple-shipkit vs SwiftPlate / ios-project-template / tuist scaffold / RevenueCat / bare gh repo. Answers 'why this vs X?' — frequent first reviewer question.

## 2. New docs/ROLLBACK.md
Walk-through for the four common rollback scenarios: TestFlight build, git tag, partial bootstrap-fork, full Apple-side reset.

## 3. New docs/NO-CI.md
RELEASE_MODE=local setup: how to run the template without GitHub Actions, GH Secrets, or match. For solo indie shippers who don't want the CI overhead.

## APPLE-PREREQS.md
Audit recommendation reconsidered. Deeper read showed it's a structured Apple-tier comparison + concrete needs list (not the 'list of nouns' the audit characterized). Kept unchanged.