### PR TITLE
feat(canary): populate .bootstrap.env from GH secrets + repo introspection

### DIFF
--- a/.github/workflows/canary-local-mode.yml
+++ b/.github/workflows/canary-local-mode.yml
@@ -447,15 +447,80 @@ jobs:
               skip_tag:true
           fi
 
-      # (Verify TestFlight ingestion step removed: bin/verify-testflight.rb
-      # requires a `.bootstrap.env` file (gitignored, never committed) and
-      # would always fail on a CI runner. The pilot upload's
-      # 'Successfully uploaded the new binary to App Store Connect' message
-      # in the previous step is sufficient signal that the local-mode
-      # shipping path worked end-to-end. Post-upload TestFlight ingestion
-      # is Apple's responsibility — not the canary's. To verify processing
-      # state across runs, query developer.apple.com/account/resources or
-      # appstoreconnect.apple.com manually.)
+      - name: Populate .bootstrap.env from secrets + repo introspection
+        # bin/verify-testflight.rb (called below) reads `.bootstrap.env` via
+        # Bootstrap::Config.load!, which requires 12 fields for local mode.
+        # The file is gitignored (never committed; per-fork user state), so
+        # it doesn't exist on a fresh CI checkout.
+        #
+        # Strategy: synthesize a `.bootstrap.env` from a mix of GH Secrets
+        # (the 4 fields verify-testflight actually USES — BUNDLE_ID, ASC
+        # creds — must have real values) plus repo-extracted values
+        # (GENERATOR from filesystem, GH_ORG/GH_APP_REPO from git remote)
+        # plus presence-only placeholders for fields validate! requires but
+        # verify-testflight doesn't read.
+        #
+        # The .p8 cert is base64-encoded in the secret; decode to a tmpfile
+        # so Bootstrap.ensure_asc_token! can read it via ASC_API_KEY_P8_PATH.
+        if: ${{ !inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          # BUNDLE_ID — the canonical source for any fork is fastlane/Fastfile's
+          # APP_IDENTIFIER constant (set by bin/rename.sh during fork creation).
+          BUNDLE_ID=$(grep '^APP_IDENTIFIER' fastlane/Fastfile | head -1 | sed 's/.*= *"\(.*\)"/\1/')
+          if [ -z "${BUNDLE_ID:-}" ]; then
+            echo "::error::Could not extract APP_IDENTIFIER from fastlane/Fastfile"
+            exit 1
+          fi
+
+          # GENERATOR — detect from filesystem. The matrix's preceding switch
+          # step has already mutated the workspace into the cell's shape.
+          if [ -f app/project.yml ]; then
+            GENERATOR=xcodegen
+          else
+            GENERATOR=tuist
+          fi
+
+          # GH_ORG / GH_APP_REPO — extracted from git remote.
+          REMOTE=$(git remote get-url origin)
+          GH_REPO_PATH=$(echo "${REMOTE}" | sed -E 's|.*github\.com[:/]([^/]+/[^/.]+)(\.git)?$|\1|')
+          GH_ORG=$(echo "${GH_REPO_PATH}" | cut -d/ -f1)
+          GH_APP_REPO=$(echo "${GH_REPO_PATH}" | cut -d/ -f2)
+
+          # Decode .p8 to disk so ensure_asc_token! can load it via path.
+          P8_PATH="${RUNNER_TEMP}/asc_api_key_canary.p8"
+          echo "${ASC_API_KEY_P8_BASE64}" | base64 -d > "${P8_PATH}"
+          chmod 600 "${P8_PATH}"
+
+          # Synthesize .bootstrap.env. Fields used by verify-testflight.rb
+          # have real values (BUNDLE_ID, ASC_API_KEY_*); other REQUIRED_ALWAYS
+          # fields get placeholders that satisfy presence checks.
+          cat > .bootstrap.env <<EOF
+          APP_NAME=canary
+          BUNDLE_ID=${BUNDLE_ID}
+          DISPLAY_NAME=Canary
+          APP_EMAIL=canary@local.invalid
+          GENERATOR=${GENERATOR}
+          RELEASE_MODE=local
+          PLATFORMS=ios,macos
+          FASTLANE_TEAM_ID=${FASTLANE_TEAM_ID}
+          ASC_API_KEY_ID=${ASC_API_KEY_ID}
+          ASC_API_KEY_ISSUER_ID=${ASC_API_KEY_ISSUER_ID}
+          ASC_API_KEY_P8_PATH=${P8_PATH}
+          GH_ORG=${GH_ORG}
+          GH_APP_REPO=${GH_APP_REPO}
+          EOF
+          echo "Synthesized .bootstrap.env:"
+          # Print the file but mask the real ASC ids (they're already secrets in CI logs)
+          sed 's/=.*/=***MASKED***/' .bootstrap.env
+
+      - name: Verify TestFlight ingestion
+        # Confirms ASC accepted the upload. Doesn't wait for full processing
+        # (5-15 min); just checks at least one build exists for the bundle.
+        # Real local-mode users run `make verify` which calls the same script.
+        if: ${{ !inputs.dry_run }}
+        run: bundle exec ruby bin/verify-testflight.rb
 
       # ─── ALWAYS-RUN POST STEPS ──────────────────────────────────────────────
       # Even if mint/ship/verify failed, revoke whatever ids were captured.


### PR DESCRIPTION
Reverses [#132](https://github.com/indiagrams/apple-shipkit/pull/132)'s drop of verify-testflight; instead synthesizes a minimal `.bootstrap.env` on the runner so the existing local-mode `make verify` script (bin/verify-testflight.rb) runs unchanged.

## Why this beats dropping the step

Drift between 'what the canary tests' and 'what users run' is exactly the failure mode the canary was built to prevent. Dropping verify would have left bin/verify-testflight.rb's surface (Bootstrap::Config.load!, validate!, ensure_asc_token!, Spaceship App.find/Build.all) **uncovered**.

## Strategy

| Field | Source | Why |
|---|---|---|
| BUNDLE_ID | `fastlane/Fastfile` APP_IDENTIFIER | Canonical for any fork (set by `bin/rename.sh`) |
| ASC_API_KEY_* | GH Secrets (already in env) | Real values needed for token creation |
| ASC_API_KEY_P8_PATH | base64-decoded secret → `${RUNNER_TEMP}` | Bootstrap.ensure_asc_token! reads from path |
| GENERATOR | `[ -f app/project.yml ]` | Switch step has already mutated workspace |
| GH_ORG / GH_APP_REPO | `git remote get-url origin` | Authoritative for the running repo |
| APP_NAME / DISPLAY_NAME / APP_EMAIL | Hardcoded placeholders | Pass validate! presence check; verify doesn't use them |
| RELEASE_MODE / PLATFORMS | `local` / `ios,macos` | Fixed for canary |

## Test matrix coverage after this PR

The canary now exercises:

  - sigh, β cert SHA-1 pinning, ExportOptions plist, bash arrays (Fastfile + ci/local-release-check.sh)
  - pilot upload to TestFlight (both iOS .ipa + macOS .pkg)
  - **bin/verify-testflight.rb** (Bootstrap::Config + Spaceship querying) — newly covered

Step gated on `!inputs.dry_run` so dry-runs skip both populate + verify.

The .bootstrap.env is in .gitignore (no commit risk); runner is ephemeral (disappears with runner).