### PR TITLE
chore(canary): change cron to Saturdays 11:30 UTC

### DIFF
--- a/.github/workflows/canary-local-mode.yml
+++ b/.github/workflows/canary-local-mode.yml
@@ -66,8 +66,8 @@ name: canary-local-mode
 # run's pre-step revokes them (worst case: 1 week stale).
 # Cache evicted (>7 days idle, never on a weekly cron) → orphans linger; manual
 # revoke via developer.apple.com/account/resources/certificates (30 sec).
-# User-driven mint contends during canary's 12-min window → fixed cron Tuesdays
-# 09:00 UTC keeps the window predictable (separate from CI canary on Mondays).
+# User-driven mint contends during canary's 12-min window → fixed cron Saturdays
+# 11:30 UTC keeps the window predictable (separate from CI canary on Mondays).
 #
 # ─── Generator matrix: xcodegen × tuist ───────────────────────────────────────
 #
@@ -107,10 +107,10 @@ on:
   #   2. running v1.5's one-time setup (revoke 1 spare DIST + 1 spare
   #      MAC_INSTALLER cert via the developer portal to dedicate cycling
   #      slots — see Phase 7 of `.planning/SMOKETEST_PLAN.md`)
-  # Cron is Tuesdays 09:00 UTC to stay clear of the existing CI canary
+  # Cron is Saturdays 11:30 UTC to stay clear of the existing CI canary
   # (canary-trigger.yml dispatches release.yml on Mondays 09:00 UTC).
   # schedule:
-  #   - cron: '0 9 * * 2'   # Tuesdays 09:00 UTC
+  #   - cron: '30 11 * * 6'   # Saturdays 11:30 UTC
 
 permissions:
   contents: read


### PR DESCRIPTION
Updates the commented `schedule:` block (forkers' default-when-uncommented) and the surrounding comments. Mirrored to smoketest's active cron in indiagrams/ios-macos-smoketest#TBD.