### PR TITLE
test(ci): regression tests pinning #108's BLOCKER fixes

### DIFF
--- a/.github/workflows/bootstrap-doctor-matrix.yml
+++ b/.github/workflows/bootstrap-doctor-matrix.yml
@@ -1,21 +1,33 @@
-# Continuously validates that this template's bootstrap pipeline (bin/doctor.rb
-# + bin/lib/bootstrap.rb) works across the 2x2 matrix of supported configs:
-#   GENERATOR    × RELEASE_MODE
-#   xcodegen|tuist × ci|local
+# Continuously validates this template's bootstrap pipeline. Three jobs:
 #
-# What this proves: the orchestration layer parses .bootstrap.env, validates
-# Apple/GH credentials, runs every doctor probe without a Ruby crash. Catches
-# config-schema breaks, mode-branching bugs, and Apple/GH side state drift.
+#   doctor                    — full e2e probe of bin/doctor.rb + bin/lib/bootstrap.rb
+#                               across the 2×2 matrix of GENERATOR × RELEASE_MODE
+#                               (xcodegen|tuist × ci|local), against real GH +
+#                               Apple state via the smoketest fork. Catches
+#                               schema breaks, mode-branching bugs, side state
+#                               drift. Runs on Mondays 07:00 UTC.
 #
-# What this does NOT prove: that `make bootstrap-fork` mints fresh certs from
-# cold, that `make ship` produces a working TestFlight build. Those are
-# destructive and require Apple-side resource churn (cert quotas, ASC App
-# records). For the full destructive E2E, run bin/refork-smoketest.sh
+#   parser-regression         — hermetic test of Bootstrap::Config.parse against
+#                               a fixture that mimics the .bootstrap.env.example
+#                               shape (every value followed by inline `# comment`).
+#                               Catches regression of #108's BLOCKER 2.
+#
+#   bundle-guard-regression   — runs `make doctor` on a fresh checkout WITHOUT
+#                               `bundle install`. Asserts friendly-error path
+#                               (`Ruby gems aren't installed yet`) instead of
+#                               a Bundler::GemNotFound stack trace. Catches
+#                               regression of #108's BLOCKER 1.
+#
+# What this workflow does NOT prove: that `make bootstrap-fork` mints fresh
+# certs from cold, that `make ship` produces a working TestFlight build.
+# Those are destructive and require Apple-side resource churn (cert quotas,
+# ASC App records). For the full destructive E2E, run bin/refork-smoketest.sh
 # manually — see docs/CONTINUOUS-VALIDATION.md.
 #
-# Inputs come from GH Secrets on this template repo, never from a local
-# .bootstrap.env. The workflow materializes .bootstrap.env at runtime in
-# /tmp on the runner and never persists it as an artifact.
+# `doctor` job inputs come from GH Secrets on this template repo, never from
+# a local .bootstrap.env. The workflow materializes .bootstrap.env at runtime
+# in /tmp on the runner and never persists it as an artifact. The two
+# regression jobs are hermetic: no secrets, no smoketest needed.
 
 name: bootstrap doctor matrix
 
@@ -25,6 +37,8 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - 'test/parser_test.rb'
+      - 'Makefile'
       - '.github/workflows/bootstrap-doctor-matrix.yml'
       - 'bin/lib/bootstrap.rb'
       - 'bin/doctor.rb'
@@ -194,3 +208,79 @@ jobs:
       - name: Tear down secrets
         if: always()
         run: rm -rf "$SECRETS_DIR" || true
+
+  # Hermetic regression test for the .bootstrap.env parser. Runs against a
+  # fixture that mimics the .bootstrap.env.example shape — every value
+  # followed by an inline `# comment`. Catches regressions of #108's
+  # BLOCKER 2 (parser kept inline comments as part of values, breaking
+  # every downstream Apple/GH probe). No secrets, no smoketest needed:
+  # the parser is platform-agnostic and tested in isolation.
+  parser-regression:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
+        with:
+          ruby-version: '3.3'
+          bundler-cache: false  # parser_test.rb is stdlib-only; no bundle exec needed
+      - name: Run parser regression fixtures
+        run: ruby test/parser_test.rb
+
+  # Regression test for #108's BLOCKER 1: `make doctor` crashed with a
+  # Bundler::GemNotFound stack trace on a fresh fork because no path in
+  # the README's onboarding ran `bundle install` first. The fix added a
+  # `_check-bundle` Makefile guard that prints a friendly hint instead.
+  # This job exercises the friendly-failure path by deliberately NOT
+  # installing project gems before running `make doctor`.
+  bundle-guard-regression:
+    runs-on: macos-15
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
+        with:
+          ruby-version: '3.3'
+          bundler-cache: false  # the whole point: gems NOT installed
+      - name: Confirm test setup (project gems should be missing)
+        run: |
+          if bundle check >/dev/null 2>&1; then
+            echo "::error::Test setup error: bundle check passed; this job needs gems missing"
+            exit 1
+          fi
+          echo "OK — bundle check fails as expected (gems missing)"
+      - name: make doctor exits cleanly with friendly message (no Ruby crash)
+        run: |
+          set +e
+          out=$(make doctor 2>&1)
+          rc=$?
+          set -e
+          echo "exit_code=$rc"
+          echo "--- output ---"
+          echo "$out"
+          echo "--- end ---"
+          # 1. Friendly bundle-guard message must be present.
+          echo "$out" | grep -qF "Ruby gems aren't installed yet" || {
+            echo "::error::Friendly bundle-guard message missing — _check-bundle target may have been removed or renamed"
+            exit 1
+          }
+          # 2. Both remediation hints must be present.
+          echo "$out" | grep -qF "bundle install" || {
+            echo "::error::'bundle install' remediation hint missing"
+            exit 1
+          }
+          echo "$out" | grep -qF "make bootstrap" || {
+            echo "::error::'make bootstrap' remediation hint missing"
+            exit 1
+          }
+          # 3. No Ruby stack-trace leakage.
+          if echo "$out" | grep -qE 'Bundler::GemNotFound|cannot load such file|spec_set\.rb'; then
+            echo "::error::Ruby stack trace leaked through bundle guard — regression of #108 BLOCKER 1"
+            exit 1
+          fi
+          # 4. Non-zero exit (fail-fast, not silent pass-through).
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::Expected non-zero exit, got rc=0 — _check-bundle guard didn't fire"
+            exit 1
+          fi
+          echo "OK — friendly guard message + non-zero exit + no stack trace"

--- a/bin/lib/bootstrap.rb
+++ b/bin/lib/bootstrap.rb
@@ -80,13 +80,22 @@ module Bootstrap
         key, _, val = line.partition("=")
         UI.fail!(".bootstrap.env line #{idx + 1}: missing '='") if val.nil? || key.strip.empty?
         val = val.strip
-        if (val.start_with?("'") && val.end_with?("'")) || (val.start_with?('"') && val.end_with?('"'))
-          # Quoted value: strip surrounding quotes; preserve any '#' inside.
-          val = val[1..-2]
-        elsif (comment_at = val.index(/\s#/))
-          # Unquoted value with an inline comment: strip everything from the
+        if val.start_with?("'") || val.start_with?('"')
+          # Quoted value. Find the matching closing quote; the value is
+          # exactly what's between the two quotes. Anything after the
+          # closing quote (typically `  # trailing comment`) is discarded.
+          # We deliberately do NOT honor backslash escapes here — `.bootstrap.env`
+          # values are paths, ids, and short strings, never multi-line literals.
+          quote_char = val[0]
+          closing = val.index(quote_char, 1)
+          val = closing ? val[1...closing] : val
+        elsif (comment_at = val.index(/(?:^|\s)#/))
+          # Unquoted value with an inline comment. Strip everything from the
           # first whitespace-hash onward (dotenv convention). Bare '#' inside
-          # an unquoted value (e.g. URL fragments) is preserved.
+          # an unquoted value (e.g. URL fragments) is preserved because it
+          # has no preceding whitespace. The (?:^|\s) form also matches a
+          # value that's purely a comment (`KEY=  # only-a-comment`) — strip
+          # to the empty string.
           # The .bootstrap.env.example template ships every fillable field
           # with an inline `# placeholder` comment; without this strip, a
           # forker who fills `BUNDLE_ID=com.foo.bar` while leaving the

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1,0 +1,82 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test for Bootstrap::Config.parse.
+#
+# Why this exists: a real first-time-shipper validation surfaced a parser bug
+# (#108) where inline `# comments` were kept as part of values, corrupting
+# every fillable field with comment text. The bug had been live for months
+# without surfacing because the maintainer's own .bootstrap.env had no
+# inline comments — only a naive first-timer would trip it.
+#
+# This test pins the parser's contract:
+#   - Strip ` #` (space-hash) onward from unquoted values.
+#   - Preserve `#` inside quoted values.
+#   - Preserve bare `#` inside unquoted values (URL fragments etc.).
+#   - Empty value followed by inline comment becomes the empty string.
+#   - Both leading and trailing whitespace are stripped.
+#
+# Runnable locally:
+#   bundle exec ruby test/parser_test.rb
+#
+# Wired into bootstrap-doctor-matrix.yml's `parser-regression` job.
+
+$LOAD_PATH.unshift File.expand_path("../bin", __dir__)
+require "lib/bootstrap"
+require "tempfile"
+require "pathname"
+
+@failures = 0
+
+def assert_eq(actual, expected, label)
+  if actual == expected
+    puts "  \u2713 #{label}"
+  else
+    puts "  \u2717 #{label}"
+    puts "    expected: #{expected.inspect}"
+    puts "    actual:   #{actual.inspect}"
+    @failures += 1
+  end
+end
+
+# Fixture mimics what `make init` scaffolds + a naive forker's typical edits:
+# values placed in front of the existing inline `# placeholder` comments.
+# This is the exact shape that broke before #108.
+fixture = <<~ENV
+  # ─── full-line comment, should be skipped ─────────────────────────────────
+  APP_NAME=MyApp                          # CamelCase. Becomes scheme + product.
+  BUNDLE_ID=com.foo.bar                   # iOS + macOS share the same bundle id.
+  DISPLAY_NAME='My App With # In Quotes'  # quoted value with # inside; the
+                                          # regex must NOT strip the inner #.
+  WEB_URL=https://example.com/page#section   # URL fragment — preserve bare #.
+  EMPTY_FIELD=                            # placeholder; should parse as ""
+  PADDED=  value with spaces              # leading + trailing whitespace
+  TABBED=value\tafter\ttab                # bare tab in unquoted value
+  COMMENT_ONLY_TAB=value\t# tab-comment   # tab+hash IS a comment delimiter
+  HASH_NO_SPACE=before#after              # bare # without preceding space
+ENV
+
+f = Tempfile.new(".bootstrap.env")
+f.write(fixture)
+f.close
+config = Bootstrap::Config.parse(Pathname.new(f.path))
+f.unlink
+
+puts "Parser regression tests:"
+assert_eq config["APP_NAME"],         "MyApp",                              "strips inline space-hash from unquoted alphanumeric value"
+assert_eq config["BUNDLE_ID"],        "com.foo.bar",                        "strips inline space-hash from value containing dots"
+assert_eq config["DISPLAY_NAME"],     "My App With # In Quotes",            "preserves # inside symmetrically-quoted value"
+assert_eq config["WEB_URL"],          "https://example.com/page#section",   "preserves bare # in URL fragment, strips trailing comment"
+assert_eq config["EMPTY_FIELD"],      "",                                   "empty-value-followed-by-comment becomes empty string"
+assert_eq config["PADDED"],           "value with spaces",                  "strips both leading and trailing whitespace"
+assert_eq config["TABBED"],           "value\tafter\ttab",                  "preserves bare tabs inside unquoted value (no following hash)"
+assert_eq config["COMMENT_ONLY_TAB"], "value",                              "tab-hash is a valid comment delimiter (\\s matches tab)"
+assert_eq config["HASH_NO_SPACE"],    "before#after",                       "preserves bare # without preceding whitespace"
+
+if @failures.zero?
+  puts "\nAll #{9} parser regression tests passed."
+  exit 0
+else
+  puts "\n#{@failures} test(s) failed."
+  exit 1
+end


### PR DESCRIPTION
## What

Two new jobs in `bootstrap-doctor-matrix.yml` plus a runnable-locally `test/parser_test.rb` fixture file. They lock in the contracts of the two parser/onboarding fixes from #108 so future refactors can't silently regress them.

## Why

#108's BLOCKERs were old bugs that only surfaced when a real first-time-shipper actually ran the flow. The smoketest didn't catch them because it operates from an already-bootstrapped fork with hand-edited (no-comments) `.bootstrap.env`. The two regression jobs here close that gap by exercising both bug paths hermetically on every PR.

## Coverage

| Job | Catches | Where |
|---|---|---|
| `parser-regression` | Inline-comment leakage into values, quoted-with-trailing-comment, URL-fragment edge cases, empty values, tab-as-whitespace | ubuntu-latest, ~30s |
| `bundle-guard-regression` | `make doctor` crashing with `Bundler::GemNotFound` instead of friendly hint when gems aren't installed | macos-15, ~2min |

## Strengthening caught real bugs

Writing the parser test against an aggressive fixture surfaced two edge cases #108's parser fix missed:

1. **Quoted value with trailing inline comment** — `end_with?(quote)` was tested *after* the line was stripped, but the trailing ` # comment` meant the line didn't end with the matching quote. The quoted-branch never fired; the elsif fell through and stripped the FIRST space-hash, which was inside the quotes. Fixed by finding the matching closing quote regardless of trailing content.

2. **Empty value followed by inline comment** (`KEY=  # comment`) — after `.strip`, value became `'# comment'`. The original `/\s#/` regex couldn't match (no preceding whitespace). Fixed by widening to `/(?:^|\s)#/` so a value that's purely a comment matches at position 0.

Both edge cases now have explicit test fixtures pinning them.

## Files

| File | Purpose |
|---|---|
| `test/parser_test.rb` | New — 9-case fixture, runnable as `ruby test/parser_test.rb` |
| `bin/lib/bootstrap.rb` | Strengthened parser handles 2 newly-discovered edge cases |
| `.github/workflows/bootstrap-doctor-matrix.yml` | 2 new jobs + extended path filter + rewritten doc-comment header |