### PR TITLE
fix(canary): ASCII-only RELEASE_CHANGELOG (ASC rejects emoji)

### DIFF
--- a/.github/workflows/canary-local-mode.yml
+++ b/.github/workflows/canary-local-mode.yml
@@ -446,8 +446,15 @@ jobs:
           # cell + run produced a given build (vs. having to decode the
           # build-number suffix). Empty for real release.yml runs; set only
           # by canary workflows.
+          #
+          # ASCII-only: ASC's BetaBuildLocalization endpoint REJECTS non-Latin
+          # characters in whatsNew with a 'contains invalid characters' error
+          # that fastlane's pilot silently swallows (logs "Successfully set
+          # the changelog for build" anyway, but the BBL never gets written).
+          # Caught by manual probe via Spaceship after canary run #9. Stick
+          # to ASCII letters / digits / common punctuation in this string.
           RELEASE_CHANGELOG: |
-            🐤 Canary build — local-mode shipping path validation
+            [CANARY] Local-mode shipping path validation
             generator:  ${{ matrix.generator }}
             run:        #${{ github.run_number }} (cell build ${{ github.run_number }}${{ matrix.generator == 'xcodegen' && '01' || '02' }})
             commit:     ${{ github.sha }}


### PR DESCRIPTION
## Bug

Run #9's manual Spaceship probe revealed pilot's success message was lying. ASC's BetaBuildLocalization API actually rejects:

```
Text for whatsNew contains invalid characters:'[🐤]'. - whatsNew
```

fastlane's pilot wrapper silently swallows this error and logs 'Successfully set the changelog for build' anyway. Net effect: no localization gets persisted, 'What to Test' stays empty in TestFlight UI despite fastlane reporting success.

## Repro

```ruby
Spaceship::ConnectAPI.post_beta_build_localizations(
  build_id: "...", attributes: { locale: "en-US", whatsNew: "🐤 ..." }
)
# → Spaceship::UnexpectedResponse: invalid characters:'[🐤]'
```

Same call without the emoji returns 201 + persists correctly.

## Fix

Replace 🐤 + em-dash with ASCII `[CANARY]` prefix and ASCII hyphens. Document the ASCII constraint in the workflow comment.

## Verification

After merge + sync to smoketest + dispatch, the next canary run's TestFlight 'What to Test' field should populate with the (ASCII) annotation.