### PR TITLE
fix: rename.sh defeats safety guard + branch protection too strict for solo

### DIFF
--- a/bin/lib/bootstrap.rb
+++ b/bin/lib/bootstrap.rb
@@ -470,7 +470,21 @@ module Bootstrap
     def name; "GitHub branch protection on main"; end
 
     def check
-      Sh.ok?("gh", "api", "repos/#{config.repo_slug}/branches/main/protection") ? :done : :pending
+      # Probe for the protection's enforce_admins value. Two reasons to
+      # re-run setup-github.sh (return :pending):
+      #   1. No protection at all (HTTP 404) — first-time fork, hasn't run yet.
+      #   2. Protection exists but enforce_admins doesn't match the current
+      #      RELEASE_MODE. Lets a forker switch ci ↔ local later by editing
+      #      .bootstrap.env + re-running `make bootstrap-fork`; without this
+      #      drift detection, BranchProtection would stay :done and the
+      #      protection config would silently mismatch the mode.
+      out, ok = Sh.run("gh", "api",
+                       "repos/#{config.repo_slug}/branches/main/protection",
+                       "--jq", ".enforce_admins.enabled")
+      return :pending unless ok
+      current = out.strip == "true"
+      desired = config.ci_mode?
+      current == desired ? :done : :pending
     end
 
     def do_it

--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -382,6 +382,15 @@ PATHSPEC_EXCLUSIONS=(
   ':!ci/test-rename-gates.sh'
   ':!bin/verify-rename.sh'
   ':!ci/test-verify-rename.sh'
+  # Upstream-only: validates the apple-shipkit template against the smoketest
+  # using indiagrams's secrets. The job's `if: github.repository ==
+  # 'indiagrams/apple-shipkit'` guard is the safety check that keeps the
+  # workflow dormant on forks. Letting Step D rewrite that string to the
+  # fork's slug DEFEATS the safety check — the workflow then runs on every
+  # fork's PR and fails because the fork has no ASC secrets, no certs-repo
+  # PAT, etc. Excluded entirely from the rename sweep so the safety guard
+  # survives.
+  ':!.github/workflows/bootstrap-doctor-matrix.yml'
 )
 
 # ── Substitutions (REQ-2, REQ-9; D-1; HIGH-6 placeholder + HIGH-7 escape) ─

--- a/bin/setup-github.sh
+++ b/bin/setup-github.sh
@@ -84,11 +84,21 @@ step "Branch protection on main"
 # Defaults to 'ios,macos' if the file or field is absent. The PR workflow
 # (.github/workflows/pr.yml) only runs the iOS jobs when do_ios=true and
 # the macOS jobs when do_macos=true, so the required checks must match.
+# Read .bootstrap.env once for both PLATFORMS (which CI checks are required)
+# and RELEASE_MODE (whether enforce_admins blocks even-the-admin from pushing
+# directly to main). CI mode = team-shared default → enforce_admins=true, no
+# bypass even for admins. Local mode = solo first-time-shipper default →
+# enforce_admins=false, admin can push directly when needed (PR-required +
+# required-checks still gate normal flow; this just lets the solo dev escape
+# the lock-out trap). Forkers can flip later by re-running this script.
 PLATFORMS_VAL=""
+RELEASE_MODE_VAL=""
 if [ -f "$REPO_ROOT/.bootstrap.env" ]; then
   PLATFORMS_VAL=$(awk -F= '/^PLATFORMS[[:space:]]*=/ { gsub(/^[[:space:]"\047]+|[[:space:]"\047]+$/, "", $2); print $2; exit }' "$REPO_ROOT/.bootstrap.env")
+  RELEASE_MODE_VAL=$(awk -F= '/^RELEASE_MODE[[:space:]]*=/ { gsub(/^[[:space:]"\047]+|[[:space:]"\047]+$/, "", $2); print $2; exit }' "$REPO_ROOT/.bootstrap.env")
 fi
 [ -z "$PLATFORMS_VAL" ] && PLATFORMS_VAL="ios,macos"
+[ -z "$RELEASE_MODE_VAL" ] && RELEASE_MODE_VAL="ci"
 
 CHECKS=()
 if echo "$PLATFORMS_VAL" | grep -qw 'ios'; then
@@ -110,6 +120,18 @@ fi
 echo "  → required CI checks (PLATFORMS=$PLATFORMS_VAL):"
 for c in "${CHECKS[@]}"; do echo "    - $c"; done
 
+# Mode-aware admin enforcement. CI mode defaults to true (team safety net).
+# Local mode defaults to false so a solo first-time-shipper isn't locked out
+# of pushing fixes to their own fork. PR-required + required-checks still
+# gate the normal flow either way.
+if [ "$RELEASE_MODE_VAL" = "local" ]; then
+  ENFORCE_ADMINS_JSON="false"
+  echo "  → enforce_admins=false (RELEASE_MODE=local — admin can push directly)"
+else
+  ENFORCE_ADMINS_JSON="true"
+  echo "  → enforce_admins=true (RELEASE_MODE=$RELEASE_MODE_VAL — no admin bypass)"
+fi
+
 # Build the JSON checks array from $CHECKS. printf %s\\n + jq -Rs build the
 # array — keeps it simple without arity-counting.
 CHECKS_JSON=$(printf '%s\n' "${CHECKS[@]}" | jq -R '{context: .}' | jq -s '.')
@@ -120,7 +142,7 @@ PROTECTION_JSON=$(cat <<JSON
     "strict": true,
     "checks": $CHECKS_JSON
   },
-  "enforce_admins": true,
+  "enforce_admins": $ENFORCE_ADMINS_JSON,
   "required_pull_request_reviews": {
     "dismiss_stale_reviews": true,
     "require_code_owner_reviews": false,

--- a/bin/verify-rename.sh
+++ b/bin/verify-rename.sh
@@ -81,12 +81,16 @@ SLUG_ORIG="indiagrams/apple-shipkit"
 YEAR_ORIG="<year>"
 
 # check_surface LABEL LITERAL
-# Greps tracked files for LITERAL excluding the 5 self-reference paths.
+# Greps tracked files for LITERAL excluding 5 self-reference paths plus the
+# bootstrap-doctor-matrix.yml workflow (whose `if: github.repository ==
+# 'indiagrams/apple-shipkit'` safety guard is intentionally preserved on
+# forks; bin/rename.sh excludes it from substitution, so verify-rename
+# excludes it from the leak audit too — symmetric exclusion).
 # On match: writes the D-09 block to stderr (header + indented matches).
 # Always writes a single integer (the match count) to stdout.
 # Returns 0 always (caller decides via the count, not the exit code).
 #
-# Co-location note (D-01): the 5 :!path exclusions are written inline
+# Co-location note (D-01): the 6 :!path exclusions are written inline
 # here ONCE. The function body IS the single auditable source of truth
 # for the exclusion list — calling this helper 4 times does not
 # duplicate the audit surface, it reuses it.
@@ -112,7 +116,8 @@ check_surface() {
               ':!bin/verify-rename.sh' \
               ':!ci/test-rename.sh' \
               ':!ci/test-rename-gates.sh' \
-              ':!ci/test-verify-rename.sh')
+              ':!ci/test-verify-rename.sh' \
+              ':!.github/workflows/bootstrap-doctor-matrix.yml')
   status=$?
   set -e
 


### PR DESCRIPTION
## Two bugs surfaced from real forker flow

User re-forked apple-shipkit as `prakashrj/my-cool-app` (option γ from earlier this session), ran `make bootstrap-fork`, then opened a 1-line sync PR. Hit two bugs.

### Bug 1 — `bin/rename.sh` rewrote a workflow safety guard

`bin/rename.sh`'s `Step D` substitutes `indiagrams/apple-shipkit` → fork slug across the entire tree. Caught `.github/workflows/bootstrap-doctor-matrix.yml`'s safety guard:

```yaml
# BEFORE rename: kept the workflow dormant on forks
if: github.repository == 'indiagrams/apple-shipkit'

# AFTER rename: now matches THE FORK, so the workflow runs there
if: github.repository == 'prakashrj/my-cool-app'
```

The workflow validates the apple-shipkit template against the smoketest using indiagrams's secrets. On forks it has no ASC secrets, no certs-repo PAT — so it ran and failed on every fork's PR. User's PR #1 on `my-cool-app` showed 4 failed `doctor (...)` matrix cells as evidence.

**Fix**: add `':!.github/workflows/bootstrap-doctor-matrix.yml'` to `PATHSPEC_EXCLUSIONS`. The file has exactly one `indiagrams/apple-shipkit` hit (the guard); excluding it entirely is the surgical fix. All other `indiagrams` refs in the file (smoketest clone URL, `GH_ORG=indiagrams`) are intentional.

### Bug 2 — Branch protection locked solo forkers out of their own fork

`bin/setup-github.sh` hardcoded `enforce_admins=true`. Smoketest needs that (multi-dev safety net). Solo first-time-shipper does NOT — every trivial fix has to go through a PR + CI on their own repo. User couldn't push their 1-line sync directly to their own fork's main.

**Fix**: mode-aware via `.bootstrap.env`'s `RELEASE_MODE`:
- `ci` → `enforce_admins=true` (current behavior preserved)
- `local` → `enforce_admins=false` (admin can push directly; PR-required + required-checks still gate normal flow)

`BranchProtection.check` also tightened: probes the live `enforce_admins` value, returns `:pending` if it drifts from the current `RELEASE_MODE`. So a forker who later switches `ci ↔ local` and re-runs `make bootstrap-fork` gets the protection updated. Was: `:done` if protection exists, regardless of content.

## Files

| | |
|---|---|
| `bin/rename.sh` | +9 lines (path exclusion) |
| `bin/setup-github.sh` | +13 / -3 (RELEASE_MODE read + mode-aware enforce_admins) |
| `bin/lib/bootstrap.rb` | +14 / -1 (BranchProtection.check drift detection) |