### PR TITLE
fix(canary): per-cell cache keys to avoid matrix collision

### DIFF
--- a/.github/workflows/canary-local-mode.yml
+++ b/.github/workflows/canary-local-mode.yml
@@ -367,7 +367,7 @@ jobs:
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.ORPHAN_IDS_FILE }}
-          key: canary-orphan-ids-v1-${{ github.run_id }}-mid
+          key: canary-orphan-ids-v1-${{ github.run_id }}-${{ matrix.generator }}-mid
 
       - name: Compute canary tag (CalVer; never pushed)
         id: ver
@@ -441,7 +441,7 @@ jobs:
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.ORPHAN_IDS_FILE }}
-          key: canary-orphan-ids-v1-${{ github.run_id }}-final
+          key: canary-orphan-ids-v1-${{ github.run_id }}-${{ matrix.generator }}-final
 
       - name: Notify Discord on failure
         if: failure()


### PR DESCRIPTION
## Bug

v1.5.1 (#126) added the generator matrix but both cells share `${{ github.run_id }}` → both try to save the same cache keys (`canary-orphan-ids-v1-<run_id>-mid` and `-final`). `actions/cache@v5` silently skips the second save when the key already exists, so cell 2's orphan tracking file would NOT be persisted to cache.

## Failure path this fixes

1. Cell 1 (xcodegen) succeeds → saves `-mid` and `-final` keys
2. Cell 2 (tuist) mints 3 fresh canary certs into team A26TJZ8QHQ
3. Cell 2's runner crashes after mint but before post-revoke (rare but possible)
4. `always()` post-step doesn't run (runner is dead)
5. **Cache save would have been a no-op** (key already exists from cell 1)
6. Result: **3 stuck orphans in team A26TJZ8QHQ, no automatic recovery**

## Fix

Include `${{ matrix.generator }}` in both cache save keys:

```yaml
key: canary-orphan-ids-v1-${{ github.run_id }}-${{ matrix.generator }}-mid
key: canary-orphan-ids-v1-${{ github.run_id }}-${{ matrix.generator }}-final
```

Each cell now saves to its own cache namespace. The restore step's prefix match (`restore-keys: canary-orphan-ids-v1-`) still finds the most recent saved entry across all cells and runs.

## Multi-cell flow after fix

- Cell 1 (xcodegen) saves `<run>-xcodegen-mid` (3 ids) → `<run>-xcodegen-final` (empty after revoke)
- Cell 2 (tuist) restore: prefix match → most recent = `<run>-xcodegen-final` (empty)
- Cell 2 saves `<run>-tuist-mid` (3 ids) → `<run>-tuist-final` (empty after revoke)
- Each cell's orphans tracked independently

## Cross-run flow

- New run cell 1 restore: prefix match → previous run's `<prev_run>-tuist-final` (empty)
- Happy path: all restores converge to 'most recent empty file'
- Recovery path: most recent non-empty file (the one with un-revoked orphans)

No CHANGELOG update — too small / internal correctness fix.
