### PR TITLE
chore: add 'swiftlint' to required-checks list (now 7, was 6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ If you fork this template and your build breaks Monday morning out of the blue, 
 │   ├── lib/bootstrap.rb         # the orchestration framework
 │   ├── rename.sh                # rename HelloApp → YourApp
 │   ├── switch-to-tuist.sh       # one-way XcodeGen → Tuist switch
-│   ├── setup-github.sh          # branch protection + squash-only + 6 required checks
+│   ├── setup-github.sh          # branch protection + squash-only + 7 required checks
 │   ├── preflight.sh             # check developer-tool prerequisites
 │   └── ...                      # several smaller helpers
 ├── ci/

--- a/bin/setup-github.sh
+++ b/bin/setup-github.sh
@@ -6,9 +6,9 @@
 #   - Default branch: main
 #   - Branch protection on main:
 #       * Require PR before merging (no direct pushes)
-#       * Require 6 status checks: 3 XcodeGen (app (iOS device), app (iOS Simulator),
-#         app (macOS)) + 3 Tuist parity (app (Tuist iOS device),
-#         app (Tuist iOS Simulator), app (Tuist macOS))
+#       * Require 7 status checks: swiftlint + 3 XcodeGen (app (iOS device),
+#         app (iOS Simulator), app (macOS)) + 3 Tuist parity (app (Tuist iOS
+#         device), app (Tuist iOS Simulator), app (Tuist macOS))
 #       * Require status checks to be up-to-date before merge
 #       * Enforce on admins (no bypass — same rules apply to repo owner)
 #       * Require linear history
@@ -97,6 +97,10 @@ fi
 if echo "$PLATFORMS_VAL" | grep -qw 'macos'; then
   CHECKS+=( "app (macOS)" "app (Tuist macOS)" )
 fi
+
+# `swiftlint` always runs (no platform gate) — append unconditionally so
+# every fork's required-checks list includes it regardless of PLATFORMS.
+CHECKS+=( "swiftlint" )
 
 if [ ${#CHECKS[@]} -eq 0 ]; then
   echo "ERROR: PLATFORMS=$PLATFORMS_VAL produced no required checks. Must include 'ios', 'macos', or both." >&2

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -110,7 +110,7 @@ a partial failure picks up where you left off.
 | 4 | Wire fastlane/Matchfile | Substitutes `git_url` to point at your certs repo |
 | 5 | Toolchain | `make bootstrap` (brew bundle + lefthook + xcodegen/tuist + bundler) |
 | 6 | Initial commit + push | First commit (rename + Matchfile) pushed to `origin/main` |
-| 7 | Branch protection | `bin/setup-github.sh` (6 required checks, squash-only, linear history) |
+| 7 | Branch protection | `bin/setup-github.sh` (7 required checks: swiftlint + xcodegen iOS device/sim + macOS + tuist parity, squash-only, linear history) |
 | 8 | Private certs repo | `gh repo create --private` if absent |
 | 9 | 7 GH Secrets | Generates `MATCH_PASSWORD` + `KEYCHAIN_PASSWORD` if absent, encodes the PAT + p8, sets all 7 secrets |
 | 10 | Bundle ID registration | `fastlane register_app_id` (idempotent — Spaceship `BundleId.create` rescues `ALREADY_EXISTS`) |

--- a/docs/NO-CI.md
+++ b/docs/NO-CI.md
@@ -10,7 +10,7 @@ If your fork ships from your laptop, not from CI, you can disable the GitHub Act
 | Code signing | fastlane match against private certs repo | Local Keychain (Xcode "Automatically manage signing") |
 | Required GH Secrets | 7 (ASC API key, match password, etc.) | 0 |
 | Bootstrap pipeline length | 17 steps | 11 steps |
-| Branch protection | 6 required CI checks | None (set yourself if you want) |
+| Branch protection | 7 required CI checks | None (set yourself if you want) |
 
 Local-only mode is appropriate for:
 
@@ -68,7 +68,7 @@ Or in the GitHub web UI: Settings → Branches → main → Delete rule.
 
 ### 3. Skip `make setup-github`
 
-`bin/setup-github.sh` configures the 6 required CI checks. In local-only mode, don't run it (or remove it from your `make all` target).
+`bin/setup-github.sh` configures the 7 required CI checks. In local-only mode, don't run it (or remove it from your `make all` target).
 
 ## What `make ship` does in local-only mode
 


### PR DESCRIPTION
Live branch protection updated out-of-band; this PR keeps the source-of-truth (`bin/setup-github.sh` + 4 docs) in sync.

After #89 wired swiftlint into pr.yml, the job ran on every PR but wasn't in the required-checks list — a swiftlint failure didn't block merge. Now it does.

## Touched
- `bin/setup-github.sh` — CHECKS array appends `'swiftlint'` unconditionally (no platform gate); header comment 6 → 7
- `docs/BOOTSTRAP.md:113`, `docs/NO-CI.md:13,71`, `README.md:480` — count refs updated

Re-runs of `make setup-github` from a fork now produce the 7-check protection that matches the upstream apple-shipkit's main branch.