### PR TITLE
docs: refresh stale pipeline-step + required-check counts

### DIFF
--- a/docs/NO-CI.md
+++ b/docs/NO-CI.md
@@ -11,8 +11,8 @@ This is the default mode shipped by `.bootstrap.env.example` since v1.3.0. Forks
 | Where `make ship` runs | GitHub Actions runner (macos-15) | Your Mac |
 | Code signing | Fresh certs minted into a controlled keychain per run, revoked on `always()` | Login Keychain (auto-minted by `bootstrap-fork`) |
 | Required GH Secrets | 5 (`KEYCHAIN_PASSWORD`, `ASC_API_KEY_ID`, `ASC_API_KEY_ISSUER_ID`, `ASC_API_KEY_P8_BASE64`, `FASTLANE_TEAM_ID`) | 0 |
-| Bootstrap pipeline length | 14 steps | 14 steps (same — v1.6 collapsed the difference) |
-| Branch protection | 7 required CI checks | None (configure manually if you want) |
+| Bootstrap pipeline length | 16 steps | 16 steps (same — v1.6 collapsed the difference) |
+| Branch protection | required CI checks set by `bin/setup-github.sh` (count varies by PLATFORMS + committed generator manifests — typically 8) | None (configure manually if you want) |
 | Required certs repo | no (dropped in v1.6) | no |
 | Auto-minted signing certs | yes — release.yml mints fresh per run on the runner | yes — `bootstrap-fork` mints into your login Keychain (see "Cert provisioning" below) |
 
@@ -110,7 +110,7 @@ Or in the GitHub web UI: Settings → Branches → main → Delete rule.
 
 ### 4. Skip `make setup-github`
 
-`bin/setup-github.sh` configures the 7 required CI checks. In local-only mode, don't run it — or remove it from your local `make all` flow if you wired it in.
+`bin/setup-github.sh` configures the required CI checks (count varies by PLATFORMS + committed generator manifests — typically 8). In local-only mode, don't run it — or remove it from your local `make all` flow if you wired it in.
 
 ## What `make ship` does in local-only mode
 

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -35,7 +35,7 @@ The tag's TestFlight build is still in ASC — handle that separately via the st
 
 ## Roll back a partial bootstrap-fork
 
-If `make bootstrap-fork` fails on step N (both CI mode and local mode run 14 steps in v1.6 — `make doctor` prints the live count), the pipeline is **idempotent** — re-running picks up where it left off:
+If `make bootstrap-fork` fails on step N (both CI mode and local mode run 16 steps post-v1.6 — `make doctor` prints the live count), the pipeline is **idempotent** — re-running picks up where it left off:
 
 ```bash
 make doctor          # see which step is the next pending one
@@ -92,4 +92,4 @@ No manual cert cleanup is required — both canaries revoke their minted certs a
 
 - [`docs/CONTINUOUS-VALIDATION.md`](CONTINUOUS-VALIDATION.md) — the catalog of Apple-side gotchas the canary has surfaced
 - [`docs/BOOTSTRAP.md`](BOOTSTRAP.md) — full `.bootstrap.env` reference
-- [`bin/lib/bootstrap.rb`](../bin/lib/bootstrap.rb) — the 15-step pipeline source (14 steps active per mode)
+- [`bin/lib/bootstrap.rb`](../bin/lib/bootstrap.rb) — the 17-step pipeline source (16 steps active per mode after mode-specific filtering)


### PR DESCRIPTION
## Refresh stale pipeline-step + required-check counts in docs/

While restructuring the README (#212 / smoketest #91), I caught three callsites in `docs/` that still claimed the doctor pipeline was 14 steps. Pipeline grew to 16 steps after #205 (`AppPrivacyForm`) and #211 (`XcodeQuarantine`); these doc references hadn't been swept.

### What changes

```diff
 docs/NO-CI.md:14
-| Bootstrap pipeline length | 14 steps | 14 steps |
+| Bootstrap pipeline length | 16 steps | 16 steps |

 docs/NO-CI.md:15
-| Branch protection | 7 required CI checks | None |
+| Branch protection | required CI checks set by bin/setup-github.sh (count
+  varies by PLATFORMS + committed generator manifests — typically 8) | None |

 docs/NO-CI.md:113
-`bin/setup-github.sh` configures the 7 required CI checks.
+`bin/setup-github.sh` configures the required CI checks (count varies by
+ PLATFORMS + committed generator manifests — typically 8).

 docs/ROLLBACK.md:38
-If make bootstrap-fork fails on step N (both CI mode and local mode run
-14 steps in v1.6 — make doctor prints the live count)
+If make bootstrap-fork fails on step N (both CI mode and local mode run
+16 steps post-v1.6 — make doctor prints the live count)

 docs/ROLLBACK.md:95
-the 15-step pipeline source (14 steps active per mode)
+the 17-step pipeline source (16 steps active per mode after mode-specific
+filtering)
```

### Where the numbers come from

| Surface | Count | Why |
|---|---|---|
| `PIPELINE` array in `bin/lib/bootstrap.rb` | 17 | Total step classes |
| `make doctor` per-mode display | 16 | Either `GHSecrets` (CI-only) or `LocalKeychainCerts` (local-only) drops out via `Step#applicable?` |
| `make doctor` with `PLATFORMS=ios` | 15 | `MakeIcons` is macOS-only |
| `bin/setup-github.sh` required CI checks (apple-shipkit default) | 8 | 4 generator cells × 2 (xcodegen + tuist) + 2 macOS cells + swiftlint + swiftformat |

The CI check count is derived at setup time, not pinned in source. Phrasing as "typically 8 (varies)" won't drift whenever a fork restricts PLATFORMS or runs `bin/switch-to-{xcodegen,tuist}.sh`.

### Cross-repo mirror

`indiagrams/ios-macos-smoketest#92`. Byte-equivalent diffs on both `docs/NO-CI.md` and `docs/ROLLBACK.md`.

```
$ diff apple-shipkit/docs/NO-CI.md ios-macos-smoketest/docs/NO-CI.md && echo "✓"
✓
$ diff apple-shipkit/docs/ROLLBACK.md ios-macos-smoketest/docs/ROLLBACK.md && echo "✓"
✓
```
