### PR TITLE
fix(fastlane): pilot_with_retry kwargs signature for Ruby 3+ strict mode

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -95,7 +95,7 @@ end
 # diagnosing days later.
 #
 # Mirrors ci/local-release-check.sh's with_timestamp_retry pattern.
-def pilot_with_retry(opts, max_attempts: 3)
+def pilot_with_retry(max_attempts: 3, **opts)
   attempts = 0
   begin
     attempts += 1


### PR DESCRIPTION
Bug #5 caught by canary dry_run=false dispatch ([run 25591918707](https://github.com/indiagrams/ios-macos-smoketest/actions/runs/25591918707)).

Function signature was `def pilot_with_retry(opts, max_attempts: 3)` — expecting a positional Hash. Both call sites pass kwargs:

```ruby
pilot_with_retry(api_key: api_key, ipa: ipa_path, skip_waiting_for_build_processing: true)
```

Ruby 3+'s strict positional-vs-keyword separation rejects this with `ArgumentError: given 0, expected 1`.

Latent since v1.2.0 (#94). The v1.4 manual cold-fork ship to TestFlight 2026.19.0111 must have run on a Ruby 2.x environment where positional/keyword interchangeability masked it. CI runs on Ruby 3.3.11 + fastlane 2.233.1 strict.

Fix: `def pilot_with_retry(max_attempts: 3, **opts)`. Call sites unchanged.

The canary doing its job: catching a v1.2 latent bug that local-Mac shipping (older Ruby, cached gems) hides.