### PR TITLE
fix: 2 BLOCKERs + 5 HIGH/MEDIUM friction points from local-mode validation

### DIFF
--- a/.bootstrap.env.example
+++ b/.bootstrap.env.example
@@ -1,10 +1,12 @@
 # ─── Fork bootstrap configuration ─────────────────────────────────────────────
 #
-# Copy this file to `.bootstrap.env` (gitignored), fill in values, then run:
-#   make doctor      # validate config + probe Apple/GH; print what's done vs missing
-#   make bootstrap   # idempotent: drive every programmatic step from this config
-#   make ship        # trigger release.yml + tail until green
-#   make verify      # confirm TestFlight build appeared in App Store Connect
+# `make init` scaffolds this file from .bootstrap.env.example (gitignored).
+# Fill in values, then run the forker journey:
+#   make doctor          # validate config + probe Apple/GH; print done vs blocked
+#   make bootstrap-fork  # idempotent: drive every programmatic step from this config
+#   make ship            # trigger release (workflow_dispatch in CI mode, local lane in local mode)
+#   make verify          # confirm TestFlight build appeared in App Store Connect
+# Or run all four with `make all`.
 #
 # Sensitive values are referenced by file path (so the dotenv itself stays low-
 # blast-radius). The actual secret bytes live in mode-0600 files outside the

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,22 @@
 # Developer entry points for the iOS + macOS template.
 #
-# Run `make bootstrap` once after cloning. After that, `git push` runs
-# ci/local-check.sh --fast automatically via lefthook.
+# Forking your own app from this template? The path is:
 #
-# The stub app is named "HelloApp" with bundle id "com.example.helloapp".
-# Rename for your project: run `bin/rename.sh --help`.
+#   1. gh repo create my-app --template indiagrams/apple-shipkit --public --clone
+#   2. cd my-app && make bootstrap   # one-time dev-env setup (brew + ruby gems + xcodegen + git hooks)
+#   3. make init                     # scaffolds .bootstrap.env (auto-fills GH_ORG/GH_APP_REPO from origin)
+#   4. $EDITOR .bootstrap.env        # fill in APP_NAME, BUNDLE_ID, Apple credentials, RELEASE_MODE
+#   5. make all                      # doctor → bootstrap-fork → ship → verify (the full forker journey)
+#
+# Maintaining this template? `make check` runs the local CI check, lefthook
+# wires it onto every push, and `make doctor` validates `.bootstrap.env` end
+# to end without mutating any state.
 
-.PHONY: all go bootstrap check check-ios check-macos check-sim build generate icons screenshots release-dryrun setup-github phase-checklist milestone-checklist help init doctor bootstrap-fork ship verify
+.PHONY: all go bootstrap check check-ios check-macos check-sim build generate icons screenshots release-dryrun setup-github phase-checklist milestone-checklist help init doctor bootstrap-fork ship verify _check-bundle
 
 help:
 	@echo "Targets:"
-	@echo "  bootstrap        One-time setup (brew bundle, lefthook install, xcodegen, bundle install)"
+	@echo "  bootstrap        One-time dev-env setup after clone (brew bundle, lefthook install, xcodegen, bundle install). Distinct from bootstrap-fork."
 	@echo "  check            Same as: ci/local-check.sh --fast (iOS device build)"
 	@echo "  check-ios        iOS device build (primary signal)"
 	@echo "  check-sim        iOS Simulator build (backup signal)"
@@ -23,7 +29,7 @@ help:
 	@echo "  init             Scaffold .bootstrap.env from .bootstrap.env.example, auto-fill GH_ORG/GH_APP_REPO from origin remote"
 	@echo "  all              One-shot: doctor → bootstrap-fork → ship → verify (the full forker journey)"
 	@echo "  doctor           Read .bootstrap.env, validate Apple+GH credentials, print pipeline status"
-	@echo "  bootstrap-fork   Idempotent: drive every programmatic fork-bootstrap step from .bootstrap.env"
+	@echo "  bootstrap-fork   Idempotent fork-bootstrap: certs, ASC bundle id, GH branch protection, etc. Reads .bootstrap.env."
 	@echo "  ship             Trigger release.yml workflow_dispatch + tail until the run completes"
 	@echo "  verify           Confirm the latest tagged build appeared in App Store Connect"
 	@echo "  phase-checklist  Print the GSD canonical per-phase checklist (usage: make phase-checklist N=3.1)"
@@ -59,7 +65,7 @@ icons:
 screenshots:
 	ci/take-screenshots.sh
 
-release-dryrun:
+release-dryrun: _check-bundle
 	bundle exec fastlane release tag:v0.0.0 skip_upload:true skip_tag:true
 
 setup-github:
@@ -68,17 +74,30 @@ setup-github:
 init:
 	@bin/init-bootstrap-env.sh
 
-doctor:
+doctor: _check-bundle
 	@bundle exec ruby bin/doctor.rb
 
-bootstrap-fork:
+bootstrap-fork: _check-bundle
 	@bundle exec ruby bin/bootstrap-fork.rb
 
-ship:
+ship: _check-bundle
 	@bundle exec ruby bin/ship.rb
 
-verify:
+verify: _check-bundle
 	@bundle exec ruby bin/verify-testflight.rb
+
+# Guard for bundle-using targets above. Fails fast with an actionable hint
+# when ruby gems aren't installed yet (typical on a fresh fork before
+# `make bootstrap` has run). Without this guard, `make doctor` would crash
+# with a Bundler::GemNotFound stack trace before the user has any chance to
+# learn what went wrong.
+_check-bundle:
+	@bundle check >/dev/null 2>&1 || { \
+	  printf "\nRuby gems aren't installed yet. Run one of:\n\n"; \
+	  printf "    bundle install            # install just the ruby gems\n"; \
+	  printf "    make bootstrap            # full dev-env setup (brew + lefthook + xcodegen + bundle)\n\n"; \
+	  exit 1; \
+	}
 
 all: doctor bootstrap-fork ship verify
 go: all

--- a/README.md
+++ b/README.md
@@ -194,8 +194,15 @@ This creates `https://github.com/<your-username>/my-cool-app`, copies the templa
 
 The template ships with a starter app called **HelloApp**. Time to make it yours.
 
+First, run the one-time dev-env setup. This installs the Ruby gems (fastlane et al.), Homebrew packages (xcodegen, lefthook, etc.), regenerates the Xcode project, and wires up the pre-push git hook. Takes ~30-90 seconds depending on what's already installed:
+
 ```bash
-# Scaffold a config file for the bootstrap pipeline:
+make bootstrap
+```
+
+Then scaffold a config file for the fork-bootstrap pipeline:
+
+```bash
 make init
 ```
 

--- a/bin/lib/bootstrap.rb
+++ b/bin/lib/bootstrap.rb
@@ -79,10 +79,21 @@ module Bootstrap
         next if line.empty? || line.start_with?("#")
         key, _, val = line.partition("=")
         UI.fail!(".bootstrap.env line #{idx + 1}: missing '='") if val.nil? || key.strip.empty?
-        # Strip surrounding quotes if symmetric
         val = val.strip
         if (val.start_with?("'") && val.end_with?("'")) || (val.start_with?('"') && val.end_with?('"'))
+          # Quoted value: strip surrounding quotes; preserve any '#' inside.
           val = val[1..-2]
+        elsif (comment_at = val.index(/\s#/))
+          # Unquoted value with an inline comment: strip everything from the
+          # first whitespace-hash onward (dotenv convention). Bare '#' inside
+          # an unquoted value (e.g. URL fragments) is preserved.
+          # The .bootstrap.env.example template ships every fillable field
+          # with an inline `# placeholder` comment; without this strip, a
+          # forker who fills `BUNDLE_ID=com.foo.bar` while leaving the
+          # trailing `# iOS + macOS share the same bundle id.` comment
+          # would have that comment text mashed onto the bundle id, breaking
+          # every downstream Apple/GH probe.
+          val = val[0...comment_at].rstrip
         end
         values[key.strip] = val
       end
@@ -875,6 +886,7 @@ module Bootstrap
 
       UI.section "Pipeline status"
       results = []
+      blockers = []  # collected for the action-required tail message
       @steps.each_with_index do |step, idx|
         result = step.check
         case result
@@ -882,7 +894,7 @@ module Bootstrap
           puts "  #{(idx + 1).to_s.rjust(2)}. #{UI.ok step.name}"
           results << :done
         when :pending
-          puts "  #{(idx + 1).to_s.rjust(2)}. #{UI.miss step.name}#{UI.dim ' — will run on bootstrap'}"
+          puts "  #{(idx + 1).to_s.rjust(2)}. #{UI.miss step.name}#{UI.dim ' — will run on bootstrap-fork'}"
           results << :pending
         when Array
           severity, msg = result
@@ -891,9 +903,14 @@ module Bootstrap
             puts msg.lines.map { |l| "      #{UI.dim l.chomp}" }.join("\n")
             results << :warn
           else
-            puts "  #{(idx + 1).to_s.rjust(2)}. #{UI.warn step.name}"
+            # Blocked: visually separate from :warn (advisory) by using the
+            # red ✗ glyph + a "needs fix" suffix, and from :pending by
+            # rendering the underlying error message at full intensity
+            # (not dim) so it pulls the eye.
+            puts "  #{(idx + 1).to_s.rjust(2)}. #{UI.miss step.name}#{UI.bold ' — needs fix'}"
             puts msg.lines.map { |l| "      #{l}" }.join
             results << :blocked
+            blockers << "#{idx + 1}. #{step.name}"
           end
         end
       end
@@ -906,21 +923,27 @@ module Bootstrap
       cells = ["#{UI.ok "#{done} done"}"]
       cells << UI.miss("#{pending} pending") if pending > 0
       cells << UI.warn("#{warned} advisory") if warned > 0
-      cells << UI.warn("#{blocked} blocked") if blocked > 0
+      cells << UI.miss("#{blocked} blocked") if blocked > 0
       puts "  #{cells.join('    ')}"
 
       if blocked > 0
         puts
-        puts UI.bold "Action required: resolve the ⚠ items above, then re-run `make doctor`."
+        puts UI.bold "Action required: fix the ✗ blocked items above, then re-run `make doctor`:"
+        blockers.each { |b| puts UI.dim("  • #{b}") }
+        if warned > 0
+          puts
+          puts UI.dim("(#{warned} advisory ⚠ items above are App-Store-review-only and don't block TestFlight.)")
+        end
         exit 2
       elsif pending > 0
         puts
         puts UI.bold "Run `make bootstrap-fork` to close the ✗ items."
+        puts UI.dim("(#{warned} advisory ⚠ items above are App-Store-review-only and don't block TestFlight.)") if warned > 0
         exit 0
       else
         puts
         puts UI.bold "All bootstrap steps complete. Run `make ship` to trigger a release."
-        puts UI.dim("(#{warned} advisory items above are App-Store-review-only and don't block TestFlight)") if warned > 0
+        puts UI.dim("(#{warned} advisory ⚠ items above are App-Store-review-only and don't block TestFlight.)") if warned > 0
         exit 0
       end
     end

--- a/bin/preflight.sh
+++ b/bin/preflight.sh
@@ -155,8 +155,9 @@ cat <<'EOF'
     2. Quickstart from a fresh fork:
 
          gh repo create my-app --template indiagrams/apple-shipkit --public --clone && cd my-app
-         bin/rename.sh YourApp com.your-org.yourapp 'Your App' --email=you@example.com
-         make bootstrap
-         make check
+         make bootstrap            # one-time dev-env setup (brew + ruby gems + xcodegen + git hooks)
+         make init                 # scaffolds .bootstrap.env (auto-fills GH_ORG/GH_APP_REPO from origin)
+         $EDITOR .bootstrap.env    # fill APP_NAME, BUNDLE_ID, Apple credentials, RELEASE_MODE
+         make all                  # doctor → bootstrap-fork → ship → verify
 
 EOF


### PR DESCRIPTION
## What

Real run-through of the local-mode onboarding from a fresh clone (`/tmp/shipkit-validation`) surfaced two blocker-class bugs the static audit missed, plus five HIGH/MEDIUM friction points. All seven addressed here; re-validation confirms each fix.

## BLOCKERs (caught by running, missed by static audit)

| # | Bug | Fix |
|---|---|---|
| 1 | `make doctor` crashes on fresh fork with `Bundler::GemNotFound` stack trace before user has any chance to learn what went wrong. README onboarding never says to `bundle install`. | New `_check-bundle` Makefile guard target that all bundle-using targets depend on. Friendly failure message lists the two ways to fix it. README Step 6 now starts with `make bootstrap`. |
| 2 | Env parser kept inline `# comments` as part of values. Naive editing pattern (fill value before the `#`) corrupts every fillable field with 30+ chars of comment garbage. | Parser strips `\s#` onward for unquoted values. Quoted values retain any `#`. URL-fragment edge case preserved. |

## HIGH

| # | Issue | Fix |
|---|---|---|
| 3 | `make bootstrap` ≠ `make bootstrap-fork` but two surfaces (Makefile header, scaffolded `.bootstrap.env` header) called the wrong one. | Both rewritten to canonical flow with explicit distinction. |
| 4+5 | Doctor output flattened `:warn` (advisory) and `:blocked` (urgent) into the same ⚠ glyph; tail message didn't name the blockers. | `:blocked` now uses `✗` + bold 'needs fix'; `:warn` keeps `⚠` (advisory); tail enumerates blockers explicitly. |

## MEDIUM

| # | Issue | Fix |
|---|---|---|
| 6 | `bin/preflight.sh` 'Next steps' advised legacy `bin/rename.sh` path | Replaced with canonical `make bootstrap → make init → make all` flow |
| 7 | Makefile top-of-file comment same problem | Covered by #3 |

## Verification

Both BLOCKER fixes were verified by re-running against the same `/tmp/shipkit-validation` fork that exposed them:

**Before parser fix** (broken):
```
1. ⚠ Apple credentials
   ASC_API_KEY_P8_PATH file does not exist:
     /Users/prakash/.config/secrets/AuthKey_272KQZ4THC.p8                     # e.g. ~/Downloads/AuthKey_AAAAAA1234.p8
```

**After parser fix** (clean):
```
1. ✓ Apple credentials
```

**Before bundle-check guard** (stack trace):
```
.../bundler/spec_set.rb:91:in 'block in materialize': Could not find rake-13.4.2 (Bundler::GemNotFound)
        from .../bundler/runtime.rb:108:in 'block in definition_method'
        ...
```

**After bundle-check guard** (friendly):
```
Ruby gems aren't installed yet. Run one of:
    bundle install            # install just the ruby gems
    make bootstrap            # full dev-env setup (brew + lefthook + xcodegen + bundle)
```

## Files

| File | Change |
|---|---|
| `bin/lib/bootstrap.rb` | Parser fix + doctor output severity distinction |
| `Makefile` | `_check-bundle` guard, top-of-file comment rewrite, help-text clarity |
| `.bootstrap.env.example` | Header references `make bootstrap-fork` (was `bootstrap`) |
| `bin/preflight.sh` | 'Next steps' uses canonical flow |
| `README.md` | Step 6 starts with `make bootstrap` |