### PR TITLE
fix(verify-rename): exclude bin/lib/bootstrap.rb (sibling to #167)

### DIFF
--- a/bin/verify-rename.sh
+++ b/bin/verify-rename.sh
@@ -117,6 +117,7 @@ check_surface() {
               ':!ci/test-rename.sh' \
               ':!ci/test-rename-gates.sh' \
               ':!ci/test-verify-rename.sh' \
+              ':!bin/lib/bootstrap.rb' \
               ':!.github/workflows/bootstrap-doctor-matrix.yml')
   status=$?
   set -e


### PR DESCRIPTION
Closes the verify-rename leak audit gap left by #167. The matrix builder + bootstrap.rb's HelloApp keepers were excluded from substitution but not from the audit; this finishes the symmetry.