### PR TITLE
fix(release.yml): set RELEASE_MODE=ci so the lane takes the match-based branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,13 @@ jobs:
       ASC_API_KEY_P8_BASE64:         ${{ secrets.ASC_API_KEY_P8_BASE64 }}
       KEYCHAIN_PASSWORD:             ${{ secrets.KEYCHAIN_PASSWORD }}
       FASTLANE_TEAM_ID:              ${{ secrets.FASTLANE_TEAM_ID }}
+      # Selects the CI signing path in the fastlane release lane:
+      # match-based (vs sigh+local-keychain in local mode). Without this,
+      # the lane defaults to "local" (Fastfile: ENV.fetch("RELEASE_MODE", "local"))
+      # and sigh fails on bare CI runners with no Apple Distribution cert
+      # in the keychain. Latent since #123 landed the RELEASE_MODE gate but
+      # never wired it through release.yml.
+      RELEASE_MODE:                  ci
       FASTLANE_HIDE_CHANGELOG:       '1'
       FASTLANE_SKIP_UPDATE_CHECK:    '1'
 


### PR DESCRIPTION
Latent bug since v1.4 #123 landed the `RELEASE_MODE` gate in the fastlane release lane but didn't wire it through `release.yml`. Dispatch-triggered runs (and weekly `canary-trigger.yml` Monday cron firings) fall to the local path and fail at `sigh` because bare CI runners have no Apple Distribution cert in the keychain.

Surfaced today on `prakashrj/my-cool-app`'s fresh CI `make ship`.

Re-opens #154 (which was based on a stale branch and inadvertently reverted #152 + #153).