### PR TITLE
fix(canary): cert action type mapping for apple_distribution/apple_development

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -114,6 +114,53 @@ def pilot_with_retry(opts, max_attempts: 3)
   end
 end
 
+# Translate a string cert type (apple_distribution / apple_development /
+# mac_installer_distribution / developer_id_application / developer_id_kext /
+# developer_id_installer) into the option hash that fastlane's cert action
+# expects.
+#
+# Why this exists: fastlane's cert action splits cert types across THREE
+# different option keys, and getting it wrong fails with a misleading error:
+#
+#   - `type:` parameter is ONLY valid for the macOS-only types
+#     (mac_installer_distribution, developer_id_*). Passing apple_distribution
+#     or apple_development as `type:` fails verify_block validation with
+#     "Unsupported types, must be: [...]" — the listed types do NOT include
+#     the App Store ones, which is the actual fastlane bug-shaped behavior
+#     this helper papers over.
+#   - `development:` boolean toggles between Apple Distribution (false) and
+#     Apple Development (true) certs. Used together with generate_apple_certs.
+#   - `generate_apple_certs:` boolean opts into the post-Xcode-11 unified
+#     cert types (Apple Distribution / Apple Development) instead of the
+#     legacy IOS_DISTRIBUTION / MAC_APP_DISTRIBUTION etc. Default-true on
+#     Mac + Xcode 11+, but we set it explicitly for clarity.
+#
+# Source of truth: cert/options.rb in fastlane 2.230.0 — verify_block at
+# line 22-26 enumerates the (limited) valid `type:` values; cert/runner.rb
+# certificate_types branches on `type` first, falls through to development +
+# generate_apple_certs.
+#
+# This is the same fix that the v1.5 canary surfaced in #115's mint_local_certs
+# lane — `type: "apple_distribution"` had been failing all along; the cold-fork
+# validation never actually exercised the auto-mint path with apple_* types.
+def cert_options_for_type(type_str)
+  case type_str.to_s
+  when "apple_distribution"
+    { development: false, generate_apple_certs: true }
+  when "apple_development"
+    { development: true,  generate_apple_certs: true }
+  when "mac_installer_distribution", "developer_id_installer",
+       "developer_id_application", "developer_id_kext"
+    { type: type_str.to_s, platform: "macos" }
+  else
+    UI.user_error!(
+      "Unsupported cert type: #{type_str.inspect}. Valid: apple_distribution, " \
+      "apple_development, mac_installer_distribution, developer_id_installer, " \
+      "developer_id_application, developer_id_kext."
+    )
+  end
+end
+
 # Reads every metadata file directly and passes explicit hashes to deliver.
 # Bypasses deliver's load_from_filesystem, which silently drops fields when
 # metadata_path is passed alone (we've reproduced this for support_url,
@@ -340,13 +387,13 @@ lane :mint_canary_certs do |options|
   minted = []
   types.each do |type|
     UI.message("Minting #{type} for canary cycle (team #{team})…")
+    type_opts = cert_options_for_type(type)
     cert(
-      type:                 type,
-      team_id:              team,
-      api_key:              asc_api_key,
-      keychain_path:        keychain,
-      output_path:          Dir.tmpdir,
-      generate_apple_certs: true
+      team_id:       team,
+      api_key:       asc_api_key,
+      keychain_path: keychain,
+      output_path:   Dir.tmpdir,
+      **type_opts
     )
 
     # cert action emits ENV["CER_CERTIFICATE_ID"] (intentional CER_, not CERT_;
@@ -524,15 +571,16 @@ lane :mint_local_certs do |options|
 
   types.each do |type|
     UI.message("Minting #{type} for team #{team} (idempotent — fastlane cert reuses existing valid certs)...")
+    type_opts = cert_options_for_type(type)
     cert(
-      type:          type,
       team_id:       team,
       api_key:       api_key,
       keychain_path: keychain,
       # output_path lands the .cer + .p12 in /tmp; cert action also imports
       # both into the keychain in one shot. We don't need the artifacts
       # afterward (login keychain is the source of truth).
-      output_path:   Dir.tmpdir
+      output_path:   Dir.tmpdir,
+      **type_opts
     )
   end
 


### PR DESCRIPTION
## Bug surfaced by v1.5 canary first dispatch

The first dispatch of canary-local-mode.yml on the smoketest ([run](https://github.com/indiagrams/ios-macos-smoketest/actions/runs/25550316765)) failed in both matrix cells at the **mint canary certs** step:

```
Error setting value 'apple_distribution' for option 'type'
You passed invalid parameters to 'cert'.
Unsupported types, must be: ["mac_installer_distribution", "developer_id_installer", "developer_id_application", "developer_id_kext"]
```

## Root cause

fastlane's cert action splits cert types across THREE different option keys:

| Type string | How to pass it | Why |
|---|---|---|
| `apple_distribution` | `development: false, generate_apple_certs: true` | New unified Apple Distribution cert (Xcode 11+) |
| `apple_development` | `development: true, generate_apple_certs: true` | New unified Apple Development cert (Xcode 11+) |
| `mac_installer_distribution` | `type: 'mac_installer_distribution', platform: 'macos'` | macOS-specific |
| `developer_id_*` | `type: 'developer_id_*', platform: 'macos'` | Developer ID for direct distribution |

The verify_block at `cert/options.rb:22-26` in fastlane 2.230 rejects any string passed as `type:` that isn't in the macOS-only list — and the error message doesn't even mention that `development:` exists as the alternative.

## Why this latent bug wasn't caught earlier

Both `mint_local_certs` (#115, v1.4) and `mint_canary_certs` (#125, v1.5) passed `type: 'apple_distribution'` to the cert action. **#115's auto-mint code path was never actually exercised end-to-end on a clean keychain**:

- v1.4 cold-fork validation against `prakashrj/my-cool-app` ran on a Mac with existing keychain certs → `LocalKeychainCerts` step's check phase saw the certs already present → `do_it` (auto-mint) was never invoked → the bug never surfaced
- The canary's design is the first time this code path runs on a fresh runner keychain (no existing certs) → cert action invoked → bug fires immediately

This is **exactly what the canary is for**: surfacing regressions that manual cold-fork testing misses.

## Fix

New `cert_options_for_type(type_str)` helper near the top of the Fastfile that maps a type string to the correct cert action options hash. Both `mint_canary_certs` and `mint_local_certs` lanes use the helper instead of passing `type:` directly.

Effect:

```ruby
# Before (broken for apple_*):
cert(type: 'apple_distribution', team_id: ..., ...)

# After (correct):
type_opts = cert_options_for_type('apple_distribution')
# → { development: false, generate_apple_certs: true }
cert(team_id: ..., ..., **type_opts)
```

## Validation

```
ruby -c fastlane/Fastfile          → Syntax OK
bundle exec fastlane lanes         → all 3 lanes register cleanly
```

End-to-end validation comes from re-dispatching the canary on the smoketest after this PR + smoketest sync land. That run is the actual proof.
