### PR TITLE
feat(canary): isolate uploads from external TestFlight testers

### DIFF
--- a/.github/workflows/canary-local-mode.yml
+++ b/.github/workflows/canary-local-mode.yml
@@ -452,6 +452,14 @@ jobs:
             run:        #${{ github.run_number }} (cell build ${{ github.run_number }}${{ matrix.generator == 'xcodegen' && '01' || '02' }})
             commit:     ${{ github.sha }}
             workflow:   https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # Isolate canary uploads from external testers. notify_external=false
+          # silences emails on every canary upload (~16/year if cron lands).
+          # distribute_external=false skips Beta App Review submission and
+          # prevents the build from being pushed to external testing groups.
+          # Both default to "would notify/distribute" at ASC; we explicitly
+          # opt out for canary builds, which never reach humans.
+          RELEASE_NOTIFY_EXTERNAL:     'false'
+          RELEASE_DISTRIBUTE_EXTERNAL: 'false'
         run: |
           set -euo pipefail
           if [ "${{ inputs.dry_run }}" = "true" ]; then

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -899,19 +899,34 @@ platform :ios do
       UI.important("Step 3/5: Skipping iOS TestFlight upload (skip_upload:true)")  if do_ios
       UI.important("Step 4/5: Skipping macOS TestFlight upload (skip_upload:true)") if do_macos
     else
-      # Build a "What to Test" changelog string from RELEASE_CHANGELOG. Empty
-      # by default (real ships don't need it; testers can read git tag);
-      # canary workflows set it to identify which cell + run produced a build.
+      # Build the optional/defensive pilot options for this build.
+      #
+      # RELEASE_CHANGELOG (optional) — TestFlight "What to Test" annotation.
+      # Empty for real ships (testers read the git tag); canary workflows
+      # set it to identify which cell + run produced a build.
+      #
+      # RELEASE_NOTIFY_EXTERNAL ("false") — pass notify_external_testers:false
+      # to pilot. Default-true at ASC means external testers get an email
+      # for every upload. For canary uploads (which testers should never
+      # see), force false.
+      #
+      # RELEASE_DISTRIBUTE_EXTERNAL ("false") — pass distribute_external:false
+      # to pilot. Prevents the build from being pushed to external testing
+      # groups + skips the Beta App Review submission. For canary builds,
+      # which never go to humans, force false.
+      pilot_extras = {}
       cl = ENV["RELEASE_CHANGELOG"].to_s.strip
-      changelog_opts = cl.empty? ? {} : { changelog: cl }
+      pilot_extras[:changelog] = cl unless cl.empty?
+      pilot_extras[:notify_external_testers] = false if ENV["RELEASE_NOTIFY_EXTERNAL"].to_s == "false"
+      pilot_extras[:distribute_external]     = false if ENV["RELEASE_DISTRIBUTE_EXTERNAL"].to_s == "false"
 
       if do_ios
         UI.message("Step 3/5: Uploading iOS .ipa to TestFlight…")
-        pilot_with_retry(api_key: api_key, ipa: ipa_path, skip_waiting_for_build_processing: true, **changelog_opts)
+        pilot_with_retry(api_key: api_key, ipa: ipa_path, skip_waiting_for_build_processing: true, **pilot_extras)
       end
       if do_macos
         UI.message("Step 4/5: Uploading macOS .pkg to TestFlight…")
-        pilot_with_retry(api_key: api_key, pkg: pkg_path, skip_waiting_for_build_processing: true, **changelog_opts)
+        pilot_with_retry(api_key: api_key, pkg: pkg_path, skip_waiting_for_build_processing: true, **pilot_extras)
       end
     end
 


### PR DESCRIPTION
Default ASC behavior is to notify external TestFlight testers about every upload. For canary builds (~16/year between local-mode + CI canaries) this is wrong — testers should never see canary builds.

Adds two env-gated pilot options:

| Env var | When 'false' | Effect |
|---|---|---|
| `RELEASE_NOTIFY_EXTERNAL` | passes `notify_external_testers: false` | Silences tester emails |
| `RELEASE_DISTRIBUTE_EXTERNAL` | passes `distribute_external: false` | Skips Beta App Review submission + external group push |

`canary-local-mode.yml` sets both to `false`. Real `release.yml` runs leave them unset → ASC defaults preserved → existing real-ship behavior unchanged.

Same pattern as `RELEASE_CHANGELOG`. Backward-compatible.

Discovered via run [25593988734](https://github.com/indiagrams/ios-macos-smoketest/actions/runs/25593988734) log:
> Using App Store Connect's default for notifying external testers (which is true) - set `notify_external_testers` for full control