### PR TITLE
docs: v1.5 audit — sync 9 doc files to current canary + cert + pipeline reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Swift 5.9](https://img.shields.io/badge/Swift-5.9-orange.svg)](https://swift.org)
 [![Discord](https://img.shields.io/badge/Discord-join%20chat-5865F2?logo=discord&logoColor=white)](https://discord.gg/sExv9eKdA)
 [![Weekly canary](https://github.com/indiagrams/apple-shipkit/actions/workflows/canary-trigger.yml/badge.svg)](https://github.com/indiagrams/apple-shipkit/actions/workflows/canary-trigger.yml)
+[![Local-mode canary](https://github.com/indiagrams/apple-shipkit/actions/workflows/canary-local-mode.yml/badge.svg)](https://github.com/indiagrams/apple-shipkit/actions/workflows/canary-local-mode.yml)
 
 > **Goal of this README:** if you've never shipped an iOS or Mac app before, by the end of it you will have one running on your phone (or Mac) via TestFlight. About 30–60 minutes of focused time, $99/year for Apple Developer Program, and a Mac to build on (Xcode and the rest of Apple's build tools only run on macOS — you need a Mac even for an iPhone-only app).
 
@@ -24,7 +25,7 @@ I'm a first-time iOS developer. Before writing a feature of my actual app, I spe
 
 I automated or documented every requirement I encountered. That's what this template is — the boring prep work, done.
 
-A public canary fork ([`indiagrams/ios-macos-smoketest`](https://github.com/indiagrams/ios-macos-smoketest)) real-ships to TestFlight every Monday on both xcodegen and tuist generators, so Apple-side regressions surface upstream. Catalog at [`docs/CONTINUOUS-VALIDATION.md`](docs/CONTINUOUS-VALIDATION.md).
+A public canary fork ([`indiagrams/ios-macos-smoketest`](https://github.com/indiagrams/ios-macos-smoketest)) real-ships to TestFlight on two cadences: CI mode every Monday and local mode every Saturday, both on xcodegen and tuist generators, so Apple-side regressions surface upstream within a week. Catalog at [`docs/CONTINUOUS-VALIDATION.md`](docs/CONTINUOUS-VALIDATION.md).
 
 ---
 
@@ -394,7 +395,7 @@ Most first-time failures fall into a few buckets. Here's what to do:
 | "Provisioning profile doesn't include the device" | You're trying to sideload, not TestFlight-distribute | TestFlight builds don't need device IDs in the profile. If you see this from `make ship`, your `RELEASE_MODE` may be misconfigured |
 | `make doctor` says "ASC App record not found" | One-time human step — Apple's API forbids `POST /apps` | Go to [appstoreconnect.apple.com/apps](https://appstoreconnect.apple.com/apps), click + → New App, fill in your bundle ID + display name, then re-run `make doctor` |
 | Apple rejects with "Account holder must accept Paid Apps Agreement" | Skip-able for free apps | If you're shipping a free app, no fix needed. If paid, log in to ASC → Agreements, Tax, and Banking → accept |
-| Random `make ship` failure during CI mode | Check the latest entries in [docs/CONTINUOUS-VALIDATION.md](docs/CONTINUOUS-VALIDATION.md) — a 12-entry catalog of known CI-only gotchas |
+| Random `make ship` failure during CI mode | Check the latest entries in [docs/CONTINUOUS-VALIDATION.md](docs/CONTINUOUS-VALIDATION.md) — a 14-entry catalog of known shipping-pipeline gotchas |
 
 If something isn't on this list, [open an issue](https://github.com/indiagrams/apple-shipkit/issues/new) with the full `make ship` output. The maintainers care; this template exists to absorb new gotchas as they're discovered.
 
@@ -444,7 +445,7 @@ Once you're past the first ship, these docs cover the rest:
 
 - **[docs/BOOTSTRAP.md](docs/BOOTSTRAP.md)** — every field of `.bootstrap.env` explained; CI-mode setup; manual fallback if you want to drive the bootstrap by hand.
 - **[docs/APPLE-PREREQS.md](docs/APPLE-PREREQS.md)** — Apple-side setup details, especially for the ASC App record.
-- **[docs/CONTINUOUS-VALIDATION.md](docs/CONTINUOUS-VALIDATION.md)** — the 12-entry catalog of CI-only gotchas (G1–G12). Living document; updated whenever something new is caught by the canary.
+- **[docs/CONTINUOUS-VALIDATION.md](docs/CONTINUOUS-VALIDATION.md)** — the 14-entry catalog of shipping-pipeline gotchas (G1–G14, covering both CI and local modes). Living document; updated whenever something new is caught by either canary.
 - **[docs/MIGRATING-TO-TUIST.md](docs/MIGRATING-TO-TUIST.md)** — switching from XcodeGen to Tuist after fork.
 - **[docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md](docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md)** — same archive/export flow without fastlane (uses `xcrun altool` + `notarytool` + ASC API directly).
 - **[docs/PRINCIPLES.md](docs/PRINCIPLES.md)** — design decisions behind the template's structure.
@@ -479,22 +480,24 @@ Each step is its own fastlane lane in `fastlane/Fastfile`. Read the file — it'
 
 ## Continuous validation
 
-[![Weekly canary](https://github.com/indiagrams/apple-shipkit/actions/workflows/canary-trigger.yml/badge.svg)](https://github.com/indiagrams/apple-shipkit/actions/workflows/canary-trigger.yml)
+[![Weekly canary (CI mode)](https://github.com/indiagrams/apple-shipkit/actions/workflows/canary-trigger.yml/badge.svg)](https://github.com/indiagrams/apple-shipkit/actions/workflows/canary-trigger.yml)
+[![Weekly canary (local mode)](https://github.com/indiagrams/apple-shipkit/actions/workflows/canary-local-mode.yml/badge.svg)](https://github.com/indiagrams/apple-shipkit/actions/workflows/canary-local-mode.yml)
 
-The badge above reflects the most recent weekly canary run, which exercises **both** the xcodegen and tuist dispatch cells against real Apple infrastructure on the [indiagrams/ios-macos-smoketest](https://github.com/indiagrams/ios-macos-smoketest) fork. Reads as:
+The two badges above reflect the most recent canary runs:
 
-- 🟢 green — the most recent run had **both** `dispatch (xcodegen)` and `dispatch (tuist)` ship successfully to TestFlight.
-- 🔴 red — at least one cell failed. [Click the badge](https://github.com/indiagrams/apple-shipkit/actions/workflows/canary-trigger.yml) to see which one (and why).
+- **CI-mode canary** ([`canary-trigger.yml`](https://github.com/indiagrams/apple-shipkit/actions/workflows/canary-trigger.yml)) — exercises the match-based shipping path used by forks with `RELEASE_MODE=ci`. Both `dispatch (xcodegen)` and `dispatch (tuist)` cells real-ship to TestFlight on the [smoketest fork](https://github.com/indiagrams/ios-macos-smoketest).
+- **Local-mode canary** ([`canary-local-mode.yml`](https://github.com/indiagrams/apple-shipkit/actions/workflows/canary-local-mode.yml)) — exercises the no-match sigh-based shipping path used by forks with `RELEASE_MODE=local` (the default). Mints throwaway certs in the same Apple team, ships to TestFlight, revokes the certs on `always()` so net team-cert delta per run is 0.
 
-Per-cell history (xcodegen vs tuist) lives in the workflow's run-by-run breakdown — each run lists two jobs (`dispatch (xcodegen)` + `dispatch (tuist)`) with independent green/red status.
+Either badge red → at least one cell failed. Click the badge to see which cell + why. Per-cell history (xcodegen vs tuist) lives in each workflow's run-by-run breakdown.
 
-The validation infrastructure:
+The validation infrastructure (all on the smoketest fork):
 - **Mondays 07:00 UTC**: read-only doctor matrix (4 cells: xcodegen|tuist × ci|local) — covers bootstrap toolchain.
-- **Mondays 09:00 UTC**: full release ship to TestFlight, both generators in sequence — covers signing pipeline + Apple infrastructure.
+- **Mondays 09:00 UTC**: full release ship to TestFlight via `release.yml`, both generators in sequence — covers the CI-mode signing pipeline + Apple infrastructure.
+- **Saturdays 11:30 UTC**: full release ship to TestFlight via `canary-local-mode.yml`, both generators sequentially — covers the local-mode signing pipeline (no match, sigh-based profiles, β cert SHA-1 pinning, controlled keychain).
 
 Bugs in fastlane / match / Apple's signing infra surface there before they bite forkers — patches land in this template before they hit your repo.
 
-If you fork this template and your build breaks Monday morning out of the blue, [check the smoketest's Actions tab](https://github.com/indiagrams/ios-macos-smoketest/actions) — it's probably broken there too, and a fix is in flight.
+If you fork this template and your build breaks unexpectedly, [check the smoketest's Actions tab](https://github.com/indiagrams/ios-macos-smoketest/actions) — it's probably broken there too (Monday morning for CI-mode regressions, Saturday morning for local-mode), and a fix is in flight.
 
 ---
 
@@ -506,7 +509,8 @@ If you fork this template and your build breaks Monday morning out of the blue, 
 │   ├── pr.yml                   # 6 build jobs on every PR (3 XcodeGen + 3 Tuist)
 │   ├── release.yml              # signed release pipeline (workflow_dispatch + canary-driven)
 │   ├── bootstrap-doctor-matrix.yml  # weekly doctor sweep across 4 cells
-│   ├── canary-trigger.yml       # weekly ship-validation (template-only; no-op on forks)
+│   ├── canary-trigger.yml       # weekly CI-mode ship-validation (template-only; no-op on forks)
+│   ├── canary-local-mode.yml    # weekly local-mode ship-validation (cron commented; forks opt in)
 │   └── verify-rename.yml        # gate: rename script integrity
 ├── Brewfile                     # xcodegen + tuist + fastlane + lefthook
 ├── Makefile                     # init | doctor | bootstrap-fork | ship | verify | all

--- a/docs/APPLE-PREREQS.md
+++ b/docs/APPLE-PREREQS.md
@@ -63,7 +63,7 @@ The `.gitignore` already blocks the common ones, but be aware:
 |------|---------------|------------------|
 | `*.p8` | App Store Connect API private key | `~/.appstoreconnect/` |
 | `*.mobileprovision` | Provisioning profiles (manual signing) | `~/Library/MobileDevice/Provisioning Profiles/` (Xcode manages) |
-| `*.cer`, `*.p12` | Distribution certificates | macOS Keychain |
+| `*.cer`, `*.p12` | Distribution certificates. Three types are needed for full ship: **Apple Distribution** (codesign for the .app), **Apple Development** (provisioning), **3rd Party Mac Developer Installer** (signs the `.pkg` wrapper around macOS apps via `productbuild`). Per-team caps verified empirically May 2026: DIST=3, DEV≥5, MAC_INSTALLER=2. | macOS Keychain |
 | `.bootstrap.env` | Local fork config (paths, identifiers; secrets stay outside repo) | repo root, gitignored |
 
 If you accidentally commit any of these, treat it as a credential leak: revoke the key/cert immediately on Apple's side, then `git rm --cached` + force-rotate.
@@ -74,6 +74,44 @@ If you accidentally commit any of these, treat it as a credential leak: revoke t
 - **Team membership ≠ ownership.** If you're added to someone else's Apple Developer team as a member, you can sign builds but may not have App Store Connect access. Coordinate with your team's Account Holder.
 - **D-U-N-S number lookup is free.** If Apple says you need to "obtain" one for an Organization enrollment, use the free Apple lookup tool — don't pay D&B for one.
 - **Apple ID without 2FA can't be added to a developer team** (Apple requirement). Enable 2FA before enrollment.
+
+## Per-team certificate quotas (verified empirically)
+
+Apple's per-team cert caps, probed via the ASC API on 2026-05-08 against
+team `A26TJZ8QHQ` (community docs are stale or contradictory):
+
+| Cert type | Cap | Notes |
+|---|---|---|
+| Apple Distribution | **3** | Used for codesigning `.app` bundles. fastlane match's standard distribution path. |
+| Apple Development | **≥ 5** | Provisioning + dev signing. We didn't probe the upper bound; the v1.5 canary mints 1 per run with no observed cap hit. |
+| 3rd Party Mac Developer Installer | **2** | Used by `productbuild` to sign `.pkg` wrappers for macOS apps. Lower than DIST — Mac shippers commonly hit this first. |
+| Developer ID Application G2 | (separate, untested) | Apple's notarization-bound cert for direct distribution outside the App Store. Not exercised by this template. |
+
+At-cap mint without `--force` returns HTTP 409 (non-destructive). At-cap
+mint **with** `--force` revokes the OLDEST cert by creation date — could
+be your production cert. `fastlane cert` defaults to no `--force` (safe).
+The `revoke_cert` lane (singular) and `revoke_certs` lane (plural,
+idempotent batch) in `fastlane/Fastfile` help free a slot.
+
+### Optional: dedicate cycling slots for continuous validation
+
+If you plan to enable `.github/workflows/canary-local-mode.yml` (the
+Saturday local-mode canary added in v1.5), dedicate 1 cycling slot per
+at-cap type up front:
+
+```bash
+# Via Apple Developer portal (~30 sec)
+# https://developer.apple.com/account/resources/certificates
+# Revoke 1 spare DIST cert + 1 spare MAC_INSTALLER cert.
+
+# Or via fastlane (if you know the cert ids):
+bundle exec fastlane revoke_certs ids:CERT_ID_1,CERT_ID_2
+```
+
+The canary then mints into the freed slots per run and revokes on
+`always()`. Net team-cert delta per run = 0; your existing shipping
+certs are never touched. See [docs/CONTINUOUS-VALIDATION.md](CONTINUOUS-VALIDATION.md)
+for the full architecture.
 
 ## Reference
 

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -96,29 +96,37 @@ actual secret bytes. The dotenv itself is low-blast-radius.
 
 ## What `make bootstrap-fork` does
 
-The pipeline has 19 step classes. CI mode (`RELEASE_MODE=ci`, the default) runs
-17 with default `PLATFORMS=ios,macos`; local mode runs 11. Each step has a
-`check` (no side effects) and a `do_it`.
-A step is skipped if its desired state is already reached, so re-running after
-a partial failure picks up where you left off.
+The pipeline has 19 step classes. CI mode (`RELEASE_MODE=ci`) runs 18 with
+default `PLATFORMS=ios,macos` (excludes `LocalKeychainCerts`); local mode
+(`RELEASE_MODE=local`, the default) runs 14 (excludes the 5 ci-only steps:
+`EditMatchfile`, `CreateCertsRepo`, `GHSecrets`, `BootstrapCerts`,
+`MintInstaller`). Each step has a `check` (no side effects) and a `do_it`.
+A step is skipped if its desired state is already reached, so re-running
+after a partial failure picks up where you left off.
 
-| # | Step | What changes |
-|---|---|---|
-| 1 | Apple credentials | Validates `.p8` + key id + issuer id by probing ASC API |
-| 2 | GitHub credentials | Validates PAT can see `GH_CERTS_REPO` |
-| 3 | Rename HelloApp → APP_NAME | Runs `bin/rename.sh` + `bin/verify-rename.sh` |
-| 4 | Wire fastlane/Matchfile | Substitutes `git_url` to point at your certs repo |
-| 5 | Toolchain | `make bootstrap` (brew bundle + lefthook + xcodegen/tuist + bundler) |
-| 6 | Initial commit + push | First commit (rename + Matchfile) pushed to `origin/main` |
-| 7 | Branch protection | `bin/setup-github.sh` (7 required checks: swiftlint + xcodegen iOS device/sim + macOS + tuist parity, squash-only, linear history) |
-| 8 | Private certs repo | `gh repo create --private` if absent |
-| 9 | 7 GH Secrets | Generates `MATCH_PASSWORD` + `KEYCHAIN_PASSWORD` if absent, encodes the PAT + p8, sets all 7 secrets |
-| 10 | Bundle ID registration | `fastlane register_app_id` (idempotent — Spaceship `BundleId.create` rescues `ALREADY_EXISTS`) |
-| 11 | Verify ASC App | Probes for the App record. **Fails loud with web-UI instructions if missing** — Apple disallows `POST /apps`, so this is the one human-gated step inside the pipeline |
-| 12 | Mint certs (iOS dist + dev + macOS dist) | `fastlane bootstrap_certs` (3 match calls in one process) |
-| 13 | Mac Installer Distribution cert | `bin/mint-installer-cert.rb` + `bin/import-installer-to-match.rb` |
-| 14 | (optional) Replace 1024 icon | If `ICON_1024_PATH` set, copies it to the iOS asset catalog |
-| 15 | (optional) Regenerate macOS icns | `make icons` — only if step 14 ran |
+Mode key: ⚪ both, 🅒 ci-only, 🅛 local-only.
+
+| # | Step | Mode | What changes |
+|---|---|---|---|
+| 1 | Apple credentials (`CheckAppleCreds`) | ⚪ | Validates `.p8` + key id + issuer id by probing ASC API |
+| 2 | GitHub credentials (`CheckGHCreds`) | ⚪ | Validates PAT can see `GH_CERTS_REPO` (CI mode) or `git remote get-url origin` (local mode) |
+| 3 | Origin remote present (`RemoteMatches`) | ⚪ | Verifies `git remote` is configured to the fork |
+| 4 | Rename HelloApp → APP_NAME (`RenameStub`) | ⚪ | Runs `bin/rename.sh` + `bin/verify-rename.sh` |
+| 5 | Wire fastlane/Matchfile (`EditMatchfile`) | 🅒 | Substitutes `git_url` to point at your certs repo |
+| 6 | Toolchain (`BrewBootstrap`) | ⚪ | `make bootstrap` (brew bundle + lefthook + xcodegen/tuist + bundler) |
+| 7 | (optional) Replace 1024 icon (`Icon1024`) | ⚪ | If `ICON_1024_PATH` set, copies it to the iOS asset catalog |
+| 8 | (optional) Regenerate macOS icns (`MakeIcons`) | ⚪ | `make icons` — only if step 7 ran |
+| 9 | Initial commit + push (`InitialPush`) | ⚪ | First commit (rename + Matchfile + icons) pushed to `origin/main` |
+| 10 | Branch protection (`BranchProtection`) | ⚪ | `bin/setup-github.sh` (7 required checks: swiftlint + xcodegen iOS device/sim + macOS + tuist parity, squash-only, linear history) |
+| 11 | Private certs repo (`CreateCertsRepo`) | 🅒 | `gh repo create --private` if absent |
+| 12 | 7 GH Secrets (`GHSecrets`) | 🅒 | Generates `MATCH_PASSWORD` + `KEYCHAIN_PASSWORD` if absent, encodes the PAT + p8, sets all 7 secrets |
+| 13 | Bundle ID registration (`RegisterAppId`) | ⚪ | `fastlane register_app_id` (idempotent — Spaceship `BundleId.create` rescues `ALREADY_EXISTS`) |
+| 14 | Verify ASC App (`VerifyAscApp`) | ⚪ | Probes for the App record. **Fails loud with web-UI instructions if missing** — Apple disallows `POST /apps`, so this is the one human-gated step inside the pipeline |
+| 15 | Mint match certs iOS dist + dev + macOS dist (`BootstrapCerts`) | 🅒 | `fastlane bootstrap_certs` (3 match calls in one process) |
+| 16 | Mac Installer Distribution cert (`MintInstaller`) | 🅒 (macOS only) | `bin/mint-installer-cert.rb` + `bin/import-installer-to-match.rb` |
+| 17 | Local keychain has signing identities (`LocalKeychainCerts`) | 🅛 | Auto-mints any missing local-mode cert types (Apple Distribution, Apple Development, 3rd Party Mac Developer Installer) via `fastlane cert` into `login.keychain-db`. New in v1.4 — replaces the v1.3 hard-blocker requiring manual remediation |
+| 18 | Scan metadata (`ScanMetadata`) | ⚪ | Informational — counts present-vs-placeholder strings under `fastlane/metadata/` |
+| 19 | Scan screenshots (`ScanScreenshots`) | ⚪ | Informational — counts present screenshots under `fastlane/screenshots/` |
 
 ## What you still have to do by hand
 
@@ -128,8 +136,8 @@ to public APIs:
 - **Enroll in the Apple Developer Program** ($99/yr; ~24-48 hr Apple review)
 - **Create the App Store Connect API Key** (web UI; Apple shows the `.p8` once)
 - **Create the App Store Connect App record** (Apple disallows `POST /apps`).
-  Step 11 of `make bootstrap-fork` fails loud with the exact form values to
-  paste — re-run after creating, and step 11 turns ✓
+  The `VerifyAscApp` step of `make bootstrap-fork` fails loud with the
+  exact form values to paste — re-run after creating, and the step turns ✓
 - **Generate a fine-grained PAT** for the certs repo (web UI)
 - **Provide a 1024 icon and metadata text** (designer + product artifacts —
   see "After bootstrap" below)
@@ -189,14 +197,19 @@ worth keeping out of source control.
 - **`make doctor` says PAT 404s on certs repo, but I just created it** —
   fine-grained PATs are pinned to repo database IDs. If you recreated the
   certs repo, edit the PAT's repo list at github.com/settings/tokens.
-- **Step 11 (Verify ASC App) is blocked but I created the App** — ASC API
+- **`VerifyAscApp` is blocked but I created the App** — ASC API
   is eventually consistent. Wait 30 seconds and re-run `make doctor`.
-- **Step 12 (match) hits "Could not create another Distribution certificate,
+- **`BootstrapCerts` (CI mode) or `MintInstaller` (CI mode) or `LocalKeychainCerts` (local mode) hits "Could not create another Distribution certificate,
   reached the maximum number of available Distribution certificates"** —
-  Apple's distribution cert quota is 3/team. Revoke an unused one via
-  `bundle exec fastlane revoke_cert id:<CERT_ID>` (run `make doctor` after,
-  the cert step will retry).
-- **Step 12 hits "Could not find the newly generated certificate installed"
+  Apple's per-team cert quotas (verified empirically May 2026 against team
+  `A26TJZ8QHQ`): Apple Distribution = 3, Apple Development ≥ 5, 3rd Party
+  Mac Developer Installer = 2. Forkers shipping macOS commonly hit the
+  installer cap (2) before the distribution cap (3). Revoke an unused one
+  via `bundle exec fastlane revoke_cert id:<CERT_ID>` (singular) or
+  `revoke_certs ids:A,B,C` (plural batch, idempotent), then re-run
+  `make doctor`. See [docs/CONTINUOUS-VALIDATION.md](CONTINUOUS-VALIDATION.md)
+  for the full ecosystem-constraints note.
+- **`BootstrapCerts` / `LocalKeychainCerts` hits "Could not find the newly generated certificate installed"
   on a populated login keychain** — see `docs/CONTINUOUS-VALIDATION.md` G11.
   The bootstrap pipeline sets `CERT_KEYCHAIN_PATH` to a temp keychain to
   avoid this; if you still hit it, run match against a fresh keychain.

--- a/docs/CONTINUOUS-VALIDATION.md
+++ b/docs/CONTINUOUS-VALIDATION.md
@@ -1,16 +1,28 @@
 # Continuous Validation via a Downstream Smoketest
 
 The signing pipeline in this template (`fastlane release` lane,
-`ci/local-release-check.sh`, `.github/workflows/release.yml`) is exercised
-**weekly** by a public reference fork:
+`ci/local-release-check.sh`, `.github/workflows/release.yml`,
+`.github/workflows/canary-local-mode.yml`) is exercised **weekly** by a
+public reference fork:
 
 > [`indiagrams/ios-macos-smoketest`](https://github.com/indiagrams/ios-macos-smoketest)
 
-Every Monday 09:00 UTC the smoketest runs `fastlane release` end-to-end on a
-fresh `macos-15` GitHub Actions runner, signs an iOS `.ipa` + macOS `.pkg`,
-and uploads both to TestFlight. A red run there means the pipeline has broken
-somewhere between fastlane, match, Apple's signing infrastructure, the ASC
-API, and the macos-15 image — usually before any active fork hits the same
+Two canaries run there on complementary cadences:
+
+- **Mondays 09:00 UTC** — `canary-trigger.yml` dispatches `release.yml` on
+  the smoketest. Exercises the **CI-mode** shipping path (match-based
+  signing, certs sourced from a private repo via fastlane match). Pre-existing
+  shipping certs; no mint/revoke loop.
+- **Saturdays 11:30 UTC** — `canary-local-mode.yml` runs in-place on the
+  smoketest. Exercises the **local-mode** shipping path (sigh-based App Store
+  profiles minted via API key, signing certs minted fresh into a controlled
+  keychain, β cert SHA-1 pinning via `DeveloperCertificates[0]` from the
+  .mobileprovision). Mint→ship→verify→revoke loop in the same Apple team;
+  net team-cert delta per run = 0.
+
+Either canary going red means the pipeline has broken somewhere between
+fastlane, match (CI-mode only), Apple's signing infrastructure, the ASC API,
+and the macos-15 image — usually before any active fork hits the same
 breakage in their own release window.
 
 ## Why a separate fork instead of CI on the template itself
@@ -25,14 +37,15 @@ inspectable form so:
   the gotchas in failed runs).
 - Patterns + fixes are discovered against a real Apple ecosystem, not a
   mocked one.
-- The template's release.yml is provably executable — it's the same file
-  shape the smoketest runs against.
+- The template's two release workflows (`release.yml`, `canary-local-mode.yml`)
+  are provably executable — the same file shape the smoketest runs against.
 
 ## What's been validated end-to-end
 
 The smoketest's phase 4-7 work (April-May 2026) discovered and fixed fourteen
-distinct CI failure modes between "looks like it should work" and
-"actually pushes a build to TestFlight":
+distinct shipping-pipeline failure modes between "looks like it should work"
+and "actually pushes a build to TestFlight" (G14 covers the local-mode path
+specifically; the rest are CI-mode):
 
 | # | Failure mode | Fix landed in |
 |---|---|---|
@@ -50,6 +63,7 @@ distinct CI failure modes between "looks like it should work" and
 | G12 | `MATCH_GIT_BASIC_AUTHORIZATION` 404s on the certs repo after delete + recreate. Fine-grained GitHub PATs are pinned to a *repo's database ID*, not its name — when the certs repo is deleted and a new one with identical name is created, the new repo has a fresh ID and the existing PAT loses access. `fastlane match` then dies at the first clone with "Error cloning certificates git repo". This blocks the template's E2E refork test from running unattended (every cycle would require manual PAT scope updates via `github.com/settings/tokens`). | Don't delete the certs repo as part of the E2E loop. Reset its branches via force-push instead — the certs repo's lifecycle is logically separate from the app fork's. `bin/refork-smoketest.sh` does this by default. The repo's database ID is preserved, so the existing fine-grained PAT (correctly scoped to "Only select repositories" → certs repo) stays valid across E2E cycles. |
 | G13 | xcodebuild archive fails with `Signing certificate is invalid. Signing certificate "Apple Distribution: <name>", serial number "...", is not valid for code signing. It may have been revoked or expired.` Even though `security find-identity -v` shows the cert as valid (it's not expired, has a private key). Cause: the cert is revoked at Apple's side but still locally cached. `find-identity -v` only filters expired certs, not revoked-at-Apple ones. xcodebuild's `CODE_SIGN_IDENTITY=Apple Distribution` substring-matches multiple certs; if any matching cert is revoked, the archive can fail when xcodebuild picks that one. | New `make clean-revoked-certs` target — queries ASC API for valid cert serials, diffs against local keychain certs, deletes the revoked locals after confirmation. Surgical user-state cleanup; doesn't touch the template's normal build path. Run once when you hit this; subsequent builds use only Apple-valid certs. (`bundle exec fastlane clean_revoked_certs dry_run:true` to preview.) |
 | G14 | The local-mode shipping path (RELEASE_MODE=local) was 0% covered by automation through v1.4 — only validated via manual cold-fork tests at release time. Regressions in `setup_ci` mode-gating, `match`-skip gating, sigh-based App Store profile minting, β cert SHA-1 pinning (extracting `DeveloperCertificates[0]` from the .mobileprovision), ExportOptions plist patching for manual signing, and bash-3.2 `${arr[@]}`-under-`set -u` array safety would surface only when a forker tried to ship — typically weeks after the regressing commit landed. | New `.github/workflows/canary-local-mode.yml` — weekly mint→ship→verify→revoke loop in the same Apple team. Mints 3 throwaway certs (`apple_distribution` + `apple_development` + `mac_installer_distribution`), runs full local-mode `fastlane release` against TestFlight, revokes the 3 just-minted certs (`if: always()`). Net team-cert delta per run = 0; user's existing shipping certs untouched. Cache-tracked orphan recovery (`actions/cache@v5`) handles partial-failure scenarios — next run's pre-step revokes any ids the prior run's post-step missed. New `revoke_certs` (plural, idempotent) and `mint_canary_certs` (capture-ids) lanes in `fastlane/Fastfile` are the building blocks. |
+| G15 | TestFlight "What to Test" annotation never persists for new builds. fastlane pilot 2.233.1's `set_changelog` path (called by `pilot(... changelog: ...)` after upload) iterates `update_localized_build_review` over an empty hash for builds with no pre-existing `BetaBuildLocalization`, then logs `Successfully set the changelog for build` without ever POSTing the localization to ASC. Affects every fresh upload (the common case for canaries; surfaces less for releases that re-upload over an existing build). Confirmed empirically across 6 canary runs (PR #135-#142) and against pilot's source (`pilot/lib/pilot/build_manager.rb:560-588`). Compounded by ASC's BetaBuildLocalization endpoint silently rejecting non-ASCII in `whatsNew` ("contains invalid characters" — pilot eats the error too). | The canary's "Annotate canary builds in TestFlight" step bypasses pilot entirely: poll for ≤10 min for ASC to register the just-uploaded builds (pilot returns from upload ~1-3 min before ASC indexes them), then PATCH the BBL via `Spaceship::ConnectAPI.patch_beta_build_localizations` if pilot's empty-creation has materialized, or POST a fresh one via `post_beta_build_localizations` if not. ASCII-only `whatsNew`. Workaround preserved as a Fastfile comment until upstream pilot is fixed. |
 
 The smoketest also surfaced two ecosystem-level constraints:
 
@@ -68,10 +82,30 @@ The smoketest also surfaced two ecosystem-level constraints:
   cert` defaults to no `--force`, which is the safe default). The
   `revoke_cert` lane (singular, ad-hoc) and `revoke_certs` lane (plural,
   idempotent batch) in `fastlane/Fastfile` help free a slot or clean up
-  canary cycles.
+  canary cycles. Forks enabling `canary-local-mode.yml` need to dedicate
+  one cycling slot per at-cap type via a one-time setup — revoke 1 spare
+  DIST + 1 spare MAC_INSTALLER cert via `developer.apple.com/account/resources/certificates`
+  (or `bundle exec fastlane revoke_certs ids:A,B`); see the v1.5 entry in
+  the [CHANGELOG](../CHANGELOG.md) for context.
 
 ## How to run the smoketest pattern in your own fork
 
-See [README → Setting up signing + ASC → Optional: enable CI signing via fastlane match](../README.md#optional-enable-ci-signing-via-fastlane-match)
-for the 8-step bootstrap. Once configured, the same `release.yml` runs
-weekly against your fork.
+There are two opt-in canaries; pick whichever matches your fork's
+`RELEASE_MODE`:
+
+- **CI mode** (`RELEASE_MODE=ci`, match-based signing) — see
+  [docs/BOOTSTRAP.md](BOOTSTRAP.md) for the certs-repo + GH Secrets
+  setup. The same `release.yml` then runs on `workflow_dispatch` and
+  whenever you tag a release; `canary-trigger.yml` (template-only)
+  dispatches it weekly against the smoketest from upstream.
+- **Local mode** (`RELEASE_MODE=local`, sigh-based, no match) — uncomment
+  the `schedule:` block in `.github/workflows/canary-local-mode.yml`
+  (default `30 11 * * 6` = Saturdays 11:30 UTC), configure five GH
+  Secrets on the fork (`ASC_API_KEY_ID`, `ASC_API_KEY_ISSUER_ID`,
+  `ASC_API_KEY_P8_BASE64`, `FASTLANE_TEAM_ID`, `KEYCHAIN_PASSWORD`),
+  and run the v1.5 one-time cert-slot dedication described in the
+  cert-caps bullet above. Optional `DISCORD_CANARY_WEBHOOK` for failure
+  notifications.
+
+Either way, the workflow runs against your fork's bundle ID + ASC app
+record + signing identity — same shape as the smoketest.

--- a/docs/MIGRATING-TO-TUIST.md
+++ b/docs/MIGRATING-TO-TUIST.md
@@ -34,7 +34,13 @@ is the only section you really need.
 > `bin/switch-to-tuist.sh`, then `make check` / `make check-sim` /
 > `make check-macos` all green. The script's
 > `ci/test-switch-to-tuist.sh` harness re-runs that validation in CI.
-
+>
+> Generator parity is also gated **at release time**, not just PR time.
+> Since v1.5, `.github/workflows/canary-local-mode.yml` ships a
+> `[xcodegen, tuist]` matrix that exercises both generators end-to-end
+> through `fastlane release` weekly on the smoketest fork — so a
+> Tuist-only fork's release pipeline is itself canary-validated upstream.
+>
 ## Why this exists
 
 Two-of-two r/iOSProgramming commenters on the v1.0.0 launch post

--- a/docs/NO-CI.md
+++ b/docs/NO-CI.md
@@ -141,9 +141,42 @@ You'll want CI mode if any of these become true:
 - A second human starts contributing
 - You ship from multiple machines
 - You want PR-time test signal (xcodebuild + xcodebuild test on every PR)
-- You want the weekly canary pattern to catch Apple-side state drift (see [docs/CONTINUOUS-VALIDATION.md](CONTINUOUS-VALIDATION.md))
+- You want match-based shared signing across multiple developers (with `canary-local-mode.yml` already in the template, **continuous validation is no longer a CI-mode-only feature** — local-mode forks get it via the Saturday canary; see § "Continuous validation in local mode" below)
 
 The switch is reversible: change `RELEASE_MODE=ci`, run `make bootstrap-fork` (the now-active CI-only steps will run), restore the workflows + branch protection.
+
+## Continuous validation in local mode
+
+Local mode is no longer a "no canary" mode. The template ships
+`.github/workflows/canary-local-mode.yml`, which is dormant by default
+(workflow_dispatch only) and can be enabled by uncommenting its `schedule:`
+block (default `30 11 * * 6` = Saturdays 11:30 UTC).
+
+When enabled, the canary mints 3 throwaway signing certs into a controlled
+keychain on the GH runner, runs full `fastlane release` (sigh-based App
+Store profiles, no match), uploads to TestFlight, then revokes the 3
+just-minted certs on `always()`. Net Apple-team cert delta per run = 0;
+your existing shipping certs are never touched.
+
+Prerequisites for enabling on your fork:
+
+1. Configure 5 GitHub Secrets on the fork — `ASC_API_KEY_ID`,
+   `ASC_API_KEY_ISSUER_ID`, `ASC_API_KEY_P8_BASE64`, `FASTLANE_TEAM_ID`,
+   `KEYCHAIN_PASSWORD`. Optional: `DISCORD_CANARY_WEBHOOK` for failure
+   notifications.
+2. Run the v1.5 one-time cert-slot dedication: revoke 1 spare DIST + 1
+   spare MAC_INSTALLER cert per team (~30 sec via
+   [developer.apple.com/account/resources/certificates](https://developer.apple.com/account/resources/certificates)
+   or `bundle exec fastlane revoke_certs ids:A,B`). This dedicates one
+   cycling slot per at-cap type so the canary can mint without hitting
+   Apple's per-team caps. See [docs/CONTINUOUS-VALIDATION.md](CONTINUOUS-VALIDATION.md)
+   for the empirical caps (DIST=3, DEV≥5, MAC_INSTALLER=2).
+3. Uncomment the `schedule:` block in
+   `.github/workflows/canary-local-mode.yml`.
+
+That's it. Saturday morning runs ship a clean canary build to TestFlight
+under your bundle ID + ASC app, verifying the entire local-mode shipping
+pipeline weekly.
 
 ## Troubleshooting
 
@@ -151,8 +184,8 @@ The switch is reversible: change `RELEASE_MODE=ci`, run `make bootstrap-fork` (t
 |---|---|---|
 | `make doctor` step 12 (`Local keychain has signing identities`) is `:pending` even after `make mint-local-certs` | Keychain access denied (Apple's keychain prompts) | Check `Console.app` for keychain prompts; click Allow when fastlane asks. Re-run. |
 | `make doctor` step 12 says "Found certs … but none for team X" | Your keychain has certs from a different team | `make mint-local-certs` mints a fresh cert for the right team. The wrong-team certs remain in your keychain (use Keychain Access to remove if desired). |
-| `fastlane cert` fails with "Could not create another …, reached the maximum" | Apple's per-team cert quota (~3) is full | `bundle exec fastlane list_certs` to enumerate, `bundle exec fastlane revoke_cert id:<id>` to revoke an unused one, then re-run. |
-| `make ship` fails uploading to TestFlight | Transient ASC / altool flake | The `pilot_with_retry` wrapper retries 3× with exponential backoff. If all 3 fail, check the smoketest's [G1-G12 catalog](CONTINUOUS-VALIDATION.md). |
+| `fastlane cert` fails with "Could not create another …, reached the maximum" | Apple's per-team cert quota is full (DIST=3, DEV≥5, MAC_INSTALLER=2 — verified empirically May 2026; see [docs/CONTINUOUS-VALIDATION.md](CONTINUOUS-VALIDATION.md)) | `bundle exec fastlane list_certs` to enumerate, `bundle exec fastlane revoke_cert id:<id>` (singular) or `revoke_certs ids:A,B,C` (plural batch, idempotent) to revoke unused ones, then re-run. |
+| `make ship` fails uploading to TestFlight | Transient ASC / altool flake | The `pilot_with_retry` wrapper retries 3× with exponential backoff. If all 3 fail, check the smoketest's [G1–G15 catalog](CONTINUOUS-VALIDATION.md). |
 | `make all` aborts at doctor | Genuine `:blocked` step (e.g., ASC App record missing) | The blocker requires a manual one-time human step Apple's API doesn't allow. Doctor's tail names which step + what to do. |
 
 ## See also

--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -11,11 +11,12 @@ first and let's talk.
 
 ## Quality gates
 
-1. **Every PR runs CI.** Six jobs (3 XcodeGen — `app (iOS device)`,
-   `app (iOS Simulator)`, `app (macOS)` — plus 3 Tuist parity —
-   `app (Tuist iOS device)`, `app (Tuist iOS Simulator)`, `app (Tuist macOS)`)
-   must be green before merge. Branch protection enforces this for
-   everyone, including maintainers.
+1. **Every PR runs CI.** Seven required checks: swiftlint plus six matrix
+   cells (3 XcodeGen — `app (iOS device)`, `app (iOS Simulator)`,
+   `app (macOS)` — plus 3 Tuist parity — `app (Tuist iOS device)`,
+   `app (Tuist iOS Simulator)`, `app (Tuist macOS)`) — must be green
+   before merge. Branch protection enforces this for everyone, including
+   maintainers.
 2. **No direct pushes to `main`.** Even one-line fixes go through a PR. The
    pre-push hook (`lefthook` → `ci/local-check.sh --fast`) catches breakage
    before it reaches GitHub.
@@ -30,13 +31,17 @@ first and let's talk.
    warning.
 6. **The release pipeline is continuously validated by a public downstream.**
    [`indiagrams/ios-macos-smoketest`](https://github.com/indiagrams/ios-macos-smoketest)
-   runs `.github/workflows/release.yml` weekly to TestFlight against this
-   template's signing pattern. Because Apple's signing infra (certs,
-   profiles, `timestamp.apple.com`, ASC ingestion) and the fastlane / match
-   stack drift independently of this template, the smoketest catches rot
-   before forkers do. Patterns + fixes there land back here in PRs that cite
+   runs **two** complementary canaries weekly to TestFlight against this
+   template's signing pattern: `release.yml` (CI mode, match-based) on
+   Mondays 09:00 UTC via `canary-trigger.yml`, and `canary-local-mode.yml`
+   (local mode, sigh-based, mint-then-revoke) on Saturdays 11:30 UTC.
+   Because Apple's signing infra (certs, profiles, `timestamp.apple.com`,
+   ASC ingestion) and the fastlane / match / pilot stacks drift
+   independently of this template, the smoketest catches rot before
+   forkers do. Patterns + fixes there land back here in PRs that cite
    the failing smoketest run. See [`docs/CONTINUOUS-VALIDATION.md`](CONTINUOUS-VALIDATION.md)
-   for the ten canonical failure modes the smoketest has surfaced.
+   for the catalog of canonical failure modes (currently 15) the smoketest
+   has surfaced.
 
 ## Documentation
 

--- a/docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md
+++ b/docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md
@@ -208,6 +208,56 @@ the "ideal for CI/CD" path. The implementation is straightforward but
 has more moving parts than `altool`; for a one-page recipe `altool`
 remains simpler.
 
+### 5. (Optional) Annotate the TestFlight build's "What to Test"
+
+Each TestFlight build can carry a localized "What to Test" string (the
+`BetaBuildLocalization` resource). fastlane pilot's `set_changelog`
+path is structurally broken in 2.233.1 (logs success but never POSTs
+the localization for fresh builds — see
+[`docs/CONTINUOUS-VALIDATION.md`](CONTINUOUS-VALIDATION.md) G15);
+the Apple-native equivalent below sidesteps that:
+
+```bash
+APP_ID="1234567890"
+BUILD_VERSION="2026.19.42"   # CFBundleVersion of the just-uploaded build
+LOCALE="en-US"
+CHANGELOG="Bug fixes and new features"   # ASCII only — see caveat below
+
+# 1. Find the just-uploaded build's id (poll for ~1-3 min after altool —
+#    ASC indexes uploads asynchronously after altool returns):
+BUILD_ID=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.appstoreconnect.apple.com/v1/builds?filter[app]=$APP_ID&filter[version]=$BUILD_VERSION&limit=1" \
+  | jq -r '.data[0].id')
+
+# 2. Check whether a BetaBuildLocalization for this locale already exists.
+#    pilot's upload path can pre-create an empty BBL[en-US]; ASC's
+#    indexing is racy — sometimes you'll see it, sometimes you won't.
+EXISTING=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.appstoreconnect.apple.com/v1/builds/$BUILD_ID/betaBuildLocalizations?filter[locale]=$LOCALE&limit=1" \
+  | jq -r '.data[0].id // empty')
+
+if [ -n "$EXISTING" ]; then
+  # 3a. PATCH the existing localization
+  curl -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    "https://api.appstoreconnect.apple.com/v1/betaBuildLocalizations/$EXISTING" \
+    -d "$(jq -n --arg id "$EXISTING" --arg whatsNew "$CHANGELOG" \
+      '{data:{type:"betaBuildLocalizations",id:$id,attributes:{whatsNew:$whatsNew}}}')"
+else
+  # 3b. POST a new one
+  curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    "https://api.appstoreconnect.apple.com/v1/betaBuildLocalizations" \
+    -d "$(jq -n --arg buildId "$BUILD_ID" --arg locale "$LOCALE" --arg whatsNew "$CHANGELOG" \
+      '{data:{type:"betaBuildLocalizations",attributes:{locale:$locale,whatsNew:$whatsNew},relationships:{build:{data:{type:"builds",id:$buildId}}}}}')"
+fi
+```
+
+> **ASCII-only caveat:** ASC's `BetaBuildLocalization` and
+> `AppStoreVersionLocalization` endpoints **silently reject non-Latin
+> characters in `whatsNew`** with a "contains invalid characters" error
+> (no character pointer, no row/column). Stick to ASCII letters, digits,
+> and common punctuation. The same caveat applies to the `whatsNew` field
+> in §2's `AppStoreVersionLocalization` PATCH.
+
 ## macOS App Store flow
 
 Identical to iOS through the export step, then a re-sign hack, then

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -35,7 +35,7 @@ The tag's TestFlight build is still in ASC — handle that separately via the st
 
 ## Roll back a partial bootstrap-fork
 
-If `make bootstrap-fork` fails on step N of 17, the pipeline is **idempotent** — re-running picks up where it left off:
+If `make bootstrap-fork` fails on step N (CI mode runs 18, local mode runs 14 — `make doctor` prints the live count), the pipeline is **idempotent** — re-running picks up where it left off:
 
 ```bash
 make doctor          # see which step is the next pending one
@@ -73,7 +73,19 @@ make bootstrap-fork
 
 ## Reset the smoketest fork (maintainer-only)
 
-For canary-related rollback see `bin/refork-smoketest.sh` — destructive E2E that recreates the smoketest fork from scratch.
+Two canaries run on the smoketest, with different rollback semantics:
+
+- **CI canary** (`canary-trigger.yml` dispatches `release.yml` on Mondays
+  09:00 UTC) — uses persistent shipping certs from the certs repo. If the
+  smoketest's signing state needs a reset, run `bin/refork-smoketest.sh`
+  (destructive E2E that recreates the smoketest fork from scratch).
+- **Local-mode canary** (`canary-local-mode.yml` on Saturdays 11:30 UTC) —
+  self-rolls back per run via the `if: always()` post-step that revokes the
+  3 just-minted certs. Orphan ids from a runner crash mid-mint are tracked
+  via `actions/cache@v5` and cleaned up by the next run's pre-step (worst
+  case: 1 week stale). If the cache is also lost (>7 days idle), revoke
+  manually at <https://developer.apple.com/account/resources/certificates>
+  (~30 sec). The canary's workflow header has the full failure-mode matrix.
 
 ## See also
 


### PR DESCRIPTION
Audit surfaced systematic v1.5 gaps across all 9 doc files. Each file now reflects: the local-mode canary (canary-local-mode.yml, Saturdays 11:30 UTC), empirical per-team cert quotas (DIST=3, DEV≥5, MAC_INSTALLER=2), updated pipeline counts (18/14, was 17/11 since v1.4 #117), the 7 required PR checks (was 6), and the v1.5 G15 pilot 2.233.1 set_changelog bug + Spaceship POST/PATCH workaround. See commit message for per-file details.