### PR TITLE
fix(gemfile): pin CFPropertyList to 3.0.8 (3.0.9 requires Ruby <3.2)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.9)
+    CFPropertyList (3.0.8)
     abbrev (0.1.2)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)

--- a/bin/lib/bootstrap.rb
+++ b/bin/lib/bootstrap.rb
@@ -209,8 +209,20 @@ module Bootstrap
       "#{self["GH_ORG"]}/#{self["GH_APP_REPO"]}"
     end
 
+    # Resolve GH_CERTS_REPO into a full owner/name slug.
+    #
+    # Two forms accepted:
+    #   GH_CERTS_REPO=my-app-certs                    → "${GH_ORG}/my-app-certs"
+    #   GH_CERTS_REPO=other-org/their-app-certs       → "other-org/their-app-certs"
+    #
+    # The slash-form lets a fork reuse a certs repo owned by another org or
+    # user — common when one Apple team is shared across several apps with
+    # the same bundle id (e.g. a development fork pointing at the upstream
+    # smoketest's certs repo). Without this, ${GH_ORG} would be prepended
+    # blindly and `gh repo view` would 404 on `prakashrj/other-org/repo`.
     def certs_slug
-      "#{self["GH_ORG"]}/#{self["GH_CERTS_REPO"]}"
+      raw = self["GH_CERTS_REPO"].to_s
+      raw.include?("/") ? raw : "#{self["GH_ORG"]}/#{raw}"
     end
 
     def certs_url
@@ -577,7 +589,19 @@ module Bootstrap
     end
 
     def do_it
-      Sh.run!("gh", "repo", "create", config.certs_slug, "--private",
+      slug = config.certs_slug
+      slug_org = slug.split("/", 2).first
+      if slug_org != config["GH_ORG"]
+        UI.fail!(<<~MSG)
+          GH_CERTS_REPO=#{config["GH_CERTS_REPO"]} resolves to #{slug}, which lives
+          in a different owner (#{slug_org}) than GH_ORG=#{config["GH_ORG"]}.
+          bootstrap-fork won't create repos in someone else's org/account.
+          Either:
+            - create #{slug} manually (gh repo create #{slug} --private), then re-run, or
+            - drop the org prefix from GH_CERTS_REPO so the repo is created under #{config["GH_ORG"]}
+        MSG
+      end
+      Sh.run!("gh", "repo", "create", slug, "--private",
               "--description", "Encrypted certs + profiles for #{config.repo_slug} (managed via fastlane match)")
     end
   end


### PR DESCRIPTION
Fresh CI runs (no warm bundler cache) fail at `bundle install` on Ruby 3.3.11 with:

> CFPropertyList-3.0.9 requires ruby version < 3.2, which is incompatible with the current version, 3.3.11

CFPropertyList split into two lines on 2025-11-19: 4.0.0 (requires Ruby ≥3.2, adds base64/nkf/rexml deps) and 3.0.9 (backport for Ruby <3.2). Fastlane caps the gem at `< 4.0.0`, so we can't use 4.0.0 yet. 3.0.8 (released 5 days before, no Ruby constraint) is API-compatible with the 3.x line and works on Ruby 3.3.11. Pin to 3.0.8 explicitly until upstream fastlane allows 4.x.

The smoketest's scheduled canary works only because its bundler cache happened to be warmed with 3.0.8 before 3.0.9/4.0.0 existed. Fresh forks get cache-miss and hit the wall.

Surfaced today on prakashrj/my-cool-app.