### PR TITLE
test(canary): TEMPORARY — force failure to verify Discord webhook e2e

### DIFF
--- a/.github/workflows/canary-trigger.yml
+++ b/.github/workflows/canary-trigger.yml
@@ -97,6 +97,19 @@ jobs:
           echo "baseline=${baseline}" >> "${GITHUB_OUTPUT}"
           echo "Baseline (only runs created after this count): ${baseline}"
 
+      # ─── TEMPORARY (PR-A) ─────────────────────────────────────────────
+      # Forces the workflow to fail before dispatching the smoketest, so the
+      # `Notify Discord on failure` step at the end fires and we can verify
+      # the DISCORD_CANARY_WEBHOOK secret + payload format end-to-end.
+      # Reverted in the immediately-following PR-B once Discord delivery is
+      # observed. Costs ~5s of CI per cell instead of waiting for a real
+      # canary failure days/weeks later.
+      - name: TEMPORARY — force failure for Discord webhook e2e test
+        run: |
+          echo "::warning::Forcing failure to test Discord notification path. Revert in next PR."
+          exit 1
+      # ─── END TEMPORARY ────────────────────────────────────────────────
+
       - name: Dispatch smoketest release (${{ matrix.generator }})
         run: |
           dry_run='${{ inputs.dry_run }}'


### PR DESCRIPTION
**TEMPORARY — to be immediately followed by PR-B revert.**

Inserts an early `exit 1` after baseline-capture so the workflow fails before dispatching the smoketest. The `if: failure()` Discord notification step at the end fires and we can verify the wiring end-to-end.

After merging this:
1. Dispatch `canary-trigger.yml` manually via `gh workflow run`
2. Watch Discord — both matrix cells (xcodegen + tuist) should post a failure message within ~30s
3. Open PR-B to revert