### PR TITLE
Revert 'test(canary): TEMPORARY — force failure to verify Discord webhook e2e'

### DIFF
--- a/.github/workflows/canary-trigger.yml
+++ b/.github/workflows/canary-trigger.yml
@@ -97,19 +97,6 @@ jobs:
           echo "baseline=${baseline}" >> "${GITHUB_OUTPUT}"
           echo "Baseline (only runs created after this count): ${baseline}"
 
-      # ─── TEMPORARY (PR-A) ─────────────────────────────────────────────
-      # Forces the workflow to fail before dispatching the smoketest, so the
-      # `Notify Discord on failure` step at the end fires and we can verify
-      # the DISCORD_CANARY_WEBHOOK secret + payload format end-to-end.
-      # Reverted in the immediately-following PR-B once Discord delivery is
-      # observed. Costs ~5s of CI per cell instead of waiting for a real
-      # canary failure days/weeks later.
-      - name: TEMPORARY — force failure for Discord webhook e2e test
-        run: |
-          echo "::warning::Forcing failure to test Discord notification path. Revert in next PR."
-          exit 1
-      # ─── END TEMPORARY ────────────────────────────────────────────────
-
       - name: Dispatch smoketest release (${{ matrix.generator }})
         run: |
           dry_run='${{ inputs.dry_run }}'


### PR DESCRIPTION
Revert of #102. Discord webhook e2e verified — both cells (xcodegen + tuist) posted to the channel successfully (run [25487325367](https://github.com/indiagrams/apple-shipkit/actions/runs/25487325367), step 8 'Notify Discord on failure' succeeded with 'Posted Discord notification.').

Restores canary-trigger.yml to working state. Next Monday's cron will dispatch the smoketest normally.