### PR TITLE
chore(canary): consolidate cron schedules to 07:00 UTC, weekend only

### DIFF
--- a/.github/workflows/bootstrap-doctor-matrix.yml
+++ b/.github/workflows/bootstrap-doctor-matrix.yml
@@ -33,7 +33,7 @@ name: bootstrap doctor matrix
 
 on:
   schedule:
-    - cron: '0 7 * * 1' # Mondays 07:00 UTC, day before canary-trigger's Tuesday release cron
+    - cron: '0 7 * * 1' # Mondays 07:00 UTC — read-only sweep after the Sat (local-mode) + Sun (CI-mode) canary ships. All three at 07:00 UTC for memorability.
   workflow_dispatch:
   pull_request:
     paths:

--- a/.github/workflows/canary-local-mode.yml
+++ b/.github/workflows/canary-local-mode.yml
@@ -67,7 +67,7 @@ name: canary-local-mode
 # Cache evicted (>7 days idle, never on a weekly cron) → orphans linger; manual
 # revoke via developer.apple.com/account/resources/certificates (30 sec).
 # User-driven mint contends during canary's 12-min window → fixed cron Saturdays
-# 11:30 UTC keeps the window predictable (separate from CI canary on Tuesdays).
+# 07:00 UTC keeps the window predictable (separate from CI canary on Sundays).
 #
 # ─── Generator matrix: xcodegen × tuist ───────────────────────────────────────
 #
@@ -107,10 +107,10 @@ on:
   #   2. running v1.5's one-time setup (revoke 1 spare DIST + 1 spare
   #      MAC_INSTALLER cert via the developer portal to dedicate cycling
   #      slots — see Phase 7 of `.planning/SMOKETEST_PLAN.md`)
-  # Cron is Saturdays 11:30 UTC to stay clear of the existing CI canary
-  # (canary-trigger.yml dispatches release.yml on Tuesdays 09:00 UTC).
+  # Cron is Saturdays 07:00 UTC to stay clear of the existing CI canary
+  # (canary-trigger.yml dispatches release.yml on Sundays 07:00 UTC).
   # schedule:
-  #   - cron: '30 11 * * 6'   # Saturdays 11:30 UTC
+  #   - cron: '0 7 * * 6'   # Saturdays 07:00 UTC
 
 permissions:
   contents: read

--- a/.github/workflows/canary-trigger.yml
+++ b/.github/workflows/canary-trigger.yml
@@ -22,7 +22,7 @@ name: canary-trigger
 
 on:
   schedule:
-    - cron: '0 9 * * 2'   # Tuesdays 09:00 UTC (was Mondays; moved to clear Apple TF upload throttle window from prior week's manual ships)
+    - cron: '0 7 * * 0'   # Sundays 07:00 UTC (alongside the smoketest's Sat 07:00 local-mode canary and the Mon 07:00 doctor matrix — all three at 07:00 UTC for memorability)
   workflow_dispatch:
     inputs:
       dry_run:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ I'm a first-time iOS developer. Before writing a feature of my actual app, I spe
 
 I automated or documented every requirement I encountered. That's what this template is — the boring prep work, done.
 
-A public canary fork ([`indiagrams/ios-macos-smoketest`](https://github.com/indiagrams/ios-macos-smoketest)) real-ships to TestFlight on two cadences: CI mode every Tuesday and local mode every Saturday, both on xcodegen and tuist generators, so Apple-side regressions surface upstream within a week. Catalog at [`docs/CONTINUOUS-VALIDATION.md`](docs/CONTINUOUS-VALIDATION.md).
+A public canary fork ([`indiagrams/ios-macos-smoketest`](https://github.com/indiagrams/ios-macos-smoketest)) real-ships to TestFlight on two cadences: CI mode every Sunday and local mode every Saturday, both on xcodegen and tuist generators, so Apple-side regressions surface upstream within a week. Catalog at [`docs/CONTINUOUS-VALIDATION.md`](docs/CONTINUOUS-VALIDATION.md).
 
 ---
 
@@ -83,8 +83,8 @@ The five-command journey hides:
 
 ### Continuous validation (against real Apple infrastructure)
 - **Mondays 07:00 UTC**: bootstrap doctor matrix (xcodegen | tuist × ci | local — 4 cells). Covers the toolchain.
-- **Tuesdays 09:00 UTC**: full CI-mode release ship to TestFlight, both generators. Covers the mint-fresh signing pipeline + Apple infrastructure.
-- **Saturdays 11:30 UTC**: full local-mode release ship to TestFlight, both generators. Covers the local signing pipeline (sigh, fresh-cert minting, β cert SHA-1 pinning, controlled keychain).
+- **Sundays 07:00 UTC**: full CI-mode release ship to TestFlight, both generators. Covers the mint-fresh signing pipeline + Apple infrastructure.
+- **Saturdays 07:00 UTC**: full local-mode release ship to TestFlight, both generators. Covers the local signing pipeline (sigh, fresh-cert minting, β cert SHA-1 pinning, controlled keychain).
 - **Bugs in fastlane / sigh / Apple's signing infra surface there first**, before they bite forks — patches land in this template before they hit your repo.
 
 ---

--- a/docs/CONTINUOUS-VALIDATION.md
+++ b/docs/CONTINUOUS-VALIDATION.md
@@ -9,11 +9,11 @@ public reference fork:
 
 Two canaries run there on complementary cadences:
 
-- **Tuesdays 09:00 UTC** — `canary-trigger.yml` dispatches `release.yml` on
+- **Sundays 07:00 UTC** — `canary-trigger.yml` dispatches `release.yml` on
   the smoketest. Exercises the **CI-mode** shipping path (match-based
   signing, certs sourced from a private repo via fastlane match). Pre-existing
   shipping certs; no mint/revoke loop.
-- **Saturdays 11:30 UTC** — `canary-local-mode.yml` runs in-place on the
+- **Saturdays 07:00 UTC** — `canary-local-mode.yml` runs in-place on the
   smoketest. Exercises the **local-mode** shipping path (sigh-based App Store
   profiles minted via API key, signing certs minted fresh into a controlled
   keychain, β cert SHA-1 pinning via `DeveloperCertificates[0]` from the
@@ -101,7 +101,7 @@ There are two opt-in canaries; pick whichever matches your fork's
   dispatches it weekly against the smoketest from upstream.
 - **Local mode** (`RELEASE_MODE=local`, sigh-based, no match) — uncomment
   the `schedule:` block in `.github/workflows/canary-local-mode.yml`
-  (default `30 11 * * 6` = Saturdays 11:30 UTC), configure five GH
+  (default `0 7 * * 6` = Saturdays 07:00 UTC), configure five GH
   Secrets on the fork (`ASC_API_KEY_ID`, `ASC_API_KEY_ISSUER_ID`,
   `ASC_API_KEY_P8_BASE64`, `FASTLANE_TEAM_ID`, `KEYCHAIN_PASSWORD`),
   and run the v1.5 one-time cert-slot dedication described in the

--- a/docs/NO-CI.md
+++ b/docs/NO-CI.md
@@ -148,7 +148,7 @@ The switch is reversible: change `RELEASE_MODE=ci`, populate `KEYCHAIN_PASSWORD_
 Local mode is no longer a "no canary" mode. The template ships
 `.github/workflows/canary-local-mode.yml`, which is dormant by default
 (workflow_dispatch only) and can be enabled by uncommenting its `schedule:`
-block (default `30 11 * * 6` = Saturdays 11:30 UTC).
+block (default `0 7 * * 6` = Saturdays 07:00 UTC).
 
 When enabled, the canary mints 3 throwaway signing certs into a controlled
 keychain on the GH runner, runs full `fastlane release` (sigh-based App

--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -32,9 +32,9 @@ first and let's talk.
 6. **The release pipeline is continuously validated by a public downstream.**
    [`indiagrams/ios-macos-smoketest`](https://github.com/indiagrams/ios-macos-smoketest)
    runs **two** canaries weekly to TestFlight against this template's
-   signing pattern: `release.yml` (CI mode) on Mondays 09:00 UTC via
+   signing pattern: `release.yml` (CI mode) on Sundays 07:00 UTC via
    `canary-trigger.yml`, and `canary-local-mode.yml` (local mode) on
-   Saturdays 11:30 UTC. As of v1.6, both exercise the **same**
+   Saturdays 07:00 UTC. As of v1.6, both exercise the **same**
    mint-fresh-cert-then-revoke code path — the architectural distinction
    between "CI mode = match-based" and "local mode = sigh-based" that
    prompted two separate canaries in v1.5 is gone. They remain as two

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -97,7 +97,7 @@ There's no certs repo to clear in v1.6 — every `release.yml` run mints its own
 
 ## Reset the smoketest fork (maintainer-only)
 
-Two canaries run on the smoketest — `canary-trigger.yml` dispatching `release.yml` (Tuesdays 09:00 UTC) and `canary-local-mode.yml` (Saturdays 11:30 UTC). Since v1.6 both paths mint fresh certs per run and self-revoke via an `if: always()` post-step, so they're equivalent from a rollback standpoint.
+Two canaries run on the smoketest — `canary-trigger.yml` dispatching `release.yml` (Sundays 07:00 UTC) and `canary-local-mode.yml` (Saturdays 07:00 UTC). Since v1.6 both paths mint fresh certs per run and self-revoke via an `if: always()` post-step, so they're equivalent from a rollback standpoint.
 
 To reset the smoketest:
 


### PR DESCRIPTION
Three canary workflows are now scheduled at a uniform **07:00 UTC**:

| Day | Workflow | What |
|---|---|---|
| **Sat 07:00 UTC** | `canary-local-mode.yml` (smoketest) | full local-mode release ship to TestFlight |
| **Sun 07:00 UTC** | `canary-trigger.yml` (apple-shipkit) | full CI-mode release ship to TestFlight |
| **Mon 07:00 UTC** | `bootstrap-doctor-matrix.yml` (apple-shipkit) | read-only doctor matrix (xcodegen × tuist × ci × local) |

Same time of day, three days in a row. Easier to remember; nicer operational rhythm (Sat ship + Sun ship + Mon read-only sweep, all complete by Monday morning Pacific time).

### Changes

- `canary-trigger.yml`: cron **Tuesdays 09:00 UTC → Sundays 07:00 UTC**
- `canary-local-mode.yml` (template): commented cron updated from Saturdays 11:30 → Saturdays 07:00; narrative comments refreshed (smoketest-fork instructions, cross-canary context)
- `bootstrap-doctor-matrix.yml`: comment refreshed to mention both Sat + Sun canary ships; cron itself unchanged (already Mon 07:00 UTC)
- `README.md` / `docs/CONTINUOUS-VALIDATION.md` / `docs/NO-CI.md` / `docs/PRINCIPLES.md` / `docs/ROLLBACK.md`: schedule narrative sweep

### Cross-repo mirror

`indiagrams/ios-macos-smoketest#99` — and that mirror PR **also re-enables the smoketest's actual schedule**, which was inadvertently re-commented by PR #85's cp-mirror (same regression class as #96). The Saturday local-mode canary has been silently OFF since 2026-05-11; last successful Saturday run was 2026-05-09.