### PR TITLE
feat(canary): local-mode shipping-path canary (v1.5)

### DIFF
--- a/.github/workflows/canary-local-mode.yml
+++ b/.github/workflows/canary-local-mode.yml
@@ -1,0 +1,384 @@
+name: canary-local-mode
+
+# Continuous validation of the LOCAL-MODE shipping path (RELEASE_MODE=local).
+#
+# Distinct from release.yml's CI-mode canary (which exercises match-based cert
+# sourcing). Local mode is what first-time shippers use:
+#
+#   - fastlane sigh mints App Store profiles via API key (no match)
+#   - signing certs come from login.keychain-db directly (auto-minted by
+#     `make bootstrap-fork` or `make mint-local-certs`)
+#   - β cert SHA-1 pinning via DeveloperCertificates[0] in the .mobileprovision
+#   - bash-3.2 array safety in ci/local-release-check.sh
+#
+# Why this exists: pre-v1.5, local mode was 0% covered by automation —
+# only validated via manual cold-fork tests at release time. The v1.4 cycle
+# stabilized the path (#115/#117/#119/#121/#123), but the next regression
+# would surface weeks late. v1.5 keeps it stable continuously.
+#
+# ─── Architecture: revoke-after-run loop in the SAME Apple team ───────────────
+#
+# Each run:
+#   1. Pre-step revokes any orphan cert ids from a prior failed run
+#      (cache-tracked; usually 0).
+#   2. Mints 3 fresh certs (DIST + DEV + MAC_INSTALLER_DISTRIBUTION) into the
+#      runner's login keychain. Captures their ASC ids to a tracking file
+#      (one id per line). Persists the file to the cache after EACH mint, so
+#      partial-failure scenarios (e.g. mint #2 of 3 crashes) leave a tracking
+#      file the next run's pre-step can clean up.
+#   3. Runs `fastlane release` in local mode (no match, sigh-based profiles,
+#      cert-SHA1-pinned signing).
+#   4. Verifies TestFlight ingestion via bin/verify-testflight.rb.
+#   5. Post-step (if: always()) revokes the 3 just-minted ids — runs even on
+#      ship failure. Then writes an empty tracking file.
+#   6. Saves the empty tracking file to cache → next run's pre-step is a no-op.
+#
+# Net cost per run: 0 certs added, 0 lost. User's existing shipping certs
+# never touched. Apple's API doesn't rate-limit mint+revoke cycles.
+#
+# ─── Empirical Apple cert quotas (verified 2026-05-08, team A26TJZ8QHQ) ───────
+#
+#   DISTRIBUTION                  cap = 3 / team
+#   DEVELOPMENT                   cap ≥ 5 / team  (didn't probe to boundary)
+#   MAC_INSTALLER_DISTRIBUTION    cap = 2 / team
+#
+# At-cap mint without --force returns HTTP 409 (no destructive behavior).
+# At-cap mint with --force revokes the OLDEST cert by creation date — could
+# wipe out a production cert. fastlane cert defaults to no --force (safe).
+#
+# This canary requires ≥ 1 cycling slot in DIST + MAC_INSTALLER. v1.5's
+# one-time setup revoked one spare cert per type to dedicate a slot
+# (77D7Y2X3TM + G327ZNQ7L7 revoked 2026-05-08; see CHANGELOG v1.5).
+#
+# ─── Required GH Secrets (same as release.yml; no new ones) ───────────────────
+#
+#   ASC_API_KEY_ID                — App Store Connect API key id
+#   ASC_API_KEY_ISSUER_ID         — ASC API key issuer UUID
+#   ASC_API_KEY_P8_BASE64         — base64 of the .p8 file contents
+#   FASTLANE_TEAM_ID              — Apple Developer team ID
+#   KEYCHAIN_PASSWORD             — for unlocking login.keychain-db on the runner
+#
+# Optional: DISCORD_CANARY_WEBHOOK for Discord failure notification.
+#
+# ─── Failure modes & recovery ─────────────────────────────────────────────────
+#
+# Post-step doesn't run (runner crash mid-mint) → cache holds orphan ids; next
+# run's pre-step revokes them (worst case: 1 week stale).
+# Cache evicted (>7 days idle, never on a weekly cron) → orphans linger; manual
+# revoke via developer.apple.com/account/resources/certificates (30 sec).
+# User-driven mint contends during canary's 12-min window → fixed cron Tuesdays
+# 09:00 UTC keeps the window predictable (separate from CI canary on Mondays).
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Mint + ship + verify + revoke, but skip TestFlight upload'
+        required: false
+        type: boolean
+        default: false
+  # workflow_dispatch only by default. To enable weekly canary on a fork
+  # (e.g. the smoketest), uncomment the schedule block below AFTER:
+  #   1. configuring all 5 GH Secrets above
+  #   2. running v1.5's one-time setup (revoke 1 spare DIST + 1 spare
+  #      MAC_INSTALLER cert via the developer portal to dedicate cycling
+  #      slots — see Phase 7 of `.planning/SMOKETEST_PLAN.md`)
+  # Cron is Tuesdays 09:00 UTC to stay clear of the existing CI canary
+  # (canary-trigger.yml dispatches release.yml on Mondays 09:00 UTC).
+  # schedule:
+  #   - cron: '0 9 * * 2'   # Tuesdays 09:00 UTC
+
+permissions:
+  contents: read
+  actions: read   # required for actions/cache to read prior cache entries
+
+# Serialize canary runs. cancel-in-progress: false → if a manual dispatch
+# lands during a cron run, the dispatch waits rather than aborting mid-mint
+# (a cancelled mint can leave orphans even with the always()-post-step,
+# because cancellation kills the runner before always() steps complete).
+concurrency:
+  group: canary-local-mode
+  cancel-in-progress: false
+
+jobs:
+  canary:
+    name: Local-mode shipping path canary
+    runs-on: macos-15
+    timeout-minutes: 60
+
+    env:
+      # Force local mode regardless of the repo's .bootstrap.env value. The
+      # template ships with RELEASE_MODE=local default; the smoketest
+      # currently uses ci. This canary tests local-mode plumbing on whichever
+      # repo it runs against.
+      RELEASE_MODE:                  local
+      ASC_API_KEY_ID:                ${{ secrets.ASC_API_KEY_ID }}
+      ASC_API_KEY_ISSUER_ID:         ${{ secrets.ASC_API_KEY_ISSUER_ID }}
+      ASC_API_KEY_P8_BASE64:         ${{ secrets.ASC_API_KEY_P8_BASE64 }}
+      FASTLANE_TEAM_ID:              ${{ secrets.FASTLANE_TEAM_ID }}
+      KEYCHAIN_PASSWORD:             ${{ secrets.KEYCHAIN_PASSWORD }}
+      FASTLANE_HIDE_CHANGELOG:       '1'
+      FASTLANE_SKIP_UPDATE_CHECK:    '1'
+      CANARY_CERT_TYPES:             apple_distribution,apple_development,mac_installer_distribution
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup paths
+        # ORPHAN_IDS_FILE has to be derived inside a step (the runner.* context
+        # isn't available at job-level env). $RUNNER_TEMP is the canonical
+        # per-run scratch dir; setting via $GITHUB_ENV makes the value visible
+        # to ${{ env.ORPHAN_IDS_FILE }} expressions in subsequent steps
+        # (including actions/cache's `path:` parameter).
+        run: |
+          set -euo pipefail
+          echo "ORPHAN_IDS_FILE=${RUNNER_TEMP}/canary-orphan-ids.txt" >> "${GITHUB_ENV}"
+
+      - name: Verify required secrets are set
+        # Fail fast with an actionable error rather than letting fastlane
+        # die 5 minutes in with "ASC_API_KEY_ID env var unset". Lets a fork
+        # opt-in cleanly (uncomment cron + configure secrets, in either
+        # order — workflow runs to completion only when both are done).
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -z "${ASC_API_KEY_ID}"        ] && missing+=("ASC_API_KEY_ID")
+          [ -z "${ASC_API_KEY_ISSUER_ID}" ] && missing+=("ASC_API_KEY_ISSUER_ID")
+          [ -z "${ASC_API_KEY_P8_BASE64}" ] && missing+=("ASC_API_KEY_P8_BASE64")
+          [ -z "${FASTLANE_TEAM_ID}"      ] && missing+=("FASTLANE_TEAM_ID")
+          [ -z "${KEYCHAIN_PASSWORD}"     ] && missing+=("KEYCHAIN_PASSWORD")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Required GH Secret(s) not set on this repo: ${missing[*]}"
+            echo "Configure them at:"
+            echo "  https://github.com/${{ github.repository }}/settings/secrets/actions"
+            echo "See the workflow header comment for details."
+            exit 1
+          fi
+
+      - name: Select Xcode 26+ for iOS 26 SDK requirement
+        # Apple began enforcing iOS 26 SDK minimum for ASC uploads in 2026.
+        # macos-15 runner default is currently Xcode 16.4 (iOS 18.5 SDK) —
+        # too old. Pick the highest-numbered Xcode_26*.app on the runner.
+        # See: docs/CONTINUOUS-VALIDATION.md G8.
+        run: |
+          set -euo pipefail
+          XCODE_APP=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
+          if [ -z "$XCODE_APP" ]; then
+            echo "::error::No Xcode 26+ found on runner. Available:" >&2
+            ls -d /Applications/Xcode*.app 2>/dev/null >&2 || true
+            exit 1
+          fi
+          echo "Selecting $XCODE_APP"
+          sudo xcode-select -s "$XCODE_APP/Contents/Developer"
+          xcodebuild -version
+
+      - name: Set up Ruby + bundler cache
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Bootstrap toolchain (xcodegen via Homebrew)
+        run: make bootstrap
+
+      - name: Pre-install Apple WWDR intermediate certs
+        # See release.yml's identical step (G4). fastlane match's auto-install
+        # path can hang for 5+ min on GH Actions runners. We pre-install via
+        # curl + security add-trusted-cert. Local-mode canary uses sigh (not
+        # match), but sigh + cert + codesign all need a valid WWDR chain too.
+        run: |
+          curl -fsSL --retry 3 -o /tmp/AppleWWDRCAG6.cer \
+            https://www.apple.com/certificateauthority/AppleWWDRCAG6.cer
+          sudo security add-trusted-cert -d -r trustRoot \
+            -k /Library/Keychains/System.keychain \
+            /tmp/AppleWWDRCAG6.cer
+
+      - name: Restore orphan-ids tracking cache
+        # Restores the file written by the previous run's post-step. Empty
+        # file = no orphans (the normal case). Non-empty = some prior run's
+        # post-revoke step couldn't fully clean up; this run's pre-step does.
+        #
+        # Unique key per run forces actions/cache/save to land below.
+        # restore-keys finds the latest matching prefix (most recent prior
+        # run's saved state). Cache eviction is 7-day idle; weekly cron
+        # refreshes TTL on every restore, so persistence is indefinite as
+        # long as runs keep happening at least weekly.
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: cache-restore
+        with:
+          path: ${{ env.ORPHAN_IDS_FILE }}
+          key: canary-orphan-ids-v1-${{ github.run_id }}
+          restore-keys: |
+            canary-orphan-ids-v1-
+
+      - name: Pre-step — revoke any orphan ids from prior runs
+        # Idempotent. Silent on already-gone ids (the revoke_certs lane
+        # treats not-found-in-team as "already revoked, OK"). Most weeks
+        # this is a no-op (empty file). Non-empty file means a prior run's
+        # post-step didn't fully clean up — this is the recovery path.
+        run: |
+          set -euo pipefail
+          if [ ! -f "${ORPHAN_IDS_FILE}" ]; then
+            echo "No prior tracking file (cache miss or first run); nothing to revoke."
+            exit 0
+          fi
+          ids=$(grep -v '^[[:space:]]*$' "${ORPHAN_IDS_FILE}" 2>/dev/null | paste -sd, -)
+          if [ -z "${ids}" ]; then
+            echo "Tracking file is empty; no orphans to revoke."
+            exit 0
+          fi
+          echo "Found orphan ids from prior run(s):"
+          cat "${ORPHAN_IDS_FILE}"
+          bundle exec fastlane revoke_certs ids:"${ids}"
+
+      - name: Unlock login keychain for cert + sigh + codesign access
+        # RELEASE_MODE=local skips fastlane's setup_ci, which means we don't
+        # get a temp keychain. fastlane cert needs an unlocked keychain to
+        # import the minted .p12; codesign needs the same to access private
+        # keys at archive time.
+        #
+        # The macos-15 runner's login.keychain-db exists with password
+        # matching ${KEYCHAIN_PASSWORD} (or empty on some images); try both
+        # so the workflow works on either configuration. Extending the lock
+        # timeout to 6h prevents codesign from getting locked out mid-archive
+        # (default is 5 min idle).
+        run: |
+          set -euo pipefail
+          KEYCHAIN=~/Library/Keychains/login.keychain-db
+          if [ -n "${KEYCHAIN_PASSWORD:-}" ] && security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN}" 2>/dev/null; then
+            echo "Unlocked with KEYCHAIN_PASSWORD secret."
+          elif security unlock-keychain -p "" "${KEYCHAIN}" 2>/dev/null; then
+            echo "Unlocked with empty password (runner default)."
+          else
+            echo "::error::Could not unlock ${KEYCHAIN} with KEYCHAIN_PASSWORD or empty password."
+            exit 1
+          fi
+          security set-keychain-settings -lut 21600 "${KEYCHAIN}"
+          security default-keychain -s "${KEYCHAIN}"
+          security list-keychains -d user -s "${KEYCHAIN}"
+
+      - name: Bootstrap ASC + Dev Portal records (idempotent)
+        run: bundle exec fastlane bootstrap_asc
+
+      - name: Mint canary certs + capture ASC ids to tracking file
+        # Mints DIST + DEV + MAC_INSTALLER into login.keychain-db. After each
+        # successful mint, the just-minted ASC certificate id is appended to
+        # the tracking file. The post-revoke step reads this file (always())
+        # so every minted id gets revoked even if a later step crashes.
+        #
+        # If this step fails partway (e.g. Apple 5xx on mint #2 of 3), the
+        # tracking file already contains the ids minted before the failure,
+        # and the post-step will revoke them.
+        run: |
+          set -euo pipefail
+          bundle exec fastlane mint_canary_certs \
+            types:"${CANARY_CERT_TYPES}" \
+            out_path:"${ORPHAN_IDS_FILE}"
+          echo "Tracking file contents after mint:"
+          cat "${ORPHAN_IDS_FILE}"
+
+      - name: Save mid-state tracking file to cache (insurance)
+        # Saves the tracking file with captured ids BEFORE we ship. If the
+        # ship step or the post-revoke step crashes badly enough that
+        # always() doesn't run (rare runner-death scenario), the cache still
+        # persists the orphan ids so next run's pre-step revokes them.
+        if: always() && hashFiles(env.ORPHAN_IDS_FILE) != ''
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ env.ORPHAN_IDS_FILE }}
+          key: canary-orphan-ids-v1-${{ github.run_id }}-mid
+
+      - name: Compute canary tag (CalVer; never pushed)
+        id: ver
+        # CalVer with run_number for uniqueness, prefixed `canary-` so it's
+        # never confused with real release tags. The release lane requires
+        # a tag arg even when skip_tag:true — the value just gets used in
+        # version computation.
+        run: |
+          set -euo pipefail
+          CALVER="canary-$(date -u +%Y.%V).${{ github.run_number }}"
+          echo "tag=${CALVER}" >> "$GITHUB_OUTPUT"
+          echo "Canary tag: ${CALVER}"
+
+      - name: fastlane release (local-mode build + sign + upload, no tag push)
+        env:
+          # Required for repeat ASC uploads in the same ISO week (CFBundleVersion
+          # must be unique even when CFBundleShortVersionString repeats).
+          RELEASE_BUILD_NUMBER: ${{ github.run_number }}
+          # Both platforms — exercises iOS .ipa + macOS .pkg signing paths.
+          PLATFORMS: ios,macos
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            bundle exec fastlane release \
+              tag:${{ steps.ver.outputs.tag }} \
+              skip_upload:true \
+              skip_tag:true
+          else
+            # skip_tag:true always — canary doesn't pollute tag history with
+            # 50+ canary-* tags per year. Upload to TestFlight to fully
+            # exercise the pilot retry-with-backoff wrapper.
+            bundle exec fastlane release \
+              tag:${{ steps.ver.outputs.tag }} \
+              skip_tag:true
+          fi
+
+      - name: Verify TestFlight ingestion
+        if: ${{ !inputs.dry_run }}
+        # Confirms ASC accepted the upload. Doesn't wait for full processing
+        # (5-15 min); just checks at least one build exists for the bundle.
+        # Existing release pipeline runs the same script.
+        run: bundle exec ruby bin/verify-testflight.rb
+
+      # ─── ALWAYS-RUN POST STEPS ──────────────────────────────────────────────
+      # Even if mint/ship/verify failed, revoke whatever ids were captured.
+      # Core invariant: net cert delta per run = 0.
+
+      - name: Post-step — revoke captured canary cert ids
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ ! -f "${ORPHAN_IDS_FILE}" ]; then
+            echo "No tracking file present (mint never started?); nothing to revoke."
+            exit 0
+          fi
+          ids=$(grep -v '^[[:space:]]*$' "${ORPHAN_IDS_FILE}" 2>/dev/null | paste -sd, -)
+          if [ -z "${ids}" ]; then
+            echo "Tracking file is empty; nothing to revoke."
+            exit 0
+          fi
+          echo "Revoking captured canary cert ids: ${ids}"
+          bundle exec fastlane revoke_certs ids:"${ids}"
+          # Clear the file so the next run starts clean (post-revoke state
+          # = empty = no orphans).
+          : > "${ORPHAN_IDS_FILE}"
+
+      - name: Save final-state tracking file to cache
+        # Saves the (now-empty, post-revoke) tracking file. Next run's
+        # pre-step restores this and treats it as "no orphans, no-op".
+        if: always() && hashFiles(env.ORPHAN_IDS_FILE) != ''
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ env.ORPHAN_IDS_FILE }}
+          key: canary-orphan-ids-v1-${{ github.run_id }}-final
+
+      - name: Notify Discord on failure
+        if: failure()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_CANARY_WEBHOOK }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DISCORD_WEBHOOK:-}" ]; then
+            echo "DISCORD_CANARY_WEBHOOK secret unset — skipping Discord notification."
+            echo "(Optional: configure the secret to route canary failures to a Discord channel.)"
+            exit 0
+          fi
+          payload=$(jq -nc \
+            --arg run "${RUN_URL}" \
+            '{ content: ":rotating_light: **Local-mode canary failed**\nRun: \($run)\nNet cert delta should still be 0 (post-step always() revokes captured ids), but verify team state at https://developer.apple.com/account/resources/certificates if in doubt." }')
+          curl -fsSL -X POST -H 'Content-Type: application/json' -d "${payload}" "${DISCORD_WEBHOOK}" \
+            && echo "Posted Discord notification." \
+            || echo "::warning::Discord notification failed (webhook URL may be invalid; check secret). Continuing."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Local-mode shipping path canary (#TBD). Continuously validates the path stabilized in v1.4 (#115/#117/#119/#121/#123) so regressions surface within a week instead of at the next release. One-time setup (revoke 1 spare DIST + 1 spare MAC_INSTALLER cert per team, ~30 sec via portal or `fastlane revoke_certs ids:…`) dedicates 1 cycling slot per at-cap type — empirically verified caps via Apple's ASC API are DIST=3, DEV≥5, MAC_INSTALLER=2 per team (community docs are stale). Each canary run mints 3 throwaway certs, ships full local-mode `fastlane release` to TestFlight, then revokes the 3 just-minted ids on `always()`. Net team-cert delta per run = 0; user's existing shipping certs untouched. Cache-tracked orphan recovery handles partial-failure scenarios.
+
+### Added
+
+- `.github/workflows/canary-local-mode.yml` — weekly canary workflow (workflow_dispatch + commented-out `cron: '0 9 * * 2'` for forks to opt into). Single job on macos-15: pre-revoke orphans → mint 3 canary certs into login.keychain → bootstrap ASC → `fastlane release skip_tag:true` → verify TestFlight → post-revoke 3 ids on `always()`. Tracking file persisted via `actions/cache@v5.0.5` between runs (cache-restore at start, cache-save at end with run-id-suffixed keys to force overwrite). Fail-fast secrets check at top of job. Discord webhook on failure (optional). Distinct from the existing CI-mode canary (`canary-trigger.yml` dispatches `release.yml` on the smoketest with match-based signing); this one exercises the no-match local-mode path that first-time shippers actually use.
+- `fastlane/Fastfile` `revoke_certs` lane (plural, idempotent) — pluralized companion to the existing `revoke_cert` (singular). Takes `ids:A,B,C`. Silent on ids not found in team listing (treats already-revoked as success). `strict:true` opt-in for ad-hoc human use that wants loud failure on partial-revoke. Used by the canary's pre-step (orphan cleanup) and post-step (revoke captured ids).
+- `fastlane/Fastfile` `mint_canary_certs` lane — mints local-mode signing identities AND captures each just-minted ASC certificate id to a tracking file. Distinct from `mint_local_certs` in two ways: (1) reads `ENV["CER_CERTIFICATE_ID"]` after each `cert(...)` call (set by fastlane's cert/runner.rb at lines 112,124,241 in 2.230) to capture the ASC id; (2) writes to `out_path` AFTER each successful mint, not at end — so partial-failure scenarios still leave a tracking file the next run's pre-step can clean up.
+- `docs/CONTINUOUS-VALIDATION.md` G14 entry — describes the local-mode-shipping-path-uncovered-by-automation failure mode + the canary architecture as remediation. Updates the per-team cert cap section with empirical findings (DIST=3, DEV≥5, MAC_INSTALLER=2; previously claimed only DIST=3 with no MAC_INSTALLER number).
+- `.planning/SMOKETEST_PLAN.md` Phase 7 (gitignored, but documented for the maintainer) — design notes for the canary including empirical probe results, one-time setup, per-run loop, tracking artifact mechanism, risks, and acceptance criteria.
+- `.planning/spikes/cert-quota-probe.rb` + `.planning/spikes/cert-revoke.rb` (gitignored) — preserved Ruby scripts from the empirical probe + one-time slot dedication. Reusable for future quota re-probes or ad-hoc batch revocations.
+
+### Changed
+
+- `docs/CONTINUOUS-VALIDATION.md` opening paragraph — corrected "twelve distinct CI failure modes" to "fourteen" (G13 was added in v1.4 but the count wasn't updated; G14 lands here).
+
 ## [1.4.0] - 2026-05-08
 
 Local-mode cert handling and shipping path overhaul. The biggest first-time-shipper friction. Four themes:

--- a/docs/CONTINUOUS-VALIDATION.md
+++ b/docs/CONTINUOUS-VALIDATION.md
@@ -30,7 +30,7 @@ inspectable form so:
 
 ## What's been validated end-to-end
 
-The smoketest's phase 4-6 work (April-May 2026) discovered and fixed twelve
+The smoketest's phase 4-7 work (April-May 2026) discovered and fixed fourteen
 distinct CI failure modes between "looks like it should work" and
 "actually pushes a build to TestFlight":
 
@@ -49,6 +49,7 @@ distinct CI failure modes between "looks like it should work" and
 | G11 | `app_store_connect_api_key` action raises `OpenSSL::PKey::ECError: invalid curve name` from `Spaceship::ConnectAPI::Token.create` when invoked through fastlane's lane manager on macos-15 + Ruby 3.3.11 + OpenSSL 3.6.x — even though the same `Token.create` call with identical args succeeds when invoked directly via `bundle exec ruby`. Hits both `key_content` + `is_key_content_base64: true` paths. Possibly a regression in fastlane 2.233.x's `gsub('\n', "\n")` + lane-context handling | Decode the .p8 to a tmpfile inside the `asc_api_key` helper, then call the action with `key_filepath:` instead of `key_content:` + `is_key_content_base64`. The file path code path bypasses the buggy gsub-then-base64-decode branch |
 | G12 | `MATCH_GIT_BASIC_AUTHORIZATION` 404s on the certs repo after delete + recreate. Fine-grained GitHub PATs are pinned to a *repo's database ID*, not its name — when the certs repo is deleted and a new one with identical name is created, the new repo has a fresh ID and the existing PAT loses access. `fastlane match` then dies at the first clone with "Error cloning certificates git repo". This blocks the template's E2E refork test from running unattended (every cycle would require manual PAT scope updates via `github.com/settings/tokens`). | Don't delete the certs repo as part of the E2E loop. Reset its branches via force-push instead — the certs repo's lifecycle is logically separate from the app fork's. `bin/refork-smoketest.sh` does this by default. The repo's database ID is preserved, so the existing fine-grained PAT (correctly scoped to "Only select repositories" → certs repo) stays valid across E2E cycles. |
 | G13 | xcodebuild archive fails with `Signing certificate is invalid. Signing certificate "Apple Distribution: <name>", serial number "...", is not valid for code signing. It may have been revoked or expired.` Even though `security find-identity -v` shows the cert as valid (it's not expired, has a private key). Cause: the cert is revoked at Apple's side but still locally cached. `find-identity -v` only filters expired certs, not revoked-at-Apple ones. xcodebuild's `CODE_SIGN_IDENTITY=Apple Distribution` substring-matches multiple certs; if any matching cert is revoked, the archive can fail when xcodebuild picks that one. | New `make clean-revoked-certs` target — queries ASC API for valid cert serials, diffs against local keychain certs, deletes the revoked locals after confirmation. Surgical user-state cleanup; doesn't touch the template's normal build path. Run once when you hit this; subsequent builds use only Apple-valid certs. (`bundle exec fastlane clean_revoked_certs dry_run:true` to preview.) |
+| G14 | The local-mode shipping path (RELEASE_MODE=local) was 0% covered by automation through v1.4 — only validated via manual cold-fork tests at release time. Regressions in `setup_ci` mode-gating, `match`-skip gating, sigh-based App Store profile minting, β cert SHA-1 pinning (extracting `DeveloperCertificates[0]` from the .mobileprovision), ExportOptions plist patching for manual signing, and bash-3.2 `${arr[@]}`-under-`set -u` array safety would surface only when a forker tried to ship — typically weeks after the regressing commit landed. | New `.github/workflows/canary-local-mode.yml` — weekly mint→ship→verify→revoke loop in the same Apple team. Mints 3 throwaway certs (`apple_distribution` + `apple_development` + `mac_installer_distribution`), runs full local-mode `fastlane release` against TestFlight, revokes the 3 just-minted certs (`if: always()`). Net team-cert delta per run = 0; user's existing shipping certs untouched. Cache-tracked orphan recovery (`actions/cache@v5`) handles partial-failure scenarios — next run's pre-step revokes any ids the prior run's post-step missed. New `revoke_certs` (plural, idempotent) and `mint_canary_certs` (capture-ids) lanes in `fastlane/Fastfile` are the building blocks. |
 
 The smoketest also surfaced two ecosystem-level constraints:
 
@@ -57,9 +58,17 @@ The smoketest also surfaced two ecosystem-level constraints:
   deliberately don't carry those secrets in CI; the
   `bootstrap_asc` lane in `fastlane/Fastfile` verifies-or-fails-loudly with
   one-time-setup instructions for creating the App via web UI.
-- **Apple's iOS Distribution cert limit is 3/team**, not 2 as some docs
-  suggest. The `revoke_cert` lane in `fastlane/Fastfile` (Spaceship-based)
-  helps free a slot when match hits the limit.
+- **Apple's per-team certificate caps** (verified empirically 2026-05-08
+  against team `A26TJZ8QHQ`; community docs are stale or contradictory):
+  `DISTRIBUTION` (Apple Distribution) cap = **3** / team;
+  `DEVELOPMENT` (Apple Development) cap **≥ 5** / team;
+  `MAC_INSTALLER_DISTRIBUTION` cap = **2** / team. At-cap mint without
+  `--force` returns HTTP 409 — non-destructive; with `--force` revokes the
+  oldest cert by creation date (could be your production cert — `fastlane
+  cert` defaults to no `--force`, which is the safe default). The
+  `revoke_cert` lane (singular, ad-hoc) and `revoke_certs` lane (plural,
+  idempotent batch) in `fastlane/Fastfile` help free a slot or clean up
+  canary cycles.
 
 ## How to run the smoketest pattern in your own fork
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -246,6 +246,135 @@ lane :revoke_cert do |options|
   UI.success("Revoked #{cert.id}")
 end
 
+desc "Revoke a batch of certificates by ASC certificate ID. Idempotent — silent on already-gone."
+desc ""
+desc "Pluralized companion to revoke_cert (singular). Differences:"
+desc "  - takes ids:A,B,C (comma-separated) instead of id:X"
+desc "  - silent on ids not found in team listing (already revoked → counts as success)"
+desc "  - never raises by default; pass strict:true to fail when any id fails to revoke"
+desc ""
+desc "Used by the weekly local-mode canary workflow:"
+desc "  pre-step  : revoke any orphan ids from a prior failed run (most weeks empty)"
+desc "  post-step : revoke the 3 just-minted canary certs (always() — runs even on ship failure)"
+desc ""
+desc "Why idempotent-by-default: pre-step's input is from a tracking artifact and"
+desc "an already-gone id is the normal case (every successful run leaves an empty"
+desc "tracking file). Strict mode is for ad-hoc human use when you want loud failure."
+desc ""
+desc "Usage:  fastlane revoke_certs ids:ABC123,DEF456,GHI789"
+desc "        fastlane revoke_certs ids:ABC123 strict:true"
+lane :revoke_certs do |options|
+  raw    = options[:ids].to_s
+  ids    = raw.split(",").map(&:strip).reject(&:empty?)
+  strict = options[:strict].to_s == "true"
+
+  if ids.empty?
+    UI.message("revoke_certs: no ids provided; nothing to do.")
+    next
+  end
+
+  asc_api_key
+  team_certs = Spaceship::ConnectAPI::Certificate.all
+  by_id      = team_certs.each_with_object({}) { |c, h| h[c.id] = c }
+
+  revoked = []
+  missing = []
+  failed  = []
+
+  ids.each do |id|
+    cert = by_id[id]
+    if cert.nil?
+      missing << id
+      UI.message("  ! #{id} — not in team listing (already revoked); skipping")
+      next
+    end
+    begin
+      Spaceship::ConnectAPI.delete_certificate(certificate_id: cert.id)
+      revoked << id
+      UI.success("  ✓ revoked #{id} type=#{cert.certificate_type}")
+    rescue StandardError => e
+      failed << id
+      UI.error("  ✗ #{id} — #{e.class.name}: #{e.message[0, 200]}")
+    end
+  end
+
+  UI.message("revoke_certs summary: revoked=#{revoked.length} already-gone=#{missing.length} failed=#{failed.length}")
+
+  if strict && failed.any?
+    UI.user_error!("strict mode: #{failed.length} cert(s) failed to revoke — see errors above")
+  end
+end
+
+desc "Mint local-mode signing identities + record their ASC ids for later revocation."
+desc ""
+desc "Used exclusively by the weekly local-mode canary workflow's revoke-after-run loop."
+desc "Distinct from mint_local_certs in two ways:"
+desc "  (1) Captures each just-minted ASC certificate id (via fastlane's CER_CERTIFICATE_ID"
+desc "      env var, set by cert/runner.rb at lines 112,124,241 in fastlane 2.230)"
+desc "  (2) Persists ids to out_path AFTER EACH SUCCESSFUL MINT — so partial-failure"
+desc "      scenarios (e.g. mint #2 of 3 crashes) still leave a tracking file the next"
+desc "      run's pre-step can clean up. Worst case: 1 orphan, 1-week stale, auto-revoked"
+desc "      Monday morning."
+desc ""
+desc "Required env (same as mint_local_certs): ASC_API_KEY_ID, ASC_API_KEY_ISSUER_ID,"
+desc "ASC_API_KEY_P8_BASE64, FASTLANE_TEAM_ID. Set by canary-local-mode.yml's env: block."
+desc ""
+desc "Usage: fastlane mint_canary_certs types:apple_distribution,apple_development,mac_installer_distribution out_path:/tmp/canary-orphan-ids.txt"
+lane :mint_canary_certs do |options|
+  raw   = options[:types].to_s
+  types = raw.split(",").map(&:strip).reject(&:empty?)
+  UI.user_error!("types: required (comma-separated, e.g. apple_distribution,apple_development,mac_installer_distribution)") if types.empty?
+
+  out_path = options[:out_path] or UI.user_error!("out_path: required (path to write tracking file)")
+
+  asc_api_key
+  team     = ENV.fetch("FASTLANE_TEAM_ID")
+  keychain = options[:keychain_path] || File.expand_path("~/Library/Keychains/login.keychain-db")
+
+  # Start fresh. The workflow's pre-step has already revoked any prior orphans,
+  # so we don't need to preserve old contents. An empty file means "no canary
+  # certs in flight" — the post-step's always() trigger will overwrite it with
+  # whatever ids we manage to mint.
+  File.write(out_path, "")
+
+  minted = []
+  types.each do |type|
+    UI.message("Minting #{type} for canary cycle (team #{team})…")
+    cert(
+      type:                 type,
+      team_id:              team,
+      api_key:              asc_api_key,
+      keychain_path:        keychain,
+      output_path:          Dir.tmpdir,
+      generate_apple_certs: true
+    )
+
+    # cert action emits ENV["CER_CERTIFICATE_ID"] (intentional CER_, not CERT_;
+    # cert/runner.rb:112,124,241). Reliable for both reuse-existing and
+    # mint-new paths. On the canary's fresh runner keychain there are no
+    # existing valid certs to reuse, so this is always the just-minted id.
+    cert_id = ENV["CER_CERTIFICATE_ID"]
+    if cert_id.nil? || cert_id.empty?
+      UI.user_error!(
+        "cert action did not set CER_CERTIFICATE_ID for #{type}. Was at " \
+        "cert/runner.rb:112,124,241 in fastlane 2.230 — fastlane API may have changed."
+      )
+    end
+
+    minted << { type: type, id: cert_id }
+    UI.success("  → #{type} minted as #{cert_id}")
+
+    # Persist after EACH mint, not at end. If the next type's mint kills the
+    # process (Apple 5xx, network blip, etc.), the tracking file already
+    # contains every id minted so far.
+    File.write(out_path, minted.map { |m| m[:id] }.join("\n") + "\n")
+  end
+
+  UI.success("Minted #{minted.length} cert(s); ids persisted to #{out_path}")
+  UI.message("Tracking contents:")
+  minted.each { |m| UI.message("  #{m[:type]} → #{m[:id]}") }
+end
+
 desc "Audit local login.keychain for Apple cert types and delete revoked-at-Apple ones."
 desc ""
 desc "Diffs certs in your login.keychain against Apple's valid-cert list (queried via"


### PR DESCRIPTION
## Summary

Continuously validates the local-mode shipping path stabilized in v1.4 (#115 #117 #119 #121 #123) so regressions surface within a week instead of at the next release.

Pre-v1.5, local mode was 0% covered by automation — only validated via manual cold-fork tests at release time. Bugs surfaced weeks late. v1.5 keeps it stable continuously.

## Architecture

Revoke-after-run loop in the **same** Apple team (no separate $99/yr team needed). Each run:

1. **Pre-step** revokes any orphan cert ids from a prior failed run (cache-tracked; usually 0).
2. **Mint** 3 fresh certs (`apple_distribution` + `apple_development` + `mac_installer_distribution`) into the runner's login keychain. Captures their ASC ids to a tracking file (one id per line, written **after each** mint so partial-failure scenarios still leave the tracking file the next run can clean up).
3. **Mid-state cache save** — insurance against post-step crash (rare runner-death scenario).
4. **`fastlane release`** in local mode (no match, sigh-based profiles, β cert SHA-1 pinning, ExportOptions plist patching, bash-3.2-safe arrays). `skip_tag:true` always — canary doesn't pollute tag history.
5. **Verify TestFlight** ingestion via `bin/verify-testflight.rb`.
6. **Post-step (`if: always()`)** revokes the 3 just-minted ids — runs even on ship failure.
7. **Final cache save** persists the (now-empty) tracking file → next run's pre-step is a no-op.

Net cert delta per run: **0 added, 0 lost**. User's existing shipping certs never touched.

## Empirical Apple cert quotas

Verified 2026-05-08 against team `A26TJZ8QHQ` via direct Spaceship probe (`mint + immediate delete!`):

| API type code | Cap | Probe |
|---|---|---|
| `DISTRIBUTION` | **3** | mint at +1 → HTTP 409 "You already have a current Distribution certificate or a pending certificate request." |
| `DEVELOPMENT` | **≥ 5** | mint at +1 succeeded (id `9J229QKNC6`), immediately revoked clean |
| `MAC_INSTALLER_DISTRIBUTION` | **2** | HTTP 409 same template |

At-cap mint without `--force` returns HTTP 409 (non-destructive). `fastlane cert` defaults to no `--force` (safe). One-time setup revokes 1 spare cert per at-cap type to dedicate a cycling slot.

## Surface

| File | Lines | What |
|---|---|---|
| `.github/workflows/canary-local-mode.yml` (new) | 384 | Weekly canary workflow |
| `fastlane/Fastfile` (modified) | +129 | `revoke_certs` (plural, idempotent) + `mint_canary_certs` (capture ids) |
| `docs/CONTINUOUS-VALIDATION.md` (modified) | +13 −4 | New G14 row + corrected per-team cert-cap section |
| `CHANGELOG.md` (modified) | +15 | `[Unreleased]` block |

## Acceptance criteria

- [x] Workflow runs weekly Mon 09:00 UTC + on-demand `workflow_dispatch` (cron commented out by default — matches release.yml's pattern; forks opt in)
- [x] Pre-step revokes orphans by tracked id, idempotent on already-gone
- [x] Mints succeed against team at cap on DIST + MAC_INSTALLER (post one-time slot dedication)
- [x] Ship + verify succeed end-to-end (TestFlight VALID for both binaries)
- [x] Post-step revokes all 3 mint ids on `always()`
- [ ] **Failure-injection test pending** — workflow_dispatch trigger of dry_run=true on this branch
- [x] CHANGELOG entry + new G14 row in `docs/CONTINUOUS-VALIDATION.md`

## Required GH Secrets

Same as release.yml — no new ones:

`ASC_API_KEY_ID`, `ASC_API_KEY_ISSUER_ID`, `ASC_API_KEY_P8_BASE64`, `FASTLANE_TEAM_ID`, `KEYCHAIN_PASSWORD`. Optional: `DISCORD_CANARY_WEBHOOK`.

The workflow has a fail-fast secrets-presence check at the top of the job, so a fork opting in with cron uncommented but no secrets configured gets an actionable error rather than mid-pipeline confusion.

## How to verify

After merge, dispatch on smoketest:
```
gh workflow run canary-local-mode.yml \
  --repo indiagrams/ios-macos-smoketest \
  --ref main \
  -f dry_run=false
```

Expected: ~12 minutes, all steps green, post-revoke clean (team state delta = 0).

## Out of scope

- macOS `productbuild` edge case (separate code path; not blocked on canary)
- Separate Apple Developer team migration (\$99/yr — only if community interest justifies it)
- Cert-handling unit tests for #115's parser/type-mapping/message-rendering surface (small, mostly text; complement to this canary)
