### PR TITLE
fix(release): annotate by ship-start-time, not by build_number

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -241,7 +241,7 @@ end
 # is the binary upload; "What to Test" is cosmetic.
 #
 # Returns nothing meaningful.
-def annotate_testflight_whats_new(app_identifier:, marketing_version:, build_number:, changelog:, expected_count:)
+def annotate_testflight_whats_new(app_identifier:, marketing_version:, ship_start_time:, changelog:, expected_count:)
   require "spaceship"
 
   Spaceship::ConnectAPI.token ||= Spaceship::ConnectAPI::Token.create(
@@ -256,9 +256,23 @@ def annotate_testflight_whats_new(app_identifier:, marketing_version:, build_num
     return
   end
 
-  # Cap at ~10 min total (40 × 15s). The canary's empirical observation:
-  # ASC indexing typically completes within 1-3 min after pilot returns,
-  # but we've seen up to ~6 min on backed-up Apple infra.
+  # Filter by ship_start_time, NOT by build_number. ASC/altool can auto-bump
+  # CFBundleVersion when a (CFBundleShortVersionString, CFBundleVersion) tuple
+  # collides with an existing build (common when prior shippers — earlier fork
+  # iterations, the canary, multi-dev teams — share the bundle id and burn
+  # build numbers under the same marketing version). The bumped value isn't
+  # visible to the lane (RELEASE_BUILD_NUMBER stays at github.run_number),
+  # so an old build_number-based filter would patch the wrong build.
+  #
+  # Time-window filter is robust: any build with app_version=marketing_version
+  # uploaded after this lane's start cannot belong to a prior shipper, only
+  # to this run. expected_count caps the take to defend against a parallel
+  # shipper sneaking an upload into the window.
+  #
+  # Pilot now blocks until ASC ingest (skip_waiting_for_build_processing
+  # dropped in apple-shipkit#169), so by the time we get here, the build is
+  # guaranteed-visible in Build.all. Poll loop kept defensively for short
+  # ASC indexing-lag windows.
   poll_attempts = 40
   targets = []
   poll_attempts.times do |i|
@@ -268,14 +282,17 @@ def annotate_testflight_whats_new(app_identifier:, marketing_version:, build_num
       sort:    "-uploadedDate",
       limit:   50,
     )
-    targets = builds.select { |b| b.version == build_number.to_s }
+    targets = builds.select do |b|
+      uploaded = (Time.parse(b.uploaded_date).utc rescue nil)
+      uploaded && uploaded >= ship_start_time
+    end.first(expected_count)
     break if targets.length >= expected_count
     sleep 15
-    UI.message("  poll #{i + 1}/#{poll_attempts}: found #{targets.length}/#{expected_count} build(s) with version=#{marketing_version} build=#{build_number}")
+    UI.message("  poll #{i + 1}/#{poll_attempts}: found #{targets.length}/#{expected_count} build(s) with version=#{marketing_version} uploaded after #{ship_start_time.iso8601}")
   end
 
   if targets.empty?
-    UI.important("Annotate: no builds matched version=#{marketing_version} build=#{build_number} after #{poll_attempts * 15}s; skipping What to Test.")
+    UI.important("Annotate: no builds matched version=#{marketing_version} uploaded after #{ship_start_time.iso8601} after #{poll_attempts * 15}s; skipping What to Test.")
     return
   end
 
@@ -832,6 +849,13 @@ platform :ios do
     # cloud-signing endpoint entirely.
     sh_env = { "RELEASE_BUNDLE_ID" => APP_IDENTIFIER }
 
+    # Capture lane start time for the time-window filter in Step 5/6's
+    # annotate step. Any TestFlight build with this app's marketing_version
+    # uploaded after this timestamp is by definition our build, regardless
+    # of what CFBundleVersion the binary ended up with after ASC's potential
+    # auto-bump.
+    ship_start_time = Time.now.utc
+
     bits = []
     bits << "iOS"   if do_ios
     bits << "macOS" if do_macos
@@ -982,13 +1006,12 @@ platform :ios do
         UI.important("Step 5/6: No changelog text resolved; skipping What to Test annotation.")
       else
         marketing_version = ENV["RELEASE_MARKETING_VERSION"].to_s.strip.empty? ? version.split("-", 2).first : ENV["RELEASE_MARKETING_VERSION"]
-        build_number      = ENV["RELEASE_BUILD_NUMBER"].to_s.strip.empty? ? "0" : ENV["RELEASE_BUILD_NUMBER"]
         expected_count    = (do_ios && do_macos) ? 2 : 1
-        UI.message("Step 5/6: Annotating What to Test in TestFlight (version=#{marketing_version} build=#{build_number}, expecting #{expected_count} build record#{expected_count == 1 ? '' : 's'})…")
+        UI.message("Step 5/6: Annotating What to Test in TestFlight (version=#{marketing_version}, after #{ship_start_time.iso8601}, expecting #{expected_count} build record#{expected_count == 1 ? '' : 's'})…")
         annotate_testflight_whats_new(
           app_identifier:    APP_IDENTIFIER,
           marketing_version: marketing_version,
-          build_number:      build_number,
+          ship_start_time:   ship_start_time,
           changelog:         changelog,
           expected_count:    expected_count,
         )


### PR DESCRIPTION
ASC auto-bumps CFBundleVersion on collision, so RELEASE_BUILD_NUMBER (= github.run_number) doesn't reliably match the build version ASC ingested. Switching annotate's filter to uploaded_date >= ship_start_time fixes the bug for good.

Symptom on prakashrj/my-cool-app run 25626987754: binary uploaded as build_version=4 (auto-bumped), annotate looked for build_version=1 and patched yesterday's already-populated build, leaving today's empty.

Pilot's wait-for-ASC-ingest (#169) means the just-uploaded build is visible by the time annotate runs; time-window filter picks it up on iteration #1.