### PR TITLE
docs(v1.6): comprehensive audit + new maintenance guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ That's the starter app you'll customize into yours.
 
 ## Why this exists
 
-I'm a first-time iOS developer. Before writing a feature of my actual app, I spent days researching what Apple requires to publish: signing certificates, fastlane match for CI signing, ASC API keys, metadata specs, branch protection, and a dozen Apple-side gotchas that only surface in TestFlight.
+I'm a first-time iOS developer. Before writing a feature of my actual app, I spent days researching what Apple requires to publish: signing certificates, GitHub Actions signing that mints fresh certs per release, ASC API keys, metadata specs, branch protection, and a dozen Apple-side gotchas that only surface in TestFlight.
 
 I automated or documented every requirement I encountered. That's what this template is — the boring prep work, done.
 
@@ -241,7 +241,6 @@ ASC_API_KEY_P8_PATH=~/.config/secrets/AuthKey_ABC1234567.p8  # fill in — from 
 # if your fork lives somewhere other than github.com/<you>/<repo>.
 GH_ORG=your-username                        # auto-filled by make init
 GH_APP_REPO=my-cool-app                     # auto-filled by make init
-GH_CERTS_REPO=my-cool-app-certs             # auto-filled by make init (CI mode only)
 
 # Optional design + ASC fields. Fill these in before running `make ship` for
 # real (placeholder icon is fine for TestFlight; SKU/ASC name only matter once
@@ -251,16 +250,18 @@ ASC_APP_SKU=mycoolapp-001                   # any unique-to-you string
 ASC_APP_NAME='My Cool App'                  # what shows on the App Store
 
 # CI-mode only — leave blank for RELEASE_MODE=local. `make bootstrap-fork`
-# generates and writes random 32-char passwords if these paths don't exist
-# yet, when you do switch to CI mode later.
-GH_PAT_FILE=                                # ~/.config/secrets/<repo>-pat (CI mode only)
-MATCH_PASSWORD_FILE=                        # ~/.config/secrets/match-password (CI mode only)
+# generates a random 32-char password and writes it to this file if it
+# doesn't exist yet, for when you switch to CI mode later. It locks the
+# controlled keychain that release.yml mints fresh signing certs into
+# per release run (then revokes them on workflow exit).
 KEYCHAIN_PASSWORD_FILE=                     # ~/.config/secrets/keychain-password (CI mode only)
 ```
 
 > **Pick BUNDLE_ID carefully.** It's the unique fingerprint of your app, and you can't change it later without losing your TestFlight history. If you own a domain, use it (`com.yourdomain.appname`). If you don't, `com.yourgithubusername.appname` is fine.
 
-> **Why two modes?** `RELEASE_MODE=local` signs from your laptop using certs in your Keychain — easy first-run, no server config needed. `RELEASE_MODE=ci` runs the full pipeline on GitHub Actions when you run `make ship` (which dispatches `release.yml` via `gh workflow run`) — more setup, but it means anyone with repo write access can ship from any machine. Start with `local`. You can switch later.
+> **Why two modes?** `RELEASE_MODE=local` signs from your laptop using certs in your Keychain — easy first-run, no server config needed. `RELEASE_MODE=ci` runs the full pipeline on GitHub Actions when you run `make ship` (which dispatches `release.yml` via `gh workflow run`) — more setup, but it means anyone with repo write access can ship from any machine. Each CI release run mints its own short-lived signing certs into a controlled keychain and revokes them when the run ends, so there's no shared certs repo or PAT to manage. Start with `local`. You can switch later.
+
+> **Bootstrapped before v1.6?** Older forks may still have `GH_CERTS_REPO`, `GH_PAT_FILE`, or `MATCH_PASSWORD_FILE` set in `.bootstrap.env`, plus `MATCH_PASSWORD` and `MATCH_GIT_BASIC_AUTHORIZATION` in their GH Secrets. They're harmless leftovers — the current pipeline ignores them. You can delete them at your leisure (or keep them; nothing reads them).
 
 > **Why pick a platform subset?** If you're shipping an iPhone-only app and don't care about Mac, set `PLATFORMS=ios` — `make doctor` will stop probing for the Mac Installer cert, `make ship` skips the macOS .pkg build/upload, and CI on PRs runs fewer jobs (saving ~2-4 min/PR of macOS runner time). Same in reverse for `PLATFORMS=macos`. Switchable later: change the value, re-run `make bootstrap-fork`. **In CI mode, also re-run `bin/setup-github.sh`** — the required-checks list is set on first bootstrap and won't update automatically when you flip platforms.
 
@@ -303,7 +304,7 @@ If you see `✗` (red) marks instead, doctor will tell you exactly what's missin
 > - Wrong Team ID → copy from Step 3 again
 > - "ASC App record not found" → see the callout above; this is the manual ASC step.
 
-When every step is `✓` or `⚠`, you're ready. (The pipeline runs 14 steps in `local` mode, 18 in `ci` mode — the count above will change accordingly.)
+When every step is `✓` or `⚠`, you're ready. (The pipeline runs 14 steps in both `local` and `ci` mode — the local-only and CI-only steps swap in and out, but the totals match.)
 
 ---
 
@@ -389,8 +390,8 @@ Most first-time failures fall into a few buckets. Here's what to do:
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `make doctor` exits 2 with "missing 7 GH Secrets" | You set `RELEASE_MODE=ci` before configuring GH secrets | Either set `RELEASE_MODE=local` for now, or follow [docs/BOOTSTRAP.md](docs/BOOTSTRAP.md) to configure CI secrets |
-| `fastlane match` says "Could not install WWDR certificate" | Apple's intermediate cert isn't trusted on your runner | The template's release.yml pre-installs WWDR — see [docs/CONTINUOUS-VALIDATION.md G4](docs/CONTINUOUS-VALIDATION.md) |
+| `make doctor` exits 2 with "missing 5 GH Secrets" | You set `RELEASE_MODE=ci` before configuring GH secrets | Either set `RELEASE_MODE=local` for now, or follow [docs/BOOTSTRAP.md](docs/BOOTSTRAP.md) to configure CI secrets |
+| Signing fails with "Could not install WWDR certificate" during a CI release | Apple's intermediate cert isn't trusted on the runner before fresh certs are minted | The template's release.yml pre-installs WWDR before sigh provisions — see [docs/CONTINUOUS-VALIDATION.md G4](docs/CONTINUOUS-VALIDATION.md) |
 | `altool` rejects with "ITMS-90296: app sandbox" on Mac | Xcode's Mac App Store profile strips `com.apple.security.app-sandbox` | The template's `local-release-check.sh` re-adds it automatically. If you see this, the script didn't run — file an issue with the full output |
 | "Provisioning profile doesn't include the device" | You're trying to sideload, not TestFlight-distribute | TestFlight builds don't need device IDs in the profile. If you see this from `make ship`, your `RELEASE_MODE` may be misconfigured |
 | `make doctor` says "ASC App record not found" | One-time human step — Apple's API forbids `POST /apps` | Go to [appstoreconnect.apple.com/apps](https://appstoreconnect.apple.com/apps), click + → New App, fill in your bundle ID + display name, then re-run `make doctor` |
@@ -418,7 +419,7 @@ These are the most common "you don't need this template" comebacks, and they're 
 
 apple-shipkit's value lives in the gap:
 
-- **More than Xcode Distribute**: reproducible builds (Gemfile.lock + pinned Swift/Xcode), audit-tracked (git tags + workflow logs + CHANGELOG per ship), CI-driven (PRs build real apps; ship is `gh workflow run`, not a button), shareable signing material via fastlane match (encrypted certs in a private repo, not just your Keychain).
+- **More than Xcode Distribute**: reproducible builds (Gemfile.lock + pinned Swift/Xcode), audit-tracked (git tags + workflow logs + CHANGELOG per ship), CI-driven (PRs build real apps; ship is `gh workflow run`, not a button), ephemeral CI signing (each release run mints its own short-lived certs into a controlled keychain on the runner and revokes them on exit, instead of trusting whatever's in any one developer's Keychain).
 - **Different shape from Xcode Cloud**: portable GitHub Actions YAML you can take to GitLab / CircleCI / Buildkite, full bash + ruby + fastlane flexibility, no per-minute Apple billing, debug failures locally with `make ship` or `make release-dryrun`.
 
 You probably **don't need** apple-shipkit if you're solo, ship one app, will always ship from one Mac, and never want to leave Xcode. You probably **do** if any of those is or will be untrue — especially if you've ever lost half a day to "why does signing work on my machine but not in CI".
@@ -429,11 +430,11 @@ Different tradeoff from other iOS starters:
 
 | You want… | Use | Why |
 |---|---|---|
-| Pipeline (signing + CI + TestFlight + ASC submission) prewired | **apple-shipkit** | What this template focuses on. Fastlane + match + GitHub Actions + canary continuous validation. |
+| Pipeline (signing + CI + TestFlight + ASC submission) prewired | **apple-shipkit** | What this template focuses on. Fastlane (sigh) + GitHub Actions (mint-fresh CI signing) + canary continuous validation. |
 | UI architecture + screens + sample data | [`ios-project-template`](https://github.com/messeb/ios-project-template), [`ios-mvp-template`](https://github.com/onl1ner/ios-mvp-template), or `SwiftPlate` | These ship app scaffolding (MVVM/MVP/Coordinator). You'd bring fastlane/CI yourself. |
 | Generate a fresh project from a manifest | `tuist scaffold` | Generates project files. No signing, no CI, no release wiring. |
 | Subscription bundle (RevenueCat + paywall + IAP) | [RevenueCat Quickstart](https://www.revenuecat.com/docs/getting-started/quickstart) | apple-shipkit is intentionally framework-agnostic; bring your own monetization. |
-| Bare `gh repo create` from a Swift project you already have | _no template needed_ | apple-shipkit is for people who don't have the project yet, or who do but want fastlane/CI/match prewired. |
+| Bare `gh repo create` from a Swift project you already have | _no template needed_ | apple-shipkit is for people who don't have the project yet, or who do but want fastlane + CI signing prewired. |
 
 Mix-and-match is fine. Many people start with apple-shipkit for the release pipeline, then drop in a UI template's screens or a RevenueCat paywall on top.
 
@@ -450,7 +451,7 @@ Once you're past the first ship, these docs cover the rest:
 - **[docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md](docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md)** — same archive/export flow without fastlane (uses `xcrun altool` + `notarytool` + ASC API directly).
 - **[docs/PRINCIPLES.md](docs/PRINCIPLES.md)** — design decisions behind the template's structure.
 - **[docs/ROLLBACK.md](docs/ROLLBACK.md)** — undoing a TestFlight build, a git tag, or a partial bootstrap-fork.
-- **[docs/NO-CI.md](docs/NO-CI.md)** — running the template in local-only mode (no GitHub Actions, no GH Secrets, no match).
+- **[docs/NO-CI.md](docs/NO-CI.md)** — running the template in local-only mode (no GitHub Actions, no GH Secrets).
 
 ---
 
@@ -468,7 +469,8 @@ RELEASE_MODE=ci?     → gh workflow run release.yml (triggers GitHub Actions)
                           ↓
                        fastlane release tag:vYYYY.WW.<run-number>
                           ↓
-                       1. match (provisions iOS + Mac certs from your certs repo)
+                       1. mint fresh iOS + Mac signing certs via sigh into a
+                          controlled keychain (revoked on workflow exit)
                        2. xcodebuild archive + export → .ipa (iOS) + .pkg (Mac)
                        3. altool upload → App Store Connect
                        4. git tag + push
@@ -485,17 +487,17 @@ Each step is its own fastlane lane in `fastlane/Fastfile`. Read the file — it'
 
 The two badges above reflect the most recent canary runs:
 
-- **CI-mode canary** ([`canary-trigger.yml`](https://github.com/indiagrams/apple-shipkit/actions/workflows/canary-trigger.yml)) — exercises the match-based shipping path used by forks with `RELEASE_MODE=ci`. Both `dispatch (xcodegen)` and `dispatch (tuist)` cells real-ship to TestFlight on the [smoketest fork](https://github.com/indiagrams/ios-macos-smoketest).
-- **Local-mode canary** ([`canary-local-mode.yml`](https://github.com/indiagrams/apple-shipkit/actions/workflows/canary-local-mode.yml)) — exercises the no-match sigh-based shipping path used by forks with `RELEASE_MODE=local` (the default). Mints throwaway certs in the same Apple team, ships to TestFlight, revokes the certs on `always()` so net team-cert delta per run is 0.
+- **CI-mode canary** ([`canary-trigger.yml`](https://github.com/indiagrams/apple-shipkit/actions/workflows/canary-trigger.yml)) — exercises the CI-mode mint-fresh shipping path used by forks with `RELEASE_MODE=ci` (release.yml mints fresh certs per run, ships, then revokes them). Both `dispatch (xcodegen)` and `dispatch (tuist)` cells real-ship to TestFlight on the [smoketest fork](https://github.com/indiagrams/ios-macos-smoketest).
+- **Local-mode canary** ([`canary-local-mode.yml`](https://github.com/indiagrams/apple-shipkit/actions/workflows/canary-local-mode.yml)) — exercises the local-mode sigh-based shipping path used by forks with `RELEASE_MODE=local` (the default). Mints throwaway certs in the same Apple team, ships to TestFlight, revokes the certs on `always()` so net team-cert delta per run is 0.
 
 Either badge red → at least one cell failed. Click the badge to see which cell + why. Per-cell history (xcodegen vs tuist) lives in each workflow's run-by-run breakdown.
 
 The validation infrastructure (all on the smoketest fork):
 - **Mondays 07:00 UTC**: read-only doctor matrix (4 cells: xcodegen|tuist × ci|local) — covers bootstrap toolchain.
 - **Mondays 09:00 UTC**: full release ship to TestFlight via `release.yml`, both generators in sequence — covers the CI-mode signing pipeline + Apple infrastructure.
-- **Saturdays 11:30 UTC**: full release ship to TestFlight via `canary-local-mode.yml`, both generators sequentially — covers the local-mode signing pipeline (no match, sigh-based profiles, β cert SHA-1 pinning, controlled keychain).
+- **Saturdays 11:30 UTC**: full release ship to TestFlight via `canary-local-mode.yml`, both generators sequentially — covers the local-mode signing pipeline (sigh-based profiles, fresh-cert minting, β cert SHA-1 pinning, controlled keychain).
 
-Bugs in fastlane / match / Apple's signing infra surface there before they bite forkers — patches land in this template before they hit your repo.
+Bugs in fastlane / sigh / Apple's signing infra surface there before they bite forkers — patches land in this template before they hit your repo.
 
 If you fork this template and your build breaks unexpectedly, [check the smoketest's Actions tab](https://github.com/indiagrams/ios-macos-smoketest/actions) — it's probably broken there too (Monday morning for CI-mode regressions, Saturday morning for local-mode), and a fix is in flight.
 
@@ -537,7 +539,6 @@ If you fork this template and your build breaks unexpectedly, [check the smokete
 │   ├── Fastfile                 # release | bootstrap_certs | upload_metadata | submit_for_review
 │   ├── Appfile                  # bundle ID + team
 │   ├── Snapfile / MacSnapfile   # screenshot capture config
-│   ├── Matchfile                # certs-repo URL (replace placeholder before running match)
 │   └── metadata/                # App Store listing copy + review info
 ├── app/
 │   ├── project.yml              # XcodeGen manifest (default generator)

--- a/docs/APPLE-PREREQS.md
+++ b/docs/APPLE-PREREQS.md
@@ -63,7 +63,7 @@ The `.gitignore` already blocks the common ones, but be aware:
 |------|---------------|------------------|
 | `*.p8` | App Store Connect API private key | `~/.appstoreconnect/` |
 | `*.mobileprovision` | Provisioning profiles (manual signing) | `~/Library/MobileDevice/Provisioning Profiles/` (Xcode manages) |
-| `*.cer`, `*.p12` | Distribution certificates. Three types are needed for full ship: **Apple Distribution** (codesign for the .app), **Apple Development** (provisioning), **3rd Party Mac Developer Installer** (signs the `.pkg` wrapper around macOS apps via `productbuild`). Per-team caps verified empirically May 2026: DIST=3, DEV≥5, MAC_INSTALLER=2. | macOS Keychain |
+| `*.cer`, `*.p12` | Distribution certificates. Three types are needed for full ship: **Apple Distribution** (codesign for the .app), **Apple Development** (provisioning), **3rd Party Mac Developer Installer** (signs the `.pkg` wrapper around macOS apps via `productbuild`). Local mode auto-mints these into the login keychain via `make mint-local-certs` (also runs as part of `make bootstrap-fork`). CI mode (`release.yml`, v1.6+) mints them fresh on the runner per release and revokes on `always()` — there is no certs repo and no `match` step. Per-team caps verified empirically May 2026: DIST=3, DEV≥5, MAC_INSTALLER=2. | macOS Keychain (local mode) / minted on the runner per run (CI mode) |
 | `.bootstrap.env` | Local fork config (paths, identifiers; secrets stay outside repo) | repo root, gitignored |
 
 If you accidentally commit any of these, treat it as a credential leak: revoke the key/cert immediately on Apple's side, then `git rm --cached` + force-rotate.
@@ -82,8 +82,8 @@ team `A26TJZ8QHQ` (community docs are stale or contradictory):
 
 | Cert type | Cap | Notes |
 |---|---|---|
-| Apple Distribution | **3** | Used for codesigning `.app` bundles. fastlane match's standard distribution path. |
-| Apple Development | **≥ 5** | Provisioning + dev signing. We didn't probe the upper bound; the v1.5 canary mints 1 per run with no observed cap hit. |
+| Apple Distribution | **3** | Used for codesigning `.app` bundles. Minted per-run by `release.yml` (CI mode, v1.6+) or once into the login keychain by `make mint-local-certs` (local mode). |
+| Apple Development | **≥ 5** | Provisioning + dev signing. We didn't probe the upper bound; the canary and `release.yml` each mint 1 per run with no observed cap hit. |
 | 3rd Party Mac Developer Installer | **2** | Used by `productbuild` to sign `.pkg` wrappers for macOS apps. Lower than DIST — Mac shippers commonly hit this first. |
 | Developer ID Application G2 | (separate, untested) | Apple's notarization-bound cert for direct distribution outside the App Store. Not exercised by this template. |
 
@@ -93,11 +93,18 @@ be your production cert. `fastlane cert` defaults to no `--force` (safe).
 The `revoke_cert` lane (singular) and `revoke_certs` lane (plural,
 idempotent batch) in `fastlane/Fastfile` help free a slot.
 
-### Optional: dedicate cycling slots for continuous validation
+### Dedicate cycling slots if at-cap (required for release.yml + canary)
 
-If you plan to enable `.github/workflows/canary-local-mode.yml` (the
-Saturday local-mode canary added in v1.5), dedicate 1 cycling slot per
-at-cap type up front:
+If your team is at-cap on Distribution (3/3) or Mac Installer (2/2),
+revoke 1 spare cert per constrained type once via the developer portal
+— this dedicates a cycling slot for the canary AND for `release.yml`
+runs. Without a cycling slot, a `make ship` run hits HTTP 409 at the
+mint step (and so does the Saturday canary).
+
+This applies to every fork running v1.6+. Earlier (v1.5) cycling-slot
+guidance only mentioned the canary because the release path then went
+through `match` against a certs repo; v1.6 release.yml mints fresh per
+run, so the same slot pressure applies to actual releases.
 
 ```bash
 # Via Apple Developer portal (~30 sec)
@@ -108,10 +115,11 @@ at-cap type up front:
 bundle exec fastlane revoke_certs ids:CERT_ID_1,CERT_ID_2
 ```
 
-The canary then mints into the freed slots per run and revokes on
-`always()`. Net team-cert delta per run = 0; your existing shipping
-certs are never touched. See [docs/CONTINUOUS-VALIDATION.md](CONTINUOUS-VALIDATION.md)
-for the full architecture.
+Both the canary and `release.yml` then mint into the freed slots per
+run and revoke on `always()`. Net team-cert delta per run = 0; your
+existing shipping certs are never touched. See
+[docs/CONTINUOUS-VALIDATION.md](CONTINUOUS-VALIDATION.md) for the full
+architecture.
 
 ## Reference
 

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -4,9 +4,9 @@ Time-to-TestFlight: ~15 minutes once your `.bootstrap.env` is filled in.
 
 This template ships a config-driven fork bootstrap. You fill out one file with
 your identity + credentials, then `make bootstrap-fork` drives every
-programmatic step (rename, push, branch protection, GH Secrets, certs repo,
-match, installer cert, icon swap, …) idempotently. The only manual steps are
-the ones Apple and GitHub deliberately don't expose to APIs.
+programmatic step (rename, push, branch protection, GH Secrets, ASC App
+registration, icon swap, …) idempotently. The only manual steps are the ones
+Apple and GitHub deliberately don't expose to APIs.
 
 ```bash
 # 1. Fork from template
@@ -40,17 +40,40 @@ make verify
 
 | | `ci` (default) | `local` |
 |---|---|---|
-| **Setup includes** | Private certs repo, fastlane match, 7 GH Secrets, branch protection, ASC App | Login keychain identities check, branch protection, ASC App |
+| **Setup includes** | 5 GH Secrets, branch protection, ASC App verify | Login keychain identities check, branch protection, ASC App verify |
 | **`make ship` does** | Triggers `.github/workflows/release.yml` on the app repo | Runs `bundle exec fastlane release tag:vYYYY.WW.HHMM` on this machine |
-| **Signing material lives** | Encrypted in the certs repo; CI decrypts via `MATCH_PASSWORD` | In your login keychain (Apple Distribution + Apple Development + 3rd Party Mac Developer Installer) |
-| **Who can release** | Anyone with `GH_PAT_FILE` (and ASC API key) | Only this laptop |
+| **Signing material lives** | Minted fresh on the GitHub Actions runner per release run, then revoked at the end of the run (net cert delta = 0). Nothing is persisted between runs. | In your login keychain (Apple Distribution + Apple Development + 3rd Party Mac Developer Installer for macOS) |
+| **Who can release** | Anyone with push to the app repo + a working `gh auth login` (the ASC API key is already in GH Secrets) | Only this laptop |
 | **Best for** | Teams, weekly TestFlight cron, repeatable builds | Solo devs, fast iteration, no shared CI |
-| **Cost to bootstrap** | ~10 min (PAT + certs repo + 7 secrets + match) | ~3 min (just verify keychain has the certs) |
+| **Cost to bootstrap** | ~5 min (5 secrets + branch protection + ASC App verify) | ~3 min (just verify keychain has the certs) |
 
-The same `fastlane/Fastfile` drives both — the release lane gates the `match` calls on `File.exist?(fastlane/Matchfile)`, so a `local`-mode fork that never touches Matchfile uses local Keychain signing automatically.
+Both modes drive the same `fastlane/Fastfile` release lane. The lane is
+sigh-based in both modes — the only difference is *where the signing certs
+come from*: local mode uses your `login.keychain-db`; CI mode mints fresh
+certs at the start of each `release.yml` run and revokes them at the end
+(`always()` step). There is no certs repo and no `fastlane match` involvement
+in v1.6+.
 
-You can switch modes later by editing `RELEASE_MODE` and re-running `make bootstrap-fork`. Going `local → ci`: bootstrap will set up the certs repo + secrets. Going `ci → local`: bootstrap won't tear down the existing certs repo (you'd remove that manually); CI just stops running.
+You can switch modes later by editing `RELEASE_MODE` and re-running
+`make bootstrap-fork`. Going `local → ci`: bootstrap sets the 5 GH Secrets
+and configures branch protection. Going `ci → local`: bootstrap doesn't tear
+down the GH Secrets (they're harmless if `release.yml` is never triggered);
+CI just stops being invoked.
 
+### Pre-v1.6 forks: harmless leftovers
+
+If you bootstrapped before v1.6 (#158), your fork may still have:
+
+- `GH_CERTS_REPO`, `GH_PAT_FILE`, `MATCH_PASSWORD_FILE` lines in `.bootstrap.env`
+- `MATCH_PASSWORD` and `MATCH_GIT_BASIC_AUTHORIZATION` GH Secrets on the app repo
+- A private `<app>-certs` repo on GitHub
+- A fine-grained PAT pointed at the certs repo
+
+None of these are referenced by anything in the v1.6 pipeline. `make doctor`
+ignores them, `make bootstrap-fork` doesn't touch them, and `release.yml`
+no longer reads them. Safe to delete (recommended for cleanliness) or leave
+in place (no functional impact). Deleting the certs repo and revoking the
+PAT is the most defense-in-depth move, but neither is required.
 
 ## Platforms
 
@@ -83,50 +106,60 @@ actual secret bytes. The dotenv itself is low-blast-radius.
 | `ASC_API_KEY_ID` | 10-char ASC API key ID | <https://appstoreconnect.apple.com/access/api> → Users and Access → Integrations → App Store Connect API |
 | `ASC_API_KEY_ISSUER_ID` | UUID format issuer ID | Same page, shown above the keys table |
 | `ASC_API_KEY_P8_PATH` | Path to the `.p8` file Apple gave you when you created the API key | Apple shows it once at creation time. If lost, generate a new key + revoke old |
-| `GH_ORG` | GitHub user/org that owns both repos | You decide |
+| `GH_ORG` | GitHub user/org that owns the app repo | You decide |
 | `GH_APP_REPO` | App repo name (already created via `gh repo create --template`; auto-filled by `make init` from origin remote) | The name you used in `gh repo create` |
-| `GH_CERTS_REPO` *(ci-only)* | Private certs repo name (created by `make bootstrap-fork` if absent) | Convention: `<app-repo>-certs` |
-| `GH_PAT_FILE` *(ci-only)* | Path to a file containing a fine-grained PAT scoped to `GH_CERTS_REPO` (Contents: read+write) | <https://github.com/settings/tokens?type=beta>. See [PAT scope tradeoff](#pat-scope-tradeoff) below |
-| `MATCH_PASSWORD_FILE` *(ci-only)* | Path to a file containing the certs-repo encryption password. Auto-generated as 32 random chars if absent | Created on first `make bootstrap-fork` |
-| `KEYCHAIN_PASSWORD_FILE` *(ci-only)* | Path to a file containing the CI keychain password. Auto-generated if absent | Created on first `make bootstrap-fork` |
+| `KEYCHAIN_PASSWORD_FILE` *(ci-only)* | Path to a file containing the CI keychain password. Auto-generated as 32 random chars on first `make bootstrap-fork` if absent | Created on first `make bootstrap-fork` |
 | `ICON_1024_PATH` (optional) | Path to your 1024×1024 PNG. If set, replaces the template hammer icon and runs `make icons` | Designer artifact |
 | `ASC_APP_SKU` (optional) | Documentation hint for the manual ASC App creation step | Any unique string |
 | `ASC_APP_NAME` (optional) | Documentation hint — defaults to `DISPLAY_NAME` | The human-readable name you want shown in the App Store |
 | `PLATFORMS` (optional) | Subset of `ios,macos` that controls which targets ship. Defaults to both if unset. See [Platforms](#platforms) above | You decide |
 
+CI mode no longer requires a separate fine-grained PAT or a private certs
+repo. The `gh` CLI's auth (set up once via `gh auth login`) is what
+`bootstrap-fork` uses to set GH Secrets and configure branch protection,
+and `release.yml` uses the workflow-scoped `GITHUB_TOKEN` for everything it
+needs.
+
 ## What `make bootstrap-fork` does
 
-The pipeline has 19 step classes. CI mode (`RELEASE_MODE=ci`) runs 18 with
-default `PLATFORMS=ios,macos` (excludes `LocalKeychainCerts`); local mode
-(`RELEASE_MODE=local`, the default) runs 14 (excludes the 5 ci-only steps:
-`EditMatchfile`, `CreateCertsRepo`, `GHSecrets`, `BootstrapCerts`,
-`MintInstaller`). Each step has a `check` (no side effects) and a `do_it`.
-A step is skipped if its desired state is already reached, so re-running
-after a partial failure picks up where you left off.
+The pipeline has 15 step classes (single source of truth: `PIPELINE` in
+`bin/lib/bootstrap.rb`). CI mode (`RELEASE_MODE=ci`) runs 14 with default
+`PLATFORMS=ios,macos` (excludes `LocalKeychainCerts`, which is local-only);
+local mode runs 14 (excludes `GHSecrets`, which is ci-only). Each step has
+a `check` (no side effects) and a `do_it`. A step is skipped if its desired
+state is already reached, so re-running after a partial failure picks up
+where you left off.
 
-Mode key: ⚪ both, 🅒 ci-only, 🅛 local-only.
+Mode key: ⚪ both, 🅒 ci-only, 🅛 local-only, 🍎 macOS-only.
 
 | # | Step | Mode | What changes |
 |---|---|---|---|
-| 1 | Apple credentials (`CheckAppleCreds`) | ⚪ | Validates `.p8` + key id + issuer id by probing ASC API |
-| 2 | GitHub credentials (`CheckGHCreds`) | ⚪ | Validates PAT can see `GH_CERTS_REPO` (CI mode) or `git remote get-url origin` (local mode) |
-| 3 | Origin remote present (`RemoteMatches`) | ⚪ | Verifies `git remote` is configured to the fork |
-| 4 | Rename HelloApp → APP_NAME (`RenameStub`) | ⚪ | Runs `bin/rename.sh` + `bin/verify-rename.sh` |
-| 5 | Wire fastlane/Matchfile (`EditMatchfile`) | 🅒 | Substitutes `git_url` to point at your certs repo |
-| 6 | Toolchain (`BrewBootstrap`) | ⚪ | `make bootstrap` (brew bundle + lefthook + xcodegen/tuist + bundler) |
-| 7 | (optional) Replace 1024 icon (`Icon1024`) | ⚪ | If `ICON_1024_PATH` set, copies it to the iOS asset catalog |
-| 8 | (optional) Regenerate macOS icns (`MakeIcons`) | ⚪ | `make icons` — only if step 7 ran |
-| 9 | Initial commit + push (`InitialPush`) | ⚪ | First commit (rename + Matchfile + icons) pushed to `origin/main` |
-| 10 | Branch protection (`BranchProtection`) | ⚪ | `bin/setup-github.sh` (7 required checks: swiftlint + xcodegen iOS device/sim + macOS + tuist parity, squash-only, linear history) |
-| 11 | Private certs repo (`CreateCertsRepo`) | 🅒 | `gh repo create --private` if absent |
-| 12 | 7 GH Secrets (`GHSecrets`) | 🅒 | Generates `MATCH_PASSWORD` + `KEYCHAIN_PASSWORD` if absent, encodes the PAT + p8, sets all 7 secrets |
-| 13 | Bundle ID registration (`RegisterAppId`) | ⚪ | `fastlane register_app_id` (idempotent — Spaceship `BundleId.create` rescues `ALREADY_EXISTS`) |
-| 14 | Verify ASC App (`VerifyAscApp`) | ⚪ | Probes for the App record. **Fails loud with web-UI instructions if missing** — Apple disallows `POST /apps`, so this is the one human-gated step inside the pipeline |
-| 15 | Mint match certs iOS dist + dev + macOS dist (`BootstrapCerts`) | 🅒 | `fastlane bootstrap_certs` (3 match calls in one process) |
-| 16 | Mac Installer Distribution cert (`MintInstaller`) | 🅒 (macOS only) | `bin/mint-installer-cert.rb` + `bin/import-installer-to-match.rb` |
-| 17 | Local keychain has signing identities (`LocalKeychainCerts`) | 🅛 | Auto-mints any missing local-mode cert types (Apple Distribution, Apple Development, 3rd Party Mac Developer Installer) via `fastlane cert` into `login.keychain-db`. New in v1.4 — replaces the v1.3 hard-blocker requiring manual remediation |
-| 18 | Scan metadata (`ScanMetadata`) | ⚪ | Informational — counts present-vs-placeholder strings under `fastlane/metadata/` |
-| 19 | Scan screenshots (`ScanScreenshots`) | ⚪ | Informational — counts present screenshots under `fastlane/screenshots/` |
+| 1 | `CheckAppleCreds` | ⚪ | Validates `.p8` + key id + issuer id by probing ASC API |
+| 2 | `CheckGHCreds` | ⚪ | CI mode: probes `gh auth status`. Local mode: no-op (gh CLI not used at ship time). |
+| 3 | `RemoteMatches` | ⚪ | Verifies `git remote get-url origin` matches `GH_ORG/GH_APP_REPO` |
+| 4 | `RenameStub` | ⚪ | Runs `bin/rename.sh` (HelloApp → APP_NAME) + `bin/verify-rename.sh` |
+| 5 | `BrewBootstrap` | ⚪ | `make bootstrap` (brew bundle + lefthook + xcodegen/tuist + bundler) |
+| 6 | `Icon1024` | ⚪ | If `ICON_1024_PATH` set, copies it to the iOS asset catalog (tree mutation lands before `InitialPush`) |
+| 7 | `MakeIcons` | 🍎 | `make icons` — regenerates the macOS `.icns` from the 1024 PNG. Runs only when `PLATFORMS` includes `macos`. |
+| 8 | `InitialPush` | ⚪ | First commit (rename + icons) pushed to `origin/main` |
+| 9 | `BranchProtection` | ⚪ | `bin/setup-github.sh` (required checks: swiftlint + xcodegen iOS device/sim + macOS + tuist parity, squash-only, linear history) |
+| 10 | `GHSecrets` | 🅒 | Generates `KEYCHAIN_PASSWORD` if absent, encodes the `.p8`, sets the 5 GH Secrets (`KEYCHAIN_PASSWORD`, `ASC_API_KEY_ID`, `ASC_API_KEY_ISSUER_ID`, `ASC_API_KEY_P8_BASE64`, `FASTLANE_TEAM_ID`) on the app repo |
+| 11 | `RegisterAppId` | ⚪ | `fastlane register_app_id` (idempotent — Spaceship `BundleId.create` rescues `ALREADY_EXISTS`) |
+| 12 | `VerifyAscApp` | ⚪ | Probes for the App record. **Fails loud with web-UI instructions if missing** — Apple disallows `POST /apps`, so this is the one human-gated step inside the pipeline |
+| 13 | `LocalKeychainCerts` | 🅛 | Auto-mints any missing local-mode cert types (Apple Distribution, Apple Development, and — when shipping macOS — 3rd Party Mac Developer Installer) via `fastlane cert` into `login.keychain-db`. New in v1.4 — replaces the v1.3 hard-blocker requiring manual remediation. |
+| 14 | `ScanMetadata` | ⚪ | Informational — counts present-vs-placeholder strings under `fastlane/metadata/` |
+| 15 | `ScanScreenshots` | ⚪ | Informational — counts present screenshots under `fastlane/screenshots/` |
+
+### CI mode at a glance (v1.6+)
+
+`bootstrap-fork` in CI mode creates **0 certs repos**, generates **0 PATs**,
+and mints **0 signing certs**. Its only ci-specific step is `GHSecrets`,
+which sets 5 secrets on the app repo. All actual signing material is
+minted fresh by `release.yml` at the start of every release run and
+revoked at the end via the `always()` post-step (orphan ASC ids from
+crashes are cleaned up by the next run's pre-step). Validated 2026-05-10
+against `prakashrj/my-cool-app` (release `v2026.19.10` minted, signed,
+uploaded, and certs revoked end-to-end).
 
 ## What you still have to do by hand
 
@@ -138,7 +171,9 @@ to public APIs:
 - **Create the App Store Connect App record** (Apple disallows `POST /apps`).
   The `VerifyAscApp` step of `make bootstrap-fork` fails loud with the
   exact form values to paste — re-run after creating, and the step turns ✓
-- **Generate a fine-grained PAT** for the certs repo (web UI)
+- **Run `gh auth login`** once on the machine that will execute `make
+  bootstrap-fork` and `make ship` (CI mode only — local mode never invokes
+  the `gh` CLI at ship time)
 - **Provide a 1024 icon and metadata text** (designer + product artifacts —
   see "After bootstrap" below)
 
@@ -164,60 +199,52 @@ For App Store *review* (not just TestFlight), you still need:
 These aren't gates for TestFlight — TestFlight just needs the build. They're
 gates for App Store review.
 
-## PAT scope tradeoff
-
-The fine-grained PAT can be scoped two ways:
-
-- **"Only select repositories" → just your certs repo** (most secure default).
-  Caveat: fine-grained PATs are pinned to a specific repo's *database ID*. If
-  you ever delete + recreate the certs repo, the PAT 404s on the new repo
-  even though the name is identical, and you have to update the PAT scope on
-  github.com/settings/tokens. See `docs/CONTINUOUS-VALIDATION.md` G12 and
-  `bin/refork-smoketest.sh` for the recreation-resilient approach.
-
-- **"All repositories"** — defense in depth, survives recreation. Same narrow
-  Contents permission, but bound to your user/org rather than a specific
-  repo's database ID.
-
-Either is fine; the first is the most secure default and what `.bootstrap.env`
-expects.
-
 ## Why is `.bootstrap.env` gitignored?
 
 Even though most fields are non-secret (team ID, repo slugs), the file
-references *paths* to your `.p8` API key and your fine-grained PAT. Anyone who
-gets the file gets a roadmap to your secret bytes. Treat it the same way you
-treat `~/.ssh/config` — not a catastrophic leak by itself, but enough to be
+references *paths* to your `.p8` API key and (for CI mode) the
+auto-generated keychain password file. Anyone who gets the file gets a
+roadmap to your secret bytes. Treat it the same way you treat
+`~/.ssh/config` — not a catastrophic leak by itself, but enough to be
 worth keeping out of source control.
 
 ## Troubleshooting
 
-- **Step N fails with a stack trace from `bundle exec ruby`** — the script
-  uses fastlane's bundle for Spaceship + match. Run `bundle install` first.
-- **`make doctor` says PAT 404s on certs repo, but I just created it** —
-  fine-grained PATs are pinned to repo database IDs. If you recreated the
-  certs repo, edit the PAT's repo list at github.com/settings/tokens.
+- **A step fails with a stack trace from `bundle exec ruby`** — the script
+  uses fastlane's bundle for Spaceship + `cert` / `sigh`. Run `bundle
+  install` first.
+- **`CheckGHCreds` says `gh CLI is not authenticated`** — run `gh auth
+  login` and re-try `make doctor`. CI mode requires this so `GHSecrets`
+  and `BranchProtection` can talk to the app repo.
 - **`VerifyAscApp` is blocked but I created the App** — ASC API
   is eventually consistent. Wait 30 seconds and re-run `make doctor`.
-- **`BootstrapCerts` (CI mode) or `MintInstaller` (CI mode) or `LocalKeychainCerts` (local mode) hits "Could not create another Distribution certificate,
-  reached the maximum number of available Distribution certificates"** —
-  Apple's per-team cert quotas (verified empirically May 2026 against team
+- **`LocalKeychainCerts` (local mode) or the release.yml mint step (CI
+  mode) hits "Could not create another Distribution certificate, reached
+  the maximum number of available Distribution certificates"** — Apple's
+  per-team cert quotas (verified empirically May 2026 against team
   `A26TJZ8QHQ`): Apple Distribution = 3, Apple Development ≥ 5, 3rd Party
   Mac Developer Installer = 2. Forkers shipping macOS commonly hit the
   installer cap (2) before the distribution cap (3). Revoke an unused one
   via `bundle exec fastlane revoke_cert id:<CERT_ID>` (singular) or
-  `revoke_certs ids:A,B,C` (plural batch, idempotent), then re-run
-  `make doctor`. See [docs/CONTINUOUS-VALIDATION.md](CONTINUOUS-VALIDATION.md)
-  for the full ecosystem-constraints note.
-- **`BootstrapCerts` / `LocalKeychainCerts` hits "Could not find the newly generated certificate installed"
-  on a populated login keychain** — see `docs/CONTINUOUS-VALIDATION.md` G11.
-  The bootstrap pipeline sets `CERT_KEYCHAIN_PATH` to a temp keychain to
-  avoid this; if you still hit it, run match against a fresh keychain.
+  `revoke_certs ids:A,B,C` (plural batch, idempotent), then re-run.
+  In CI mode, orphan ids from crashed runs are auto-revoked by the
+  pre-step of the next `release.yml` run; if a fork has been idle long
+  enough for the cache to evict (>7 days), revoke manually via
+  developer.apple.com/account/resources/certificates. See
+  [docs/CONTINUOUS-VALIDATION.md](CONTINUOUS-VALIDATION.md) for the full
+  ecosystem-constraints note.
+- **`LocalKeychainCerts` hits "Could not find the newly generated
+  certificate installed" on a populated login keychain** — see
+  `docs/CONTINUOUS-VALIDATION.md` G11. The CI release.yml pipeline mints
+  into a fresh runner-scoped keychain (immune to this). Locally, run
+  `fastlane cert` against a fresh keychain.
 
 ## What `bin/lib/bootstrap.rb` is
 
-The orchestrator. Pure Ruby, ~700 lines, depends only on the gems already
-in this template's `Gemfile` (fastlane + spaceship). Every step lives as a
-separate class (`RenameStub`, `BrewBootstrap`, `BootstrapCerts`, …) so
+The orchestrator. Pure Ruby, depends only on the gems already in this
+template's `Gemfile` (fastlane + spaceship). Every step lives as a
+separate class (`RenameStub`, `BrewBootstrap`, `LocalKeychainCerts`, …) so
 adding new steps or skipping ones is a one-class change. `bin/doctor.rb`
-and `bin/bootstrap-fork.rb` are thin wrappers on `Bootstrap::Runner`.
+and `bin/bootstrap-fork.rb` are thin wrappers on `Bootstrap::Runner`. The
+canonical step order lives in the `PIPELINE` constant near the bottom of
+the file — that's the ground truth the table above mirrors.

--- a/docs/MAINTAINING-A-FORK.md
+++ b/docs/MAINTAINING-A-FORK.md
@@ -1,0 +1,275 @@
+# Maintaining your fork after the first ship
+
+You've forked apple-shipkit, run `make all`, and your build is in TestFlight. Now what?
+
+This guide answers the questions that come up *after* the first release:
+
+- What state do I actually own?
+- What does Apple manage for me?
+- What needs backing up?
+- What breaks if I ignore it for six months?
+- I want to add [push notifications / Sign in with Apple / iCloud / App Groups] — does that change anything?
+- An Apple cert expired. What do I do?
+
+It's deliberately accessible — assumes you've shipped *one* iOS or macOS app before, but doesn't assume you've memorized Apple's certificate hierarchy or fastlane's internals.
+
+## TL;DR for the impatient
+
+If you do nothing else after your first ship:
+
+1. **Renew Apple Developer Program annually** ($99/yr). If it lapses, every cert your team holds is auto-revoked. Apple emails reminders 30 days out.
+2. **Ship at least once every ~12 months**, even just a no-op build. Apple processing requirements drift (new SDK minimums, new entitlement formats); shipping keeps you exercised against the current policy.
+3. **Keep `.bootstrap.env` and `~/.config/secrets/*` backed up somewhere safe** (1Password, your dotfiles repo, etc.). Without these, you can re-create state from scratch in ~30 minutes; with them, ~2 minutes.
+
+That's it. Everything else below is "in case you need it."
+
+## What's persistent (lives forever, you own it)
+
+These survive across releases, machine swaps, even moving to a different fork:
+
+| Asset | Lives where | Why it persists |
+|---|---|---|
+| **Bundle ID** | Apple Developer Portal | Registered once via `make bootstrap-fork`; tied to your team. Identifies your app to iOS/macOS forever. |
+| **App Store Connect App record** | App Store Connect | Created manually (Apple disallows API creation). Holds your app's metadata, screenshots, reviews. |
+| **Team ID** | Apple Developer Portal | Your `FASTLANE_TEAM_ID` — assigned when you joined the Apple Developer Program. |
+| **App ID capabilities** (App Groups, Push, Sign in with Apple, iCloud, etc.) | Apple Developer Portal | Each capability you enable is registered against your Bundle ID. Stays enabled across releases. |
+| **App users' iCloud data, Keychain entries, settings** | User devices, iCloud | Tied to Bundle ID + Team ID. Won't be lost when you ship a new version. |
+| **GitHub repo + commit history** | GitHub | Standard git stuff. |
+| **Source code, CHANGELOG, screenshots, App Store metadata** | Your repo | All in version control. |
+
+What this means: you can lose your laptop, lose your `.bootstrap.env`, lose every cert in your keychain, and your app's *identity* is fine. You'd just need to re-bootstrap a new machine to get back to shipping.
+
+## What's ephemeral (auto-managed by apple-shipkit, ignore it)
+
+These are minted on-demand and revoked or rotated automatically. You don't think about them:
+
+| Asset | When it's created | When it's gone |
+|---|---|---|
+| **Apple Distribution cert** (used to sign App Store builds) | CI mode: each `release.yml` run mints one. Local mode: auto-minted by `make bootstrap-fork` into your login keychain. | CI mode: revoked at end of every run via `if: always()`. Local mode: stays in keychain ~1 year, then expires; replaced on next `make bootstrap-fork` or `make mint-local-certs`. |
+| **Apple Development cert** | Same as above. | Same as above. |
+| **3rd Party Mac Developer Installer cert** (used to sign macOS .pkg installers) | Same as above. | Same as above. |
+| **App Store provisioning profile** | `fastlane sigh` mints one each release run. | Apple expires them after ~1 year, but you're minting fresh per release anyway. |
+
+What this means: signing certs are throwaway. **Apple identifies your app by Bundle ID + Team ID, not by which specific cert signed each build.** Once a TestFlight build is uploaded, Apple archives the cert that signed it; later cert revocation doesn't invalidate the already-uploaded build. Your testers see the new build via TestFlight as if nothing changed.
+
+## What you (the developer) actively own
+
+Things apple-shipkit *won't* manage for you. Most forks need none of these — they're for apps with specific features.
+
+### If your app uses push notifications (APNs)
+
+Apple Push Notification service uses a **separate** auth key (`.p8` file) — not your signing certs.
+
+- **Where to get it**: App Store Connect → Users and Access → Keys → Generate (select "Apple Push Notifications service (APNs)" capability).
+- **What you back up**: the `.p8` file (Apple shows it once at creation; if you lose it, you generate a new one and revoke the old).
+- **What apple-shipkit knows about it**: nothing. APNs is outside the bootstrap flow. You hold the `.p8` and feed it to your push-sending backend (your server, OneSignal, AWS SNS, etc.).
+- **Lifecycle**: never expires (unlike push *certs* which Apple deprecated). Revoke + replace if it leaks.
+
+> **Note**: the `.p8` you used during `make init` (`ASC_API_KEY_P8_BASE64` GH Secret) is a *different* `.p8` — that one is the App Store Connect API key, used by fastlane to talk to Apple. APNs auth keys are separate. They look identical (PEM-encoded EC key), but Apple treats them as different credential types.
+
+### If your app uses Sign in with Apple
+
+Sign in with Apple needs a **Service ID** + a **private key** for verifying user tokens server-side.
+
+- **Where to get it**: Apple Developer Portal → Identifiers → New → Services IDs.
+- **What you back up**: the Service ID name and the private key it's bound to.
+- **Lifecycle**: tied to your Apple Developer Program membership. Never auto-rotated.
+
+### If your app uses Wallet (Pass Type ID)
+
+Each pass type your app issues needs a Pass Type ID + cert.
+
+- **Where to get it**: Apple Developer Portal → Identifiers → New → Pass Type IDs.
+- **What you back up**: the cert's `.p12` (export from Keychain Access). Apple expires these certs annually; renew via the portal.
+- **Why apple-shipkit doesn't manage it**: Pass Type ID certs aren't standard signing certs and aren't part of the App Store distribution flow.
+
+### If your app distributes outside the Mac App Store (Developer ID)
+
+Direct distribution (the user downloads a `.dmg` or `.pkg` from your website) requires a **Developer ID Application** cert, distinct from Mac App Distribution.
+
+- **Where to get it**: Apple Developer Portal → Certificates → Production → Developer ID Application.
+- **What you back up**: the `.p12` (private key + cert).
+- **Lifecycle**: 5 years. Renew before expiry.
+- **Why apple-shipkit doesn't auto-mint these**: the project is App Store first; Developer ID is a separate distribution path. If you need it, mint via the portal manually and add a custom signing step in your release lane.
+
+### If your app uses CloudKit / iCloud / App Groups
+
+These are **entitlements** registered against your Bundle ID. They have no separate cert lifecycle.
+
+- **Where to enable**: Apple Developer Portal → Identifiers → your Bundle ID → enable the capability.
+- **What you back up**: the entitlement is auto-saved in your `.entitlements` files in the repo. Just keep your repo backed up.
+- **Lifecycle**: enabled forever once registered. Free to use within Apple Developer Program limits.
+
+## Day-2 operations: when you need to do something
+
+### "I want to ship a new version"
+
+`make ship` (CI mode) or `make ship` from your local Mac (local mode). The `release.yml` workflow handles version computation (CalVer: `vYYYY.WW.<run_number>`), cert minting, signing, upload, tag push, "What to Test" annotation. Takes ~5 minutes.
+
+### "I want to submit to App Store review"
+
+After at least one TestFlight build is processed:
+
+```bash
+# Take screenshots (uses fastlane snapshot)
+bundle exec fastlane take_screenshots
+
+# Upload screenshots + metadata to ASC
+bundle exec fastlane ios upload_screenshots
+bundle exec fastlane ios upload_metadata
+
+# Submit for review (selects the latest TestFlight build)
+bundle exec fastlane ios submit_for_review
+```
+
+Apple's review takes 24-48 hours typically. If they reject, fix the issue and re-submit; the same build can be re-submitted unchanged (pure metadata fixes), or upload a new build.
+
+### "I added a new entitlement (e.g. Push) and signing now fails"
+
+Each time you add a new capability to your Bundle ID:
+
+1. Enable it in Apple Developer Portal → Identifiers → your Bundle ID.
+2. Add it to your `.entitlements` files in the repo (`app/iOS/HelloApp.entitlements`, `app/macOS/HelloApp.entitlements`).
+3. Re-ship via `make ship`. The next mint cycle will produce certs/profiles that include the new capability.
+
+If you re-ship without enabling the capability in the portal first, signing succeeds but the entitlement is stripped from the binary and your feature won't work at runtime.
+
+### "An Apple cert expired"
+
+Distribution + Development certs expire ~1 year from issuance. The mint-fresh CI flow doesn't care (each run mints fresh). For local mode:
+
+```bash
+make clean-revoked-certs    # removes locally-cached expired/revoked certs
+make mint-local-certs       # mints fresh ones via fastlane cert
+```
+
+### "I'm at-cap on Apple's cert quota"
+
+Apple limits per team:
+
+| Cert type | Cap | Why it might fill up |
+|---|---|---|
+| Apple Distribution | 3 | Manual mints over the years; multiple devs per team |
+| Apple Development | ≥5 | Same |
+| 3rd Party Mac Developer Installer | 2 | Same |
+
+If `make ship` fails with HTTP 409 at the mint step, you're at-cap. Fix:
+
+```bash
+# Preview what's in the team:
+bundle exec fastlane list_certs
+
+# Revoke a specific cert (find its ID in the list output):
+bundle exec fastlane revoke_cert id:<CERT_ID>
+
+# Or revoke many at once:
+bundle exec fastlane revoke_certs ids:CERT_ID_1,CERT_ID_2
+```
+
+For ongoing CI mint-fresh runs, you need at least 1 free cycling slot per constrained type. See [docs/APPLE-PREREQS.md](APPLE-PREREQS.md) — "Per-team certificate quotas".
+
+### "My Apple Developer Program membership lapsed"
+
+If you don't renew within ~30 days of expiry, Apple revokes ALL your team's certs. Effects:
+
+- TestFlight: existing builds stop accepting new testers; existing testers can keep using the build until it expires (~90 days after upload).
+- App Store: published versions stay live (Apple already-vetted them); you can't ship new builds.
+- Re-enrollment: pay $99, wait 24-48 hours for Apple to re-activate, then re-bootstrap (`make bootstrap-fork` mints fresh certs).
+
+Set a calendar reminder. Apple's email reminders are easy to miss.
+
+### "I want to migrate to a different Apple team"
+
+The fork's bundle ID is registered against ONE team. Migrating means:
+
+1. Register the same bundle ID under the new team (might require Apple support if the bundle ID's already taken in the old team — Apple has a transfer process).
+2. Update `FASTLANE_TEAM_ID` in `.bootstrap.env` (and the corresponding GH Secret).
+3. Re-run `make bootstrap-fork`.
+
+This is rare. Most forks stay on one team forever.
+
+### "I want to retire this fork"
+
+If you stop developing the app:
+
+1. **Apple side**: log into App Store Connect, set the app to "Removed from sale" (existing users keep the app; new downloads blocked). Or if you want to fully delete, there's a "Remove App" button at the bottom of the App Information page.
+2. **GitHub side**: archive the repo (`gh repo archive`). Optional — keeps history accessible without active maintenance.
+3. **Cert cleanup** (optional, just hygiene): `bundle exec fastlane revoke_certs ids:…` to free up team slots.
+
+## Backups checklist
+
+Things worth backing up to a secrets manager (1Password, Bitwarden, etc.):
+
+| What | Why |
+|---|---|
+| `.bootstrap.env` | Reconstructible from secrets, but faster to restore |
+| `~/.config/secrets/AuthKey_*.p8` (the ASC API key) | Apple won't give you this again — only generate-and-replace |
+| `~/.config/secrets/keychain-password` (CI mode only) | Only matters if you want to keep the same controlled-keychain password on a new machine; otherwise just regenerate |
+| Apple Developer Program login email + password (or your team admin's) | Without it, you can't renew membership or manage certs |
+| App Store Connect API key team admin email | If your ASC API key is revoked at Apple's end (rare), you need ASC web access to mint a new one |
+| Your fork's repo URL + branch protection state (or `bin/setup-github.sh` config) | Reconstructible but easier to restore from notes |
+
+What you do **not** need to back up (apple-shipkit can recreate or doesn't store):
+
+- Signing certs (`.cer`, `.p12`) — auto-minted on demand
+- Provisioning profiles (`.mobileprovision`, `.provisionprofile`) — auto-minted by `sigh` per run
+- Match repo / certs repo — doesn't exist anymore (v1.6+)
+- MATCH_PASSWORD — doesn't exist anymore (v1.6+)
+- GitHub fine-grained PAT — only existed for the old certs repo (v1.6+ removed it)
+
+## What changes when apple-shipkit upgrades
+
+apple-shipkit ships breaking changes occasionally (e.g. v1.6 dropped match-based signing entirely). When you bump your fork:
+
+1. **Read the CHANGELOG** for the version range you're crossing. Breaking changes are flagged.
+2. **Check `.bootstrap.env.example`** for new fields. Compare to your `.bootstrap.env`; add anything new.
+3. **Re-run `make doctor`**. If new required fields appear, doctor will tell you. Fix and re-run `make bootstrap-fork`.
+4. **Existing leftovers from old apple-shipkit versions are harmless** — apple-shipkit's doctor only complains about *missing* required fields, not present-extra ones. So old fields like `GH_CERTS_REPO`, `MATCH_PASSWORD_FILE`, etc. (removed in v1.6) can stay in your `.bootstrap.env` indefinitely without breaking anything.
+
+## When things go sideways
+
+- **Build won't sign**: see [docs/CONTINUOUS-VALIDATION.md](CONTINUOUS-VALIDATION.md) — the failure-mode catalog has 16 entries covering every signing failure we've seen in the wild.
+- **CI release fails**: see [docs/ROLLBACK.md](ROLLBACK.md) for the rollback procedure.
+- **`make ship` says "no certs found"**: local mode — run `make mint-local-certs`. CI mode — check your team isn't at-cap; check you ran `gh auth login` on the machine triggering `make ship`.
+- **TestFlight "What to Test" is empty**: should be auto-populated from `CHANGELOG.md`'s `[Unreleased]` block. If empty, set `RELEASE_CHANGELOG=...` in `release.yml`'s env block before triggering.
+- **Anything else**: open an issue on apple-shipkit upstream. The smoketest fork validates the shipping path weekly, so the upstream maintainers usually catch regressions before forkers do.
+
+## Mental model: who owns what
+
+```
+                  Apple (forever)
+                  ──────────────
+                  ├── Team ID (your $99/yr)
+                  ├── Bundle ID + capabilities
+                  ├── ASC App record + metadata + reviews
+                  └── User devices: installed apps, iCloud data, Keychain
+
+                                    │
+                                    │  registered against
+                                    ▼
+
+                  apple-shipkit (per ship)
+                  ────────────────────────
+                  ├── Mints fresh signing certs on the runner
+                  ├── Mints provisioning profiles via sigh
+                  ├── Builds + signs + uploads
+                  ├── Tags release in git
+                  ├── Annotates "What to Test" from CHANGELOG.md
+                  └── Revokes the just-minted certs (always)
+
+                                    │
+                                    │  reuses
+                                    ▼
+
+                  You (one-time setup)
+                  ────────────────────
+                  ├── Apple Developer Program subscription ($99/yr)
+                  ├── App Store Connect API key (.p8) — generate once, reuse forever
+                  ├── GitHub repo + `gh auth login`
+                  ├── `.bootstrap.env` filled in
+                  └── (Optional) APNs key, Pass Type ID, Sign in with Apple — for those features
+```
+
+The whole point of v1.6's mint-fresh-per-run architecture: the middle layer is *as ephemeral as possible*. You set up the bottom layer once, Apple manages the top layer forever, and apple-shipkit churns the middle layer per ship.
+
+You don't have to think about the middle layer. That's the design.

--- a/docs/MIGRATING-TO-TUIST.md
+++ b/docs/MIGRATING-TO-TUIST.md
@@ -35,11 +35,16 @@ is the only section you really need.
 > `make check-macos` all green. The script's
 > `ci/test-switch-to-tuist.sh` harness re-runs that validation in CI.
 >
-> Generator parity is also gated **at release time**, not just PR time.
-> Since v1.5, `.github/workflows/canary-local-mode.yml` ships a
-> `[xcodegen, tuist]` matrix that exercises both generators end-to-end
-> through `fastlane release` weekly on the smoketest fork — so a
-> Tuist-only fork's release pipeline is itself canary-validated upstream.
+> Generator parity is gated at multiple points, not just PR time:
+> `pr.yml`'s 6-job matrix on every PR (build-only); since v1.5,
+> `.github/workflows/canary-local-mode.yml`'s `[xcodegen, tuist]`
+> matrix runs `fastlane release` weekly on the smoketest fork; and
+> since v1.6, `release.yml` itself uses the same mint-fresh-cert-then-revoke
+> path as `canary-local-mode.yml`, so every actual ship from a
+> Tuist-only fork exercises the post-migration Tuist release pipeline
+> through the same code path the canary validates. A Tuist-only fork's
+> release pipeline is canary-validated upstream **and** validated on
+> each of its own ships.
 >
 ## Why this exists
 

--- a/docs/NO-CI.md
+++ b/docs/NO-CI.md
@@ -1,6 +1,6 @@
-# Local-only mode (no GitHub Actions, no certs repo, no match)
+# Local-only mode (no GitHub Actions, ship from your laptop)
 
-If your fork ships from your laptop — not from CI — you can run the entire release pipeline without GitHub Actions, without a private certs repo, and without `fastlane match`.
+If your fork ships from your laptop — not from CI — you can run the entire release pipeline without GitHub Actions involvement. (CI mode itself no longer requires a certs repo or `fastlane match` either, as of v1.6 — both modes now sign with sigh-fetched App Store profiles. The remaining axis of choice is _where_ `make ship` runs.)
 
 This is the default mode shipped by `.bootstrap.env.example` since v1.3.0. Forks just need a Mac with Xcode 26 and an Apple Developer account ($99/yr).
 
@@ -9,18 +9,18 @@ This is the default mode shipped by `.bootstrap.env.example` since v1.3.0. Forks
 | | CI mode | Local-only mode |
 |---|---|---|
 | Where `make ship` runs | GitHub Actions runner (macos-15) | Your Mac |
-| Code signing | `fastlane match` against private certs repo | Login Keychain (auto-minted by `bootstrap-fork`) |
-| Required GH Secrets | 7 (`ASC_*`, `MATCH_PASSWORD`, etc.) | 0 |
-| Bootstrap pipeline length | 18 steps | 14 steps |
+| Code signing | Fresh certs minted into a controlled keychain per run, revoked on `always()` | Login Keychain (auto-minted by `bootstrap-fork`) |
+| Required GH Secrets | 5 (`KEYCHAIN_PASSWORD`, `ASC_API_KEY_ID`, `ASC_API_KEY_ISSUER_ID`, `ASC_API_KEY_P8_BASE64`, `FASTLANE_TEAM_ID`) | 0 |
+| Bootstrap pipeline length | 14 steps | 14 steps (same — v1.6 collapsed the difference) |
 | Branch protection | 7 required CI checks | None (configure manually if you want) |
-| Required certs repo | yes (`<app>-certs` private repo) | no |
-| Auto-minted local certs | n/a — match handles it on the runner | yes — see "Cert provisioning" below |
+| Required certs repo | no (dropped in v1.6) | no |
+| Auto-minted signing certs | yes — release.yml mints fresh per run on the runner | yes — `bootstrap-fork` mints into your login Keychain (see "Cert provisioning" below) |
 
 Local-only mode is appropriate for:
 
 - **Solo indie shipping** — you trust your own laptop, no team workflow
 - **Personal apps** — no need to gate merges on CI
-- **Apps where match overhead exceeds benefit** — single dev, single machine, occasional ships
+- **Apps where running a release on a hosted runner is unwanted overhead** — single dev, single machine, occasional ships
 
 CI mode is the right default for everyone else (multi-dev, security-sensitive, or any case where local laptop drift would be a liability — see [docs/CONTINUOUS-VALIDATION.md](CONTINUOUS-VALIDATION.md) for why CI mode + the canary pattern matters).
 
@@ -51,14 +51,13 @@ ASC_APP_NAME='Your App'                        # display name on the App Store
 GH_ORG=your-username
 GH_APP_REPO=your-app
 
-# CI-only fields — leave blank for local-only mode:
-GH_CERTS_REPO=
-GH_PAT_FILE=
-MATCH_PASSWORD_FILE=
+# CI-only field — leave blank for local-only mode:
 KEYCHAIN_PASSWORD_FILE=
 ```
 
-`make doctor` detects `RELEASE_MODE=local` and skips the 5 CI-only steps (`EditMatchfile`, `CreateCertsRepo`, `GHSecrets`, `BootstrapCerts`, `MintInstaller`).
+If you bootstrapped before v1.6, your `.bootstrap.env` may still contain `GH_CERTS_REPO=`, `GH_PAT_FILE=`, and `MATCH_PASSWORD_FILE=` lines. They're harmless leftovers — `make doctor` and `bootstrap-fork` no longer read them. You can delete the lines whenever, but you don't have to.
+
+`make doctor` detects `RELEASE_MODE=local` and skips the CI-only step (`GHSecrets`). Pre-v1.6 there were 5 CI-only steps; v1.6 (#158) removed `EditMatchfile`, `CreateCertsRepo`, `BootstrapCerts`, and `MintInstaller` along with the match-based signing path that needed them.
 
 ### 2. Cert provisioning
 
@@ -121,8 +120,8 @@ Or in the GitHub web UI: Settings → Branches → main → Delete rule.
 The same `make ship` command works on your Mac as on CI. It:
 
 1. Reads `.bootstrap.env`
-2. Detects `RELEASE_MODE=local` → uses login-Keychain signing instead of match
-3. Runs `bundle exec fastlane release` to archive + export iOS .ipa + macOS .pkg
+2. Detects `RELEASE_MODE=local` → runs `bundle exec fastlane release` directly on your Mac, signing with the certs already in your login Keychain. (CI mode runs the same sigh-based release lane on a runner with fresh per-run certs; since v1.6 both paths converge on a single lane — `RELEASE_MODE` only routes _where_ the lane runs.)
+3. Archives + exports iOS .ipa + macOS .pkg
 4. Runs `fastlane pilot` to upload to TestFlight (with the `pilot_with_retry` 3-attempt exponential-backoff wrapper added in v1.2.0)
 5. Pushes a `vYYYY.WW.<run_number>` tag
 
@@ -141,9 +140,11 @@ You'll want CI mode if any of these become true:
 - A second human starts contributing
 - You ship from multiple machines
 - You want PR-time test signal (xcodebuild + xcodebuild test on every PR)
-- You want match-based shared signing across multiple developers (with `canary-local-mode.yml` already in the template, **continuous validation is no longer a CI-mode-only feature** — local-mode forks get it via the Saturday canary; see § "Continuous validation in local mode" below)
+- You want hermetic per-release signing — CI mode mints fresh signing certs on a clean macos-15 runner per release and revokes them after `always()`, so no laptop keychain drift can affect what ships
 
-The switch is reversible: change `RELEASE_MODE=ci`, run `make bootstrap-fork` (the now-active CI-only steps will run), restore the workflows + branch protection.
+(With `canary-local-mode.yml` already in the template, **continuous validation is no longer a CI-mode-only feature** — local-mode forks get it via the Saturday canary; see § "Continuous validation in local mode" below.)
+
+The switch is reversible: change `RELEASE_MODE=ci`, populate `KEYCHAIN_PASSWORD_FILE`, run `make bootstrap-fork` (it provisions the 5 required GH Secrets — `KEYCHAIN_PASSWORD`, `ASC_API_KEY_ID`, `ASC_API_KEY_ISSUER_ID`, `ASC_API_KEY_P8_BASE64`, `FASTLANE_TEAM_ID`), restore the workflows + branch protection. No certs repo, no PAT, no `MATCH_PASSWORD` — those went away in v1.6.
 
 ## Continuous validation in local mode
 
@@ -178,13 +179,15 @@ That's it. Saturday morning runs ship a clean canary build to TestFlight
 under your bundle ID + ASC app, verifying the entire local-mode shipping
 pipeline weekly.
 
+If you also enable CI-mode `release.yml` shippers on the same Apple team, note that each CI release run also occupies one DIST slot (and, when shipping macOS, one MAC_INSTALLER slot) for the lifetime of the run before revoking on `always()`. With the per-team caps above, simultaneous CI ships + canary runs + local-mode mints can collide on slot availability — plan for the total churn across local + CI + canary, not any single path in isolation.
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `make doctor` step 12 (`Local keychain has signing identities`) is `:pending` even after `make mint-local-certs` | Keychain access denied (Apple's keychain prompts) | Check `Console.app` for keychain prompts; click Allow when fastlane asks. Re-run. |
 | `make doctor` step 12 says "Found certs … but none for team X" | Your keychain has certs from a different team | `make mint-local-certs` mints a fresh cert for the right team. The wrong-team certs remain in your keychain (use Keychain Access to remove if desired). |
-| `fastlane cert` fails with "Could not create another …, reached the maximum" | Apple's per-team cert quota is full (DIST=3, DEV≥5, MAC_INSTALLER=2 — verified empirically May 2026; see [docs/CONTINUOUS-VALIDATION.md](CONTINUOUS-VALIDATION.md)) | `bundle exec fastlane list_certs` to enumerate, `bundle exec fastlane revoke_cert id:<id>` (singular) or `revoke_certs ids:A,B,C` (plural batch, idempotent) to revoke unused ones, then re-run. |
+| `fastlane cert` fails with "Could not create another …, reached the maximum" | Apple's per-team cert quota is full (DIST=3, DEV≥5, MAC_INSTALLER=2 — verified empirically May 2026; see [docs/CONTINUOUS-VALIDATION.md](CONTINUOUS-VALIDATION.md)). Remember CI-mode `release.yml` also briefly holds a DIST (+ MAC_INSTALLER on macOS ships) slot per run before revoking on `always()`, so heavy local + CI traffic can race. | `bundle exec fastlane list_certs` to enumerate, `bundle exec fastlane revoke_cert id:<id>` (singular) or `revoke_certs ids:A,B,C` (plural batch, idempotent) to revoke unused ones, then re-run. |
 | `make ship` fails uploading to TestFlight | Transient ASC / altool flake | The `pilot_with_retry` wrapper retries 3× with exponential backoff. If all 3 fail, check the smoketest's [G1–G15 catalog](CONTINUOUS-VALIDATION.md). |
 | `make all` aborts at doctor | Genuine `:blocked` step (e.g., ASC App record missing) | The blocker requires a manual one-time human step Apple's API doesn't allow. Doctor's tail names which step + what to do. |
 

--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -31,16 +31,21 @@ first and let's talk.
    warning.
 6. **The release pipeline is continuously validated by a public downstream.**
    [`indiagrams/ios-macos-smoketest`](https://github.com/indiagrams/ios-macos-smoketest)
-   runs **two** complementary canaries weekly to TestFlight against this
-   template's signing pattern: `release.yml` (CI mode, match-based) on
-   Mondays 09:00 UTC via `canary-trigger.yml`, and `canary-local-mode.yml`
-   (local mode, sigh-based, mint-then-revoke) on Saturdays 11:30 UTC.
+   runs **two** canaries weekly to TestFlight against this template's
+   signing pattern: `release.yml` (CI mode) on Mondays 09:00 UTC via
+   `canary-trigger.yml`, and `canary-local-mode.yml` (local mode) on
+   Saturdays 11:30 UTC. As of v1.6, both exercise the **same**
+   mint-fresh-cert-then-revoke code path — the architectural distinction
+   between "CI mode = match-based" and "local mode = sigh-based" that
+   prompted two separate canaries in v1.5 is gone. They remain as two
+   schedules to keep coverage cadence and as separate signals on the
+   smoketest dashboard; consolidating them is a separate workstream.
    Because Apple's signing infra (certs, profiles, `timestamp.apple.com`,
-   ASC ingestion) and the fastlane / match / pilot stacks drift
-   independently of this template, the smoketest catches rot before
-   forkers do. Patterns + fixes there land back here in PRs that cite
-   the failing smoketest run. See [`docs/CONTINUOUS-VALIDATION.md`](CONTINUOUS-VALIDATION.md)
-   for the catalog of canonical failure modes (currently 15) the smoketest
+   ASC ingestion) and the fastlane / pilot stacks drift independently
+   of this template, the smoketest catches rot before forkers do.
+   Patterns + fixes there land back here in PRs that cite the failing
+   smoketest run. See [`docs/CONTINUOUS-VALIDATION.md`](CONTINUOUS-VALIDATION.md)
+   for the catalog of canonical failure modes (currently 16) the smoketest
    has surfaced.
 
 ## Documentation

--- a/docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md
+++ b/docs/RELEASE-WITH-APPLE-NATIVE-TOOLS.md
@@ -21,15 +21,19 @@ The trade-off is genuine:
 |---|---|---|
 | Dependencies | Ruby + fastlane gem + plugins | None beyond Xcode |
 | Cold-run startup | ~3–5 s | <1 s |
-| Integrated metadata + screenshots + signing | ✓ (`deliver`, `snapshot`, `match`) | Manual (separate ASC API calls) |
+| Integrated metadata + screenshots + signing | ✓ (`deliver`, `snapshot`, `sigh` / `match`) | Manual (separate ASC API calls) |
 | macOS notarization (outside App Store) | via plugin or shell-out | `xcrun notarytool` (Apple-supported) |
 | Community + plugins | Mature, large | Apple-only |
 | Best for | Full release pipeline in one tool | "Build + upload" only; minimal-deps shops |
 
 Pick fastlane if you want one tool that does build + upload + screenshots
-+ metadata + signing-management (`match`). Pick Apple-native if you'd
-rather not depend on a Ruby gem and you're comfortable wiring the pieces
-together yourself.
++ metadata + signing-management. (As of v1.6 apple-shipkit's own fastlane
+lane uses `sigh` for profile fetching and mints fresh Apple Distribution
+certs per CI run via the App Store Connect API instead of routing through
+`match` + a certs repo — see [`docs/BOOTSTRAP.md`](BOOTSTRAP.md). `match`
+remains an option in the fastlane ecosystem if you'd rather keep a
+long-lived certs repo.) Pick Apple-native if you'd rather not depend on
+a Ruby gem and you're comfortable wiring the pieces together yourself.
 
 ## What this doc covers
 
@@ -44,10 +48,16 @@ together yourself.
 
 - **`fastlane match` replacement.** Manual cert + profile management is
   documented in [`docs/APPLE-PREREQS.md`](APPLE-PREREQS.md). Apple does
-  not ship a `match`-equivalent; if you leave fastlane, you take on cert
-  rotation manually (or use a third-party tool like
-  [`apple-actions/upload-testflight-build`](https://github.com/apple-actions)
-  or roll your own).
+  not ship a `match`-equivalent. Note that as of v1.6 the template's own
+  fastlane release lane no longer uses `match` either: CI mints a fresh
+  Apple Distribution cert per run via the App Store Connect API (and
+  revokes it on `always()`), and local mode signs with whatever
+  Distribution cert is already in your login Keychain. So if you're
+  leaving fastlane *for* the Apple-native path below, the cert story
+  inherits from the same baseline the template's fastlane path uses:
+  bring your own certs in the keychain, or script ASC API cert minting
+  yourself. (Or use a third-party helper like
+  [`apple-actions/upload-testflight-build`](https://github.com/apple-actions).)
 - **`fastlane snapshot` / `MacSnapfile` replacement.** Screenshot
   automation is genuinely fastlane-strong territory — there is no
   drop-in Apple-native equivalent. The template's
@@ -216,6 +226,16 @@ path is structurally broken in 2.233.1 (logs success but never POSTs
 the localization for fresh builds — see
 [`docs/CONTINUOUS-VALIDATION.md`](CONTINUOUS-VALIDATION.md) G15);
 the Apple-native equivalent below sidesteps that:
+
+> **Note:** As of v1.6, the template's own fastlane release lane already
+> performs this same POST/PATCH dance automatically via the
+> `annotate_testflight_whats_new` helper in
+> [`fastlane/Fastfile`](../fastlane/Fastfile) (added in #149). The recipe
+> below is for forkers shipping *outside* the v1.6 fastlane path — i.e.
+> you've replaced `fastlane release` entirely with `xcrun altool` + the
+> curl calls in this doc, and therefore need to do the BBL annotation by
+> hand. If you're still on the template's `fastlane release` lane, you
+> get this for free.
 
 ```bash
 APP_ID="1234567890"
@@ -514,7 +534,12 @@ What you give up by leaving fastlane:
 - **No `match`.** Cert + provisioning profile sync across machines is
   manual. You can install certs in the login Keychain by hand,
   re-download profiles from `developer.apple.com` when they expire, or
-  rely on `-allowProvisioningUpdates` to auto-create on first run.
+  rely on `-allowProvisioningUpdates` to auto-create on first run. (As
+  of v1.6 the template's own fastlane lane doesn't use `match` either —
+  CI mints a fresh Apple Distribution cert per run via the ASC API and
+  revokes it on `always()`; local mode signs from your login Keychain —
+  so the cert situation here is the same one the fastlane path lives
+  with.)
 - **No `precheck`.** Fastlane's pre-flight ASC linting (broken URLs,
   metadata length limits, prohibited keywords) is gone. You'll find
   these issues at App Review time instead. Run `Validate App` in

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -35,7 +35,7 @@ The tag's TestFlight build is still in ASC — handle that separately via the st
 
 ## Roll back a partial bootstrap-fork
 
-If `make bootstrap-fork` fails on step N (CI mode runs 18, local mode runs 14 — `make doctor` prints the live count), the pipeline is **idempotent** — re-running picks up where it left off:
+If `make bootstrap-fork` fails on step N (both CI mode and local mode run 14 steps in v1.6 — `make doctor` prints the live count), the pipeline is **idempotent** — re-running picks up where it left off:
 
 ```bash
 make doctor          # see which step is the next pending one
@@ -47,6 +47,19 @@ If a specific step keeps failing and you want to skip it (rare; usually means up
 1. Read the step's `check` and `do_it` methods in `bin/lib/bootstrap.rb`
 2. Either fix the upstream state manually (e.g. delete the conflicting bundle ID in Apple Developer portal, then re-run), or
 3. If the step is genuinely optional for your fork, delete it from the `PIPELINE` constant in `bin/lib/bootstrap.rb`. Don't skip it silently — leave a comment explaining why.
+
+## Roll back a failed release (mid-mint cert cleanup)
+
+Since v1.6, `release.yml` mints fresh signing certs at the start of every run and revokes them in an `if: always()` post-step — there's no certs repo to roll back, and no manual cert cleanup after a normal failed release. The post-step runs whether the build succeeded, failed, or was cancelled.
+
+If a runner crashes hard enough to skip the post-step (process killed, hosted runner evicted), the next `release.yml` run's pre-step revokes any orphan IDs tracked by the previous run via `actions/cache@v5`. Worst case: the orphan lingers until the next release.
+
+Manual cleanup is only needed if **both** the post-step and the cache miss (e.g. >7 days idle and cache evicted):
+
+1. https://developer.apple.com/account/resources/certificates/list
+2. Filter by recent date → revoke the orphan Apple Distribution / Apple Development / Mac Installer entries left by the failed run (~30 sec)
+
+> If you bootstrapped a fork before v1.6, leftover `GH_CERTS_REPO`, `GH_PAT_FILE`, and `MATCH_PASSWORD_FILE` entries in `.bootstrap.env`, plus a `MATCH_PASSWORD` / `MATCH_GIT_BASIC_AUTHORIZATION` pair in GitHub repo secrets, are harmless — `release.yml` no longer reads them. You can remove them at your convenience but nothing in v1.6 depends on their state.
 
 ## Reset a fork to a clean slate
 
@@ -60,35 +73,26 @@ If you want to nuke a fork's Apple-side state and start over (e.g. you used the 
 #    https://developer.apple.com/account/resources/identifiers/list
 #    Click bundle ID → bottom of page → Delete
 
-# 3. Optionally: clear the certs repo
-git -C path/to/your-certs-repo log  # see what's in it
-# fastlane match nuke distribution --readonly false   # nukes distro certs
-# fastlane match nuke development --readonly false    # nukes dev certs
-
-# 4. Re-run from a clean state
+# 3. Re-run from a clean state
 make bootstrap-fork
 ```
 
-**Caution:** `match nuke` revokes certificates Apple-side. If your other apps share this team, they'll need to re-mint. Only do this if you're sure no other app depends on these certs.
+There's no certs repo to clear in v1.6 — every `release.yml` run mints its own short-lived certs and revokes them in the `if: always()` post-step, so there's no persistent signing state attached to the fork.
 
 ## Reset the smoketest fork (maintainer-only)
 
-Two canaries run on the smoketest, with different rollback semantics:
+Two canaries run on the smoketest — `canary-trigger.yml` dispatching `release.yml` (Mondays 09:00 UTC) and `canary-local-mode.yml` (Saturdays 11:30 UTC). Since v1.6 both paths mint fresh certs per run and self-revoke via an `if: always()` post-step, so they're equivalent from a rollback standpoint.
 
-- **CI canary** (`canary-trigger.yml` dispatches `release.yml` on Mondays
-  09:00 UTC) — uses persistent shipping certs from the certs repo. If the
-  smoketest's signing state needs a reset, run `bin/refork-smoketest.sh`
-  (destructive E2E that recreates the smoketest fork from scratch).
-- **Local-mode canary** (`canary-local-mode.yml` on Saturdays 11:30 UTC) —
-  self-rolls back per run via the `if: always()` post-step that revokes the
-  3 just-minted certs. Orphan ids from a runner crash mid-mint are tracked
-  via `actions/cache@v5` and cleaned up by the next run's pre-step (worst
-  case: 1 week stale). If the cache is also lost (>7 days idle), revoke
-  manually at <https://developer.apple.com/account/resources/certificates>
-  (~30 sec). The canary's workflow header has the full failure-mode matrix.
+To reset the smoketest:
+
+```bash
+bin/refork-smoketest.sh   # destructive E2E that recreates the smoketest fork
+```
+
+No manual cert cleanup is required — both canaries revoke their minted certs at the end of every run, and orphans from a runner crash are reaped by the next run's pre-step (cache-tracked, worst case 1 week stale). If both the post-step and cache miss, revoke manually at <https://developer.apple.com/account/resources/certificates> (~30 sec). The canary's workflow header has the full failure-mode matrix.
 
 ## See also
 
 - [`docs/CONTINUOUS-VALIDATION.md`](CONTINUOUS-VALIDATION.md) — the catalog of Apple-side gotchas the canary has surfaced
 - [`docs/BOOTSTRAP.md`](BOOTSTRAP.md) — full `.bootstrap.env` reference
-- [`bin/lib/bootstrap.rb`](../bin/lib/bootstrap.rb) — the 19-step pipeline source
+- [`bin/lib/bootstrap.rb`](../bin/lib/bootstrap.rb) — the 15-step pipeline source (14 steps active per mode)


### PR DESCRIPTION
Closes the v1.6 doc workstream. Brings every user-facing doc in line with the post-#158/#160 architecture (mint-fresh CI, no match) and adds a Day-2-ops guide.

**Files updated**: README, BOOTSTRAP, NO-CI, APPLE-PREREQS, RELEASE-WITH-APPLE-NATIVE-TOOLS, ROLLBACK, PRINCIPLES, MIGRATING-TO-TUIST

**New file**: docs/MAINTAINING-A-FORK.md — first-timer-accessible cert lifecycle, APNs, App Store submission, quota management, Apple Developer renewal, retirement procedures.