### PR TITLE
feat: auto-mint local-mode signing certs (closes biggest local-mode blocker)

### DIFF
--- a/.github/workflows/bootstrap-doctor-matrix.yml
+++ b/.github/workflows/bootstrap-doctor-matrix.yml
@@ -47,6 +47,8 @@ on:
       - 'bin/verify-testflight.rb'
       - 'bin/init-bootstrap-env.sh'
       - '.bootstrap.env.example'
+      - 'bin/mint-local-certs.rb'
+      - 'fastlane/Fastfile'
 
 permissions:
   contents: read

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # wires it onto every push, and `make doctor` validates `.bootstrap.env` end
 # to end without mutating any state.
 
-.PHONY: all go bootstrap check check-ios check-macos check-sim build generate icons screenshots release-dryrun setup-github phase-checklist milestone-checklist help init doctor bootstrap-fork ship verify _check-bundle
+.PHONY: all go bootstrap check check-ios check-macos check-sim build generate icons screenshots release-dryrun setup-github phase-checklist milestone-checklist help init doctor bootstrap-fork ship verify mint-local-certs _check-bundle
 
 help:
 	@echo "Targets:"
@@ -32,6 +32,7 @@ help:
 	@echo "  bootstrap-fork   Idempotent fork-bootstrap: certs, ASC bundle id, GH branch protection, etc. Reads .bootstrap.env."
 	@echo "  ship             Trigger release.yml workflow_dispatch + tail until the run completes"
 	@echo "  verify           Confirm the latest tagged build appeared in App Store Connect"
+	@echo "  mint-local-certs Auto-mint missing local-mode signing identities into the login keychain via fastlane cert. Idempotent."
 	@echo "  phase-checklist  Print the GSD canonical per-phase checklist (usage: make phase-checklist N=3.1)"
 	@echo "  milestone-checklist  Print the GSD milestone wrap-up checklist (usage: make milestone-checklist M=1)"
 
@@ -85,6 +86,9 @@ ship: _check-bundle
 
 verify: _check-bundle
 	@bundle exec ruby bin/verify-testflight.rb
+
+mint-local-certs: _check-bundle
+	@bundle exec ruby bin/mint-local-certs.rb
 
 # Guard for bundle-using targets above. Fails fast with an actionable hint
 # when ruby gems aren't installed yet (typical on a fresh fork before

--- a/bin/lib/bootstrap.rb
+++ b/bin/lib/bootstrap.rb
@@ -821,30 +821,151 @@ module Bootstrap
       "3rd Party Mac Developer Installer"
     ].freeze
 
+    # Maps the human identity name (as it appears in `security find-identity`)
+    # to fastlane cert's --type argument. Auto-mint flow uses these to invoke
+    # the right fastlane cert call per missing identity.
+    IDENTITY_TO_CERT_TYPE = {
+      "Apple Distribution"                => "apple_distribution",
+      "Apple Development"                 => "apple_development",
+      "3rd Party Mac Developer Installer" => "mac_installer_distribution"
+    }.freeze
+
     def required_identities
       ids = REQUIRED_IDENTITIES_ALWAYS.dup
       ids.concat(REQUIRED_IDENTITIES_MACOS) if config.macos?
       ids
     end
 
-    def check
-      return :done if config.ci_mode? # only relevant in local mode
+    # Returns the matching `security find-identity -v -p codesigning` lines
+    # from the user's login keychain. Each line is e.g.
+    #   '  1) BD06...A78 "Apple Distribution: Person Name (A26TJZ8QHQ)"'
+    def keychain_lines
       out, _ok = Sh.run("security", "find-identity", "-v", "-p", "codesigning",
                         File.expand_path("~/Library/Keychains/login.keychain-db"))
-      ids = required_identities
-      missing = ids.reject { |id| out.include?(id) }
-      return :done if missing.empty?
-      [:blocked, <<~MSG]
-        Login keychain is missing #{missing.length} signing identit#{missing.length == 1 ? 'y' : 'ies'}:
-        #{missing.map { |m| "  - #{m}" }.join("\n")}
-
-        Add via Xcode → Settings → Accounts → (your team) → Manage Certificates → +.
-        Or via Apple Developer Portal → Certificates → + (then double-click the .cer).
-      MSG
+      out.lines
     end
 
+    # Pulls the LAST `(XXXXXXXXXX)` 10-char alphanumeric token from an
+    # identity line. For
+    #   '  1) BD06...A78 "Apple Distribution: Person Name (A26TJZ8QHQ)"'
+    # returns "A26TJZ8QHQ". We use scan-and-pick-last because the line ends
+    # in `"` (not `)`), so a `\)\s*$`-anchored pattern wouldn't fire.
+    #
+    # Caveat: Apple's "Created via API" cert names use the same `(XXXXXXXXXX)`
+    # shape but the token is the API key id, NOT the team id. We can't tell
+    # the two apart from `find-identity` output alone — that's why
+    # team_mismatched_identities is permissive on lines containing
+    # "Created via API".
+    def extract_team_id(line)
+      line.scan(/\(([A-Z0-9]{10})\)/).last&.first
+    end
+
+    # Identities whose name doesn't appear at all in the keychain. These
+    # require fresh minting (or manual install).
+    def missing_identities
+      lines = keychain_lines
+      required_identities.reject do |name|
+        lines.any? { |line| line.include?(name) }
+      end
+    end
+
+    # Identities present BUT whose certs are all clearly for non-matching
+    # teams. Conservative logic — only flagged when:
+    #   1. At least one cert with the right name exists (else: missing, not mismatched)
+    #   2. None of those certs has a parenthesized team id matching FASTLANE_TEAM_ID
+    #   3. None is "Created via API" (ambiguous — we can't verify the team)
+    # Catches the consultant / multi-team scenario without false-positiving on
+    # API-minted certs that may be for the right team.
+    def team_mismatched_identities
+      expected = config["FASTLANE_TEAM_ID"]
+      return [] if expected.nil? || expected.empty?
+
+      lines = keychain_lines
+      required_identities.select do |name|
+        type_lines = lines.select { |line| line.include?(name) }
+        next false if type_lines.empty?               # missing, not mismatched
+        next false if type_lines.any? { |line| extract_team_id(line) == expected }
+        next false if type_lines.any? { |line| line.include?("Created via API") }
+        true
+      end
+    end
+
+    def check
+      return :done if config.ci_mode?
+      missing = missing_identities
+      mismatched = team_mismatched_identities
+      return :done if missing.empty? && mismatched.empty?
+      # :pending (with rich message) — bootstrap-fork's do_it auto-mints
+      # the missing/mismatched identities via fastlane cert. Doctor renders
+      # the message so the user knows what's going to happen and can opt
+      # for one of the manual paths if they prefer.
+      [:pending, build_message(missing, mismatched)]
+    end
+
+    # do_it (called by `make bootstrap-fork` and `make mint-local-certs`)
+    # auto-mints any missing OR mismatched-team identities by shelling out to
+    # the fastlane mint_local_certs lane. Idempotent — fastlane cert itself
+    # detects existing valid certs and skips minting duplicates, so re-running
+    # is safe even if the keychain state changed since `make doctor` ran.
     def do_it
-      UI.fail!("Local mode requires signing identities in your login keychain. Add them and re-run.")
+      needed = (missing_identities + team_mismatched_identities).uniq
+      return if needed.empty?
+
+      cert_types = needed.map { |id| IDENTITY_TO_CERT_TYPE.fetch(id) }
+      UI.section "Minting #{needed.length} local-mode signing identit#{needed.length == 1 ? 'y' : 'ies'}"
+      needed.each_with_index do |id, i|
+        puts "  #{i + 1}. #{id}  (fastlane cert --type #{cert_types[i]})"
+      end
+
+      env = Bootstrap.asc_env(config)
+      Sh.run!("bundle", "exec", "fastlane", "mint_local_certs",
+              "types:#{cert_types.join(',')}",
+              env: env)
+    end
+
+    private
+
+    def build_message(missing, mismatched)
+      parts = []
+
+      if missing.any?
+        parts << "Login keychain is missing #{missing.length} signing identit#{missing.length == 1 ? 'y' : 'ies'}:"
+        missing.each do |id|
+          parts << "  - #{id}  (fastlane cert --type #{IDENTITY_TO_CERT_TYPE.fetch(id)})"
+        end
+      end
+
+      if mismatched.any?
+        parts << "" if missing.any?
+        expected = config["FASTLANE_TEAM_ID"]
+        parts << "Found certs for #{mismatched.length} identit#{mismatched.length == 1 ? 'y' : 'ies'} but none for team #{expected}:"
+        mismatched.each { |id| parts << "  - #{id}" }
+        parts << "(your keychain has certs from other teams. xcodebuild will fail at"
+        parts << " ship time without a team-#{expected} cert.)"
+      end
+
+      parts << ""
+      parts << "Easiest fix — auto-mints + installs each identity into your login keychain:"
+      parts << "  make mint-local-certs"
+      parts << ""
+      parts << "(or just run `make bootstrap-fork`; it auto-mints these too.)"
+      parts << ""
+      parts << "Manual alternatives:"
+      parts << "  Xcode → Settings → Accounts → (your team) → Manage Certificates → +"
+      parts << "  Apple Developer Portal → Certificates → + (then double-click the .cer)"
+
+      # macOS-only escape hatch: if every problem is a Mac-only identity, the
+      # user can drop macOS shipping by setting PLATFORMS=ios — saves them
+      # from minting a cert they don't need.
+      affected = (missing + mismatched).uniq
+      mac_only = affected.all? { |id| REQUIRED_IDENTITIES_MACOS.include?(id) } && affected.any?
+      if mac_only
+        parts << ""
+        parts << "Or, if you don't need to ship macOS yet:"
+        parts << "  set PLATFORMS=ios in .bootstrap.env (skips Mac signing entirely)"
+      end
+
+      parts.join("\n") + "\n"
     end
   end
 
@@ -911,6 +1032,15 @@ module Bootstrap
             puts "  #{(idx + 1).to_s.rjust(2)}. #{UI.warn step.name}"
             puts msg.lines.map { |l| "      #{UI.dim l.chomp}" }.join("\n")
             results << :warn
+          elsif severity == :pending
+            # Pending-with-message: doctor explains the fix; bootstrap-fork's
+            # do_it auto-runs and resolves it. Rendered like :pending (red ✗
+            # + dim "will auto-fix on bootstrap-fork") plus the rich message
+            # so the user can ALSO fix it manually if they want
+            # (e.g. `make mint-local-certs`, `PLATFORMS=ios` escape hatch, etc).
+            puts "  #{(idx + 1).to_s.rjust(2)}. #{UI.miss step.name}#{UI.dim ' — will auto-fix on bootstrap-fork'}"
+            puts msg.lines.map { |l| "      #{UI.dim l.chomp}" }.join("\n")
+            results << :pending
           else
             # Blocked: visually separate from :warn (advisory) by using the
             # red ✗ glyph + a "needs fix" suffix, and from :pending by
@@ -973,6 +1103,12 @@ module Bootstrap
           severity, msg = result
           if severity == :warn
             puts "  #{UI.warn msg.lines.first.chomp}"
+          elsif severity == :pending
+            # Auto-fixable: bootstrap-fork runs do_it (which mints/restores
+            # state programmatically). Distinct from :blocked which is
+            # human-gated and aborts.
+            step.do_it
+            puts "  #{UI.ok 'done'}"
           else
             UI.fail!(msg)
           end

--- a/bin/mint-local-certs.rb
+++ b/bin/mint-local-certs.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Mint any missing local-mode signing identities (Apple Distribution,
+# Apple Development, 3rd Party Mac Developer Installer) into the user's
+# login keychain. Idempotent — fastlane cert detects existing valid certs
+# and reuses rather than minting duplicates.
+#
+# Used by `make mint-local-certs`. Same code path as
+# `make bootstrap-fork`'s LocalKeychainCerts step.
+#
+# Usage: bundle exec ruby bin/mint-local-certs.rb
+
+require_relative "lib/bootstrap"
+
+config = Bootstrap::Config.load!
+config.validate!
+
+if config.ci_mode?
+  Bootstrap::UI.fail!(
+    "make mint-local-certs is local-mode-only; this fork has RELEASE_MODE=ci.\n" \
+    "In CI mode, fastlane match handles cert provisioning on the runner — there's\n" \
+    "nothing to mint locally."
+  )
+end
+
+step = Bootstrap::LocalKeychainCerts.new(config)
+needed = (step.missing_identities + step.team_mismatched_identities).uniq
+
+if needed.empty?
+  Bootstrap::UI.section "All local-mode signing identities present"
+  puts "  Nothing to mint. Run `make doctor` to see the full pipeline status."
+  exit 0
+end
+
+step.do_it
+puts
+puts Bootstrap::UI.bold("Done. Run `make doctor` to verify.")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -242,6 +242,43 @@ lane :revoke_cert do |options|
   UI.success("Revoked #{cert.id}")
 end
 
+desc "Mint missing local-mode signing identities into the user's login keychain."
+desc ""
+desc "Idempotent: fastlane cert detects existing valid certs in the keychain and"
+desc "reuses rather than minting duplicates, so re-running on a partially-set-up"
+desc "machine is safe."
+desc ""
+desc "Required env (set automatically by Bootstrap.asc_env when called via"
+desc "`make mint-local-certs` or `make bootstrap-fork`):"
+desc "  ASC_API_KEY_ID, ASC_API_KEY_ISSUER_ID, ASC_API_KEY_P8_BASE64, FASTLANE_TEAM_ID"
+desc ""
+desc "Usage: fastlane mint_local_certs types:apple_distribution,apple_development,mac_installer_distribution"
+lane :mint_local_certs do |options|
+  raw = options[:types].to_s
+  types = raw.split(",").map(&:strip).reject(&:empty?)
+  UI.user_error!("types: required (comma-separated, e.g. apple_distribution,mac_installer_distribution)") if types.empty?
+
+  api_key = asc_api_key
+  team    = ENV.fetch("FASTLANE_TEAM_ID")
+  keychain = File.expand_path("~/Library/Keychains/login.keychain-db")
+
+  types.each do |type|
+    UI.message("Minting #{type} for team #{team} (idempotent — fastlane cert reuses existing valid certs)...")
+    cert(
+      type:          type,
+      team_id:       team,
+      api_key:       api_key,
+      keychain_path: keychain,
+      # output_path lands the .cer + .p12 in /tmp; cert action also imports
+      # both into the keychain in one shot. We don't need the artifacts
+      # afterward (login keychain is the source of truth).
+      output_path:   Dir.tmpdir
+    )
+  end
+
+  UI.success("Local-mode signing identities ready in login keychain.")
+end
+
 desc "Idempotently verify Dev Portal App ID + ASC App record exist."
 desc ""
 desc "Calls register_app_id (creates the Dev Portal App ID via Spaceship if"


### PR DESCRIPTION
Implements the v1.4 cert-handling work (A+B+C+D from the design discussion).

## Why

Real first-time-shipper validation against `my-cool-app` hit step 12 (`Local keychain has signing identities`) as a hard blocker. Doctor's remediation offered only manual paths (Xcode Settings → … or Developer Portal CSR-upload, 7 steps). Worse, `make all` would NEVER reach `bootstrap-fork` because doctor exited 2 on the blocker — local-mode `make all` was structurally broken for first-time-shippers with an empty keychain.

## Changes

| Tag | What | File |
|---|---|---|
| **A** | Doctor message rewrites: lead with `fastlane cert`, mention `make mint-local-certs`, `PLATFORMS=ios` escape hatch when missing identities are mac-only | `bin/lib/bootstrap.rb` |
| **B** | New `make mint-local-certs` target | `Makefile` + `bin/mint-local-certs.rb` |
| **C** | Team-mismatch check: parse `(TEAMID)` from `find-identity` output, compare against `FASTLANE_TEAM_ID`. Conservative — permissive on "Created via API" (ambiguous) lines | `bin/lib/bootstrap.rb` |
| **D** | `bootstrap-fork` auto-mints missing local certs via new `mint_local_certs` fastlane lane. New `[:pending, msg]` result semantics (rendered like `:pending` in doctor, calls `do_it` in bootstrap) | `bin/lib/bootstrap.rb` + `fastlane/Fastfile` |

## Test method

Verified by re-running `make doctor` against `/tmp/shipkit-validation` (the local-mode validation fork from earlier this session) in two configurations.

**Config A** (unique BUNDLE_ID, no ASC record): doctor exits 2 — still blocked on step 11 (ASC App record, genuinely human-gated). Step 12 correctly shows new auto-fix message + PLATFORMS=ios escape.

**Config B** (BUNDLE_ID=com.indiagram.smoke-app, reusing the smoketest's ASC App record — mirrors the user's actual `my-cool-app` setup): doctor exits 0 — only step 12 is `:pending`. `make all` would proceed to `bootstrap-fork`, which would call `LocalKeychainCerts.do_it` and auto-mint via `fastlane cert`.

## Bug caught while writing the test

The team-match regex `\(([A-Z0-9]{10})\)\s*$` failed because `find-identity` lines end in `"` (the closing quote on the cert name), not the `)`. Fixed via scan-and-pick-last:

```ruby
def extract_team_id(line)
  line.scan(/\(([A-Z0-9]{10})\)/).last&.first
end
```

## Caveat

The auto-mint path itself (the `fastlane cert` invocation through the new lane) hasn't been runtime-tested in this PR. fastlane cert is well-tested upstream, but the env-passing + API-key wiring is integration code. The user (this PR's author) is the natural integration test on their `my-cool-app` fork.