### PR TITLE
fix(canary): use localized_build_info: instead of changelog: (fastlane bug)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -903,7 +903,13 @@ platform :ios do
       #
       # RELEASE_CHANGELOG (optional) — TestFlight "What to Test" annotation.
       # Empty for real ships (testers read the git tag); canary workflows
-      # set it to identify which cell + run produced a build.
+      # set it to identify which cell + run produced a build. Sent to pilot
+      # via `localized_build_info:` (NOT `changelog:`) — pilot 2.233.1's
+      # `changelog:` path silently no-ops on builds with no pre-existing
+      # BetaBuildLocalization (its update loop iterates an empty hash; see
+      # pilot/lib/pilot/build_manager.rb:575-586). The localized_build_info:
+      # path explicitly seeds the locale-keyed hash, so the post-create
+      # branch fires correctly.
       #
       # RELEASE_NOTIFY_EXTERNAL ("false") — pass notify_external_testers:false
       # to pilot. Default-true at ASC means external testers get an email
@@ -916,7 +922,7 @@ platform :ios do
       # which never go to humans, force false.
       pilot_extras = {}
       cl = ENV["RELEASE_CHANGELOG"].to_s.strip
-      pilot_extras[:changelog] = cl unless cl.empty?
+      pilot_extras[:localized_build_info] = { "en-US" => { whats_new: cl } } unless cl.empty?
       pilot_extras[:notify_external_testers] = false if ENV["RELEASE_NOTIFY_EXTERNAL"].to_s == "false"
       pilot_extras[:distribute_external]     = false if ENV["RELEASE_DISTRIBUTE_EXTERNAL"].to_s == "false"
 


### PR DESCRIPTION
Run #10 STILL showed empty 'What to Test' despite pilot logging success. Investigation found a real bug in fastlane pilot 2.233.1's `set_changelog` flow:

```ruby
# pilot/lib/pilot/build_manager.rb:560-588 (update_localized_build_review)
localizations_by_lang = {}                                    # empty
info_by_lang.each_key { |k| localizations_by_lang[k] = nil }  # info_by_lang is empty
build.get_beta_build_localizations.each { ... }               # empty for new build
localizations_by_lang.each { ... }                            # NO-OP, empty hash
```

When called via `changelog:`, fastlane passes `default_info` instead of `info_by_lang`. The locale-keyed hash never gets seeded → the upsert loop iterates nothing → no API POST → 'What to Test' stays empty.

The `UI.success("Successfully set the changelog for build")` log at line 283 fires regardless of whether anything was actually written.

## Fix

Pass `localized_build_info: { 'en-US' => { whats_new: cl } }` instead of `changelog: cl`. This explicitly seeds `info_by_lang` with the en-US key, so the locale-keyed loop iterates and the create branch (line 597-598) fires correctly.

## Verification

Manually verified via direct `Spaceship::ConnectAPI.post_beta_build_localizations(...)` that ASC's API itself works fine with ASCII text. The issue was entirely pilot's flawed implementation.