### PR TITLE
feat(canary): TestFlight changelog annotations for cell identification

### DIFF
--- a/.github/workflows/canary-local-mode.yml
+++ b/.github/workflows/canary-local-mode.yml
@@ -441,6 +441,17 @@ jobs:
           RELEASE_BUILD_NUMBER: ${{ github.run_number }}${{ matrix.generator == 'xcodegen' && '01' || '02' }}
           # Both platforms — exercises iOS .ipa + macOS .pkg signing paths.
           PLATFORMS: ios,macos
+          # Annotates each canary build's TestFlight "What to Test" entry so
+          # a human looking at App Store Connect can identify which matrix
+          # cell + run produced a given build (vs. having to decode the
+          # build-number suffix). Empty for real release.yml runs; set only
+          # by canary workflows.
+          RELEASE_CHANGELOG: |
+            🐤 Canary build — local-mode shipping path validation
+            generator:  ${{ matrix.generator }}
+            run:        #${{ github.run_number }} (cell build ${{ github.run_number }}${{ matrix.generator == 'xcodegen' && '01' || '02' }})
+            commit:     ${{ github.sha }}
+            workflow:   https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           if [ "${{ inputs.dry_run }}" = "true" ]; then

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -899,13 +899,19 @@ platform :ios do
       UI.important("Step 3/5: Skipping iOS TestFlight upload (skip_upload:true)")  if do_ios
       UI.important("Step 4/5: Skipping macOS TestFlight upload (skip_upload:true)") if do_macos
     else
+      # Build a "What to Test" changelog string from RELEASE_CHANGELOG. Empty
+      # by default (real ships don't need it; testers can read git tag);
+      # canary workflows set it to identify which cell + run produced a build.
+      cl = ENV["RELEASE_CHANGELOG"].to_s.strip
+      changelog_opts = cl.empty? ? {} : { changelog: cl }
+
       if do_ios
         UI.message("Step 3/5: Uploading iOS .ipa to TestFlight…")
-        pilot_with_retry(api_key: api_key, ipa: ipa_path, skip_waiting_for_build_processing: true)
+        pilot_with_retry(api_key: api_key, ipa: ipa_path, skip_waiting_for_build_processing: true, **changelog_opts)
       end
       if do_macos
         UI.message("Step 4/5: Uploading macOS .pkg to TestFlight…")
-        pilot_with_retry(api_key: api_key, pkg: pkg_path, skip_waiting_for_build_processing: true)
+        pilot_with_retry(api_key: api_key, pkg: pkg_path, skip_waiting_for_build_processing: true, **changelog_opts)
       end
     end
 


### PR DESCRIPTION
Closes the 'which build belongs to which matrix cell?' visibility gap. The build-number suffix encoding (`01`=xcodegen, `02`=tuist) works but requires hidden knowledge.

Now every pilot upload from the canary workflow threads a RELEASE_CHANGELOG env var through the release lane to pilot's `changelog:` parameter. Each canary build's TestFlight 'What to Test' section becomes:

```
🐤 Canary build — local-mode shipping path validation
generator:  xcodegen
run:        #7 (cell build 701)
commit:     243a0cc
workflow:   https://github.com/.../actions/runs/...
```

Click on build 701 in TestFlight → see immediately that it's the xcodegen cell of run #7, with a deep link back to logs.

Real `release.yml` runs don't set RELEASE_CHANGELOG, so the `changelog:` arg stays unset → backward-compatible.