### PR TITLE
chore(ci): SHA-pin all actions/* uses (full supply-chain hygiene)

### DIFF
--- a/.github/workflows/bootstrap-doctor-matrix.yml
+++ b/.github/workflows/bootstrap-doctor-matrix.yml
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout template (this repo)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           path: template
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - id: matrix
         run: |
           set -euo pipefail
@@ -85,7 +85,7 @@ jobs:
       HOMEBREW_NO_INSTALL_CLEANUP: "1"
       HOMEBREW_NO_ANALYTICS: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: install swiftlint
         run: brew install swiftlint
       - name: lint
@@ -110,7 +110,7 @@ jobs:
       HOMEBREW_NO_INSTALL_CLEANUP: "1"
       HOMEBREW_NO_ANALYTICS: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: install xcbeautify + generator
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
       FASTLANE_SKIP_UPDATE_CHECK:    '1'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # Tag push at end of release lane needs full history; setting 0 also
           # gives fastlane access to all prior tags for changelog/rev parsing.
@@ -235,7 +235,7 @@ jobs:
           fi
 
       - name: Upload artifacts (.ipa + .pkg + .sha256)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: signed-builds-${{ steps.ver.outputs.version }}

--- a/.github/workflows/verify-rename.yml
+++ b/.github/workflows/verify-rename.yml
@@ -32,7 +32,7 @@ jobs:
     # D-08: 10x the SPEC's <30s budget; generous cold-runner headroom.
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: install xcodegen
         run: brew install xcodegen


### PR DESCRIPTION
## What

Pins every `actions/*` reference in `.github/workflows/*` to an immutable commit SHA, with a trailing `# v4.x.y` comment for human readability. Matches the pinning format already used for `ruby/setup-ruby` (#96).

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` (4 uses) | `@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1` |
| `actions/upload-artifact` | `@v4` (1 use) | `@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2` |

## Why pin first-party actions

The earlier audit (#96) framed first-party `actions/*` as 'covered by GitHub's own infrastructure' and pinned only `ruby/setup-ruby`. That distinction is real — GitHub directly controls the `actions/*` repos — but it doesn't make them immune to the threat that tag-pinning is supposed to mitigate. Tags are mutable refs. Whoever controls the action repo (whether Microsoft or `@me-on-twitter`) can rewrite `v4` to point at a different commit at any time, and our workflows would silently start running it.

SHA-pinning removes the rewrite surface entirely. The `# v4.3.1` comment preserves the human-readable version so you can still scan the file and know what's running.

## Trade-off

Slightly more friction when bumping versions — you now need the new SHA, not just the new version tag. `bin/lib/bootstrap.rb` has no automation for that yet; it'd be a Renovate / Dependabot rule. Worth doing whenever someone wants it.