### PR TITLE
fix(doctor): keychain check missed installer-signing certs (false-pending loop)

### DIFF
--- a/bin/lib/bootstrap.rb
+++ b/bin/lib/bootstrap.rb
@@ -836,11 +836,19 @@ module Bootstrap
       ids
     end
 
-    # Returns the matching `security find-identity -v -p codesigning` lines
-    # from the user's login keychain. Each line is e.g.
+    # Returns the matching `security find-identity -v` lines from the user's
+    # login keychain. Each line is e.g.
     #   '  1) BD06...A78 "Apple Distribution: Person Name (A26TJZ8QHQ)"'
+    #
+    # Note we deliberately do NOT pass `-p codesigning` here, because that
+    # filter excludes installer-signing identities (3rd Party Mac Developer
+    # Installer is for `productbuild`, not for code signing). Without -p,
+    # find-identity returns valid identities for ANY policy — code-signing,
+    # installer-signing, mail-signing, etc. -v alone keeps the validity
+    # check (filters out expired or private-key-missing identities). We
+    # match by name in the caller, so policy mixing here is fine.
     def keychain_lines
-      out, _ok = Sh.run("security", "find-identity", "-v", "-p", "codesigning",
+      out, _ok = Sh.run("security", "find-identity", "-v",
                         File.expand_path("~/Library/Keychains/login.keychain-db"))
       out.lines
     end


### PR DESCRIPTION
## Bug

`LocalKeychainCerts.keychain_lines` queried with `security find-identity -v -p codesigning`. The `-p codesigning` filter excludes installer-signing identities by design — installer certs (3rd Party Mac Developer Installer, signs .pkg wrappers via `productbuild`) are a different security policy from code-signing certs (Apple Distribution / Apple Development).

Result: even after `bootstrap-fork`'s LocalKeychainCerts step successfully minted + installed the Mac Installer cert via fastlane cert (#115's auto-mint), the immediately-subsequent doctor re-check still reported it missing.

## Reproduction

User ran `make bootstrap-fork` on a fresh `my-cool-app` fork:

```
[12/14] Local keychain has signing identities

Minting 1 local-mode signing identity
─────────────────────────────────────
  1. 3rd Party Mac Developer Installer  (fastlane cert --type mac_installer_distribution)
  ✓ done
```

`fastlane cert` exited 0 (installed cert into login keychain). But `make doctor` re-run:

```
12. ✗ Local keychain has signing identities — will auto-fix on bootstrap-fork
    Login keychain is missing 1 signing identity:
      - 3rd Party Mac Developer Installer
```

Verified empirically:

| `security find-identity -v` flag | Mac Installer certs visible |
|---|---|
| `-p codesigning` | **0** ← what the doctor used |
| `-p basic` | 3 |
| `-p packageSigning` | 0 (Apple doesn't honor this) |
| `-p macappstore` | 3 |
| (no -p flag) | 3 |

## Fix

Drop the `-p` flag. `-v` alone keeps the validity check (filters out expired or private-key-missing identities). Cert names (`Apple Distribution`, `Apple Development`, `3rd Party Mac Developer Installer`) are distinctive enough that policy-mixing in the keychain query is safe — wrong-policy match is impossible.

## Verification

After patch, doctor on the same `my-cool-app` fork:
```
12. ✓ Local keychain has signing identities

Summary
  ✓ 11 done    ⚠ 3 advisory
```

Step 12 ✓; the only remaining items are App-Store-review-only advisories (icon, metadata, screenshots).