### PR TITLE
cleanup: drop backward-compat narrative (no users to be backward-compatible with)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,8 +261,6 @@ KEYCHAIN_PASSWORD_FILE=                     # ~/.config/secrets/keychain-passwor
 
 > **Why two modes?** `RELEASE_MODE=local` signs from your laptop using certs in your Keychain — easy first-run, no server config needed. `RELEASE_MODE=ci` runs the full pipeline on GitHub Actions when you run `make ship` (which dispatches `release.yml` via `gh workflow run`) — more setup, but it means anyone with repo write access can ship from any machine. Each CI release run mints its own short-lived signing certs into a controlled keychain and revokes them when the run ends, so there's no shared certs repo or PAT to manage. Start with `local`. You can switch later.
 
-> **Bootstrapped before v1.6?** Older forks may still have `GH_CERTS_REPO`, `GH_PAT_FILE`, or `MATCH_PASSWORD_FILE` set in `.bootstrap.env`, plus `MATCH_PASSWORD` and `MATCH_GIT_BASIC_AUTHORIZATION` in their GH Secrets. They're harmless leftovers — the current pipeline ignores them. You can delete them at your leisure (or keep them; nothing reads them).
-
 > **Why pick a platform subset?** If you're shipping an iPhone-only app and don't care about Mac, set `PLATFORMS=ios` — `make doctor` will stop probing for the Mac Installer cert, `make ship` skips the macOS .pkg build/upload, and CI on PRs runs fewer jobs (saving ~2-4 min/PR of macOS runner time). Same in reverse for `PLATFORMS=macos`. Switchable later: change the value, re-run `make bootstrap-fork`. **In CI mode, also re-run `bin/setup-github.sh`** — the required-checks list is set on first bootstrap and won't update automatically when you flip platforms.
 
 ---

--- a/bin/lib/bootstrap.rb
+++ b/bin/lib/bootstrap.rb
@@ -29,10 +29,6 @@ module Bootstrap
   ENV_FILE  = REPO_ROOT.join(".bootstrap.env")
 
   # The 5 GH Secrets the release pipeline needs. Order: stable for doctor.
-  # v1.6 (#158) dropped MATCH_PASSWORD + MATCH_GIT_BASIC_AUTHORIZATION when
-  # release.yml moved from match-based signing to mint-fresh certs per run.
-  # Existing forks with these GH Secrets set: harmless leftovers; no action
-  # needed. Future bootstrap-fork runs no longer create them.
   REQUIRED_SECRETS = %w[
     KEYCHAIN_PASSWORD
     ASC_API_KEY_ID
@@ -50,10 +46,6 @@ module Bootstrap
       GH_ORG GH_APP_REPO
     ].freeze
 
-    # v1.6 (#158) dropped GH_CERTS_REPO, GH_PAT_FILE, MATCH_PASSWORD_FILE
-    # — release.yml no longer uses match (no certs repo, no PAT for it,
-    # no encryption password). Existing forks with these fields in their
-    # .bootstrap.env: harmless leftovers; doctor doesn't complain.
     REQUIRED_CI_ONLY = %w[
       KEYCHAIN_PASSWORD_FILE
     ].freeze

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -56,25 +56,9 @@ in v1.6+.
 
 You can switch modes later by editing `RELEASE_MODE` and re-running
 `make bootstrap-fork`. Going `local → ci`: bootstrap sets the 5 GH Secrets
-and configures branch protection. Going `ci → local`: bootstrap doesn't tear
-down the GH Secrets (they're harmless if `release.yml` is never triggered);
-CI just stops being invoked.
-
-### Pre-v1.6 forks: harmless leftovers
-
-If you bootstrapped before v1.6 (#158), your fork may still have:
-
-- `GH_CERTS_REPO`, `GH_PAT_FILE`, `MATCH_PASSWORD_FILE` lines in `.bootstrap.env`
-- `MATCH_PASSWORD` and `MATCH_GIT_BASIC_AUTHORIZATION` GH Secrets on the app repo
-- A private `<app>-certs` repo on GitHub
-- A fine-grained PAT pointed at the certs repo
-
-None of these are referenced by anything in the v1.6 pipeline. `make doctor`
-ignores them, `make bootstrap-fork` doesn't touch them, and `release.yml`
-no longer reads them. Safe to delete (recommended for cleanliness) or leave
-in place (no functional impact). Deleting the certs repo and revoking the
-PAT is the most defense-in-depth move, but neither is required.
-
+and configures branch protection. Going `ci → local`: bootstrap leaves the
+GH Secrets in place (they're inert if `release.yml` is never triggered)
+and CI just stops being invoked.
 ## Platforms
 
 `.bootstrap.env` has a `PLATFORMS` field that gates which targets get built, signed, and uploaded. Three valid values:

--- a/docs/MAINTAINING-A-FORK.md
+++ b/docs/MAINTAINING-A-FORK.md
@@ -224,7 +224,6 @@ apple-shipkit ships breaking changes occasionally (e.g. v1.6 dropped match-based
 1. **Read the CHANGELOG** for the version range you're crossing. Breaking changes are flagged.
 2. **Check `.bootstrap.env.example`** for new fields. Compare to your `.bootstrap.env`; add anything new.
 3. **Re-run `make doctor`**. If new required fields appear, doctor will tell you. Fix and re-run `make bootstrap-fork`.
-4. **Existing leftovers from old apple-shipkit versions are harmless** — apple-shipkit's doctor only complains about *missing* required fields, not present-extra ones. So old fields like `GH_CERTS_REPO`, `MATCH_PASSWORD_FILE`, etc. (removed in v1.6) can stay in your `.bootstrap.env` indefinitely without breaking anything.
 
 ## When things go sideways
 

--- a/docs/NO-CI.md
+++ b/docs/NO-CI.md
@@ -54,10 +54,7 @@ GH_APP_REPO=your-app
 # CI-only field — leave blank for local-only mode:
 KEYCHAIN_PASSWORD_FILE=
 ```
-
-If you bootstrapped before v1.6, your `.bootstrap.env` may still contain `GH_CERTS_REPO=`, `GH_PAT_FILE=`, and `MATCH_PASSWORD_FILE=` lines. They're harmless leftovers — `make doctor` and `bootstrap-fork` no longer read them. You can delete the lines whenever, but you don't have to.
-
-`make doctor` detects `RELEASE_MODE=local` and skips the CI-only step (`GHSecrets`). Pre-v1.6 there were 5 CI-only steps; v1.6 (#158) removed `EditMatchfile`, `CreateCertsRepo`, `BootstrapCerts`, and `MintInstaller` along with the match-based signing path that needed them.
+`make doctor` detects `RELEASE_MODE=local` and skips the CI-only step (`GHSecrets`).
 
 ### 2. Cert provisioning
 

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -58,9 +58,6 @@ Manual cleanup is only needed if **both** the post-step and the cache miss (e.g.
 
 1. https://developer.apple.com/account/resources/certificates/list
 2. Filter by recent date → revoke the orphan Apple Distribution / Apple Development / Mac Installer entries left by the failed run (~30 sec)
-
-> If you bootstrapped a fork before v1.6, leftover `GH_CERTS_REPO`, `GH_PAT_FILE`, and `MATCH_PASSWORD_FILE` entries in `.bootstrap.env`, plus a `MATCH_PASSWORD` / `MATCH_GIT_BASIC_AUTHORIZATION` pair in GitHub repo secrets, are harmless — `release.yml` no longer reads them. You can remove them at your convenience but nothing in v1.6 depends on their state.
-
 ## Reset a fork to a clean slate
 
 If you want to nuke a fork's Apple-side state and start over (e.g. you used the wrong bundle ID and want to free it up):


### PR DESCRIPTION
Removes the 'pre-v1.6 leftovers' callouts from #160 + #161. With no actual users on pre-v1.6 versions, the narrative is just noise. The CHANGELOG already records what changed; that's where 'we used to have GH_CERTS_REPO' belongs.

6 files, -37/+4 lines.