### PR TITLE
fix(bootstrap): @config not config in success summary (regression from #165)

### DIFF
--- a/bin/lib/bootstrap.rb
+++ b/bin/lib/bootstrap.rb
@@ -1002,10 +1002,10 @@ module Bootstrap
       puts
       puts UI.bold "✅ Bootstrap complete."
       puts
-      puts "What just happened on #{config.repo_slug}:"
-      puts "  - #{config['APP_NAME']} (#{config['BUNDLE_ID']}) project files committed"
+      puts "What just happened on #{@config.repo_slug}:"
+      puts "  - #{@config['APP_NAME']} (#{@config['BUNDLE_ID']}) project files committed"
       puts "  - Pushed directly to main (no GitHub PR opened — bootstrap-fork pushes straight)"
-      if config.ci_mode?
+      if @config.ci_mode?
         puts
         puts %(GitHub Actions starts a workflow named "PR" (file: .github/workflows/pr.yml))
         puts %(on every push, including this one. It is a CI sanity check, NOT a Pull Request,)


### PR DESCRIPTION
Typo in #165's new end-of-pipeline summary. Used bare `config` instead of `@config` (no `attr_reader :config` on Runner), causing:

```
✅ Bootstrap complete.
.../bin/lib/bootstrap.rb:1005:in 'bootstrap': undefined local variable or method 'config' for #<Bootstrap::Runner:...> (NameError)
```

The error fires after all pipeline steps complete and after the success banner prints, so the bootstrap actually did its work — but `make bootstrap-fork` returns exit 1, which is hostile to first-time forkers ('did it work? what now?').

4 lines: `config.repo_slug` → `@config.repo_slug`, etc.

Verified live by instantiating Runner with a stub config + empty @steps and watching the success summary render through the actual instance scope.