### PR TITLE
refactor: eliminate the two cp-mirror divergence points (Fastfile + canary schedule)

### DIFF
--- a/.github/workflows/canary-local-mode.yml
+++ b/.github/workflows/canary-local-mode.yml
@@ -101,16 +101,32 @@ on:
         required: false
         type: boolean
         default: false
-  # workflow_dispatch only by default. To enable weekly canary on a fork
-  # (e.g. the smoketest), uncomment the schedule block below AFTER:
-  #   1. configuring all 5 GH Secrets above
-  #   2. running v1.5's one-time setup (revoke 1 spare DIST + 1 spare
-  #      MAC_INSTALLER cert via the developer portal to dedicate cycling
-  #      slots — see Phase 7 of `.planning/SMOKETEST_PLAN.md`)
-  # Cron is Saturdays 07:00 UTC to stay clear of the existing CI canary
-  # (canary-trigger.yml dispatches release.yml on Sundays 07:00 UTC).
-  # schedule:
-  #   - cron: '0 7 * * 6'   # Saturdays 07:00 UTC
+  # The schedule below is always uncommented in BOTH apple-shipkit (template)
+  # and ios-macos-smoketest (live canary). The job-level `if:` gate at the
+  # bottom of this file is what decides whether the scheduled run actually
+  # executes work: enable the canary on a fork by setting the
+  # `CANARY_ENABLED` repo variable to `true` via:
+  #
+  #   gh variable set CANARY_ENABLED --body true --repo <owner>/<fork>
+  #
+  # On forks without the variable (apple-shipkit included), the Saturday
+  # 07:00 UTC trigger fires but the job is skipped — a single grey check
+  # on the Actions tab, no work performed. This pattern keeps the workflow
+  # file byte-equivalent across template + fork (no cp-mirror divergence).
+  #
+  # Cross-canary timing: the CI canary fires Sundays 07:00 UTC via
+  # canary-trigger.yml on apple-shipkit. The doctor matrix fires Mondays
+  # 07:00 UTC via bootstrap-doctor-matrix.yml. All three at 07:00 UTC for
+  # memorability.
+  #
+  # One-time setup required on the fork before flipping the variable:
+  #   1. Configure all 5 GH Secrets enumerated in canary's
+  #      `bin/setup-github.sh --canary` flow
+  #   2. Revoke 1 spare DIST + 1 spare MAC_INSTALLER cert on the fork's
+  #      Apple team to dedicate cycling slots (see Phase 7 of
+  #      `.planning/SMOKETEST_PLAN.md` in the smoketest repo).
+  schedule:
+    - cron: '0 7 * * 6'   # Saturdays 07:00 UTC
 
 permissions:
   contents: read
@@ -127,6 +143,12 @@ concurrency:
 jobs:
   canary:
     name: Local-mode shipping path canary (${{ matrix.generator }})
+    # Gate: scheduled runs ONLY execute on forks that have flipped the
+    # repo variable CANARY_ENABLED=true (see the comment block on the
+    # schedule trigger above). Manual workflow_dispatch always runs.
+    # This keeps apple-shipkit's Actions tab quiet (single grey "skipped"
+    # marker on Sat 07:00 UTC) while the smoketest actually ships.
+    if: ${{ github.event_name == 'workflow_dispatch' || vars.CANARY_ENABLED == 'true' }}
     runs-on: macos-15
     timeout-minutes: 60
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -49,13 +49,48 @@ before_all do
   asc_api_key
 end
 
-# ─── Shared helpers ───────────────────────────────────────────────────────────
+# ─── Per-fork identity ────────────────────────────────────────────────────────
+#
+# APP_NAME + BUNDLE_ID are the only two values that differ between this
+# template and any fork made from it. Reading them at lane-resolution time
+# from .bootstrap.env (with ENV-var override for CI workflows) keeps this
+# entire file byte-equivalent across apple-shipkit, ios-macos-smoketest,
+# and every downstream fork.
+#
+# Resolution chain (first non-nil wins):
+#   1. ENV["APP_NAME"]  / ENV["BUNDLE_ID"]   — workflow secrets, manual override
+#   2. <repo-root>/.bootstrap.env values     — per-fork tracked config
+#   3. Template fallbacks ("HelloApp" / "com.example.helloapp") — fail-loud
+#      defaults; if a real ship hits these, the cert / bundle-id lookups
+#      against Apple will surface "not registered" immediately.
+#
+# All other Fastfile constants (IOS_SCHEME, MACOS_SCHEME, IPA_NAME_PATTERN,
+# PKG_NAME_PATTERN, bundle_name) are computed from APP_NAME. Forks no longer
+# need bin/rename.sh to sed-substitute Fastfile literals.
 
-APP_IDENTIFIER     = "com.example.helloapp"
-IOS_SCHEME         = "HelloApp-iOS"
-MACOS_SCHEME       = "HelloApp-macOS"
-IPA_NAME_PATTERN   = "HelloApp-%s.ipa"   # printf with version
-PKG_NAME_PATTERN   = "HelloApp-%s.pkg"
+def _fork_config
+  bootstrap_env = File.join(File.dirname(__FILE__), "..", ".bootstrap.env")
+  return {} unless File.exist?(bootstrap_env)
+  File.foreach(bootstrap_env).each_with_object({}) do |line, h|
+    line = line.strip
+    next if line.empty? || line.start_with?("#")
+    k, v = line.split("=", 2)
+    next unless k && v
+    # Strip surrounding quotes (env values may be quoted) + drop inline `# …` comments.
+    v = v.sub(/\s+#.*\z/, "")
+    v = v.gsub(/\A['"]|['"]\z/, "")
+    h[k.strip] = v.strip
+  end
+end
+
+_FORK_CONFIG       = _fork_config
+
+APP_NAME           = ENV["APP_NAME"]  || _FORK_CONFIG["APP_NAME"]  || "HelloApp"
+APP_IDENTIFIER     = ENV["BUNDLE_ID"] || _FORK_CONFIG["BUNDLE_ID"] || "com.example.helloapp"
+IOS_SCHEME         = "#{APP_NAME}-iOS"
+MACOS_SCHEME       = "#{APP_NAME}-macOS"
+IPA_NAME_PATTERN   = "#{APP_NAME}-%s.ipa"   # printf with version
+PKG_NAME_PATTERN   = "#{APP_NAME}-%s.pkg"
 
 def asc_api_key
   # Decode .p8 to a tmpfile and pass key_filepath instead of key_content +
@@ -803,7 +838,7 @@ lane :register_app_id do
   asc_api_key  # sets Spaceship::ConnectAPI.token globally
 
   bundle_id_str = APP_IDENTIFIER
-  bundle_name   = "HelloApp"
+  bundle_name   = APP_NAME
 
   existing = Spaceship::ConnectAPI::BundleId.all(filter: { identifier: bundle_id_str }).first
 


### PR DESCRIPTION
Closes the cp-mirror regression class that produced #96 and #99 this turn.

## The problem

Two divergence points between apple-shipkit (template) and ios-macos-smoketest (live canary) were being repeatedly clobbered by mirror PRs using `cp apple-shipkit/<file> smoketest/<file>`:

1. **`fastlane/Fastfile`** — 6 lines of per-fork constants (`APP_IDENTIFIER`, `IOS_SCHEME`, `MACOS_SCHEME`, `IPA_NAME_PATTERN`, `PKG_NAME_PATTERN`, `bundle_name`). Reverted by PR #94 → Tuesday cron failed (#96).

2. **`.github/workflows/canary-local-mode.yml`** — 2-line uncomment of the `schedule:` block. Reverted by PR #85 → Saturday cron silently OFF for 3 weeks (#99).

## Phase 1: Fastfile env-driven constants

Replace 6 hardcoded literals with values computed from `.bootstrap.env`:

```ruby
_FORK_CONFIG       = _fork_config   # parses .bootstrap.env

APP_NAME           = ENV["APP_NAME"]  || _FORK_CONFIG["APP_NAME"]  || "HelloApp"
APP_IDENTIFIER     = ENV["BUNDLE_ID"] || _FORK_CONFIG["BUNDLE_ID"] || "com.example.helloapp"
IOS_SCHEME         = "#{APP_NAME}-iOS"
MACOS_SCHEME       = "#{APP_NAME}-macOS"
IPA_NAME_PATTERN   = "#{APP_NAME}-%s.ipa"
PKG_NAME_PATTERN   = "#{APP_NAME}-%s.pkg"
# (bundle_name at line 841 now reads APP_NAME)
```

Resolution chain validated across all three trees:

| Tree | .bootstrap.env present | APP_NAME resolved | BUNDLE_ID resolved |
|---|---|---|---|
| apple-shipkit (template, no env) | no | `HelloApp` (fallback) | `com.example.helloapp` (fallback) |
| ios-macos-smoketest | yes | `SmokeApp` (from env) | `com.indiagram.smoke-app` (from env) |
| prakashrj/my-cool-app | yes | `SmokeApp` (from env) | `com.indiagram.smoke-app` (from env) |

## Phase 2: Canary schedule via repo variable

Move the smoketest-specific schedule activation **out of the file** and into a repo-level variable. Both `canary-local-mode.yml` files now have `schedule: - cron: '0 7 * * 6'` uncommented (byte-equivalent). The job has a gate:

```yaml
if: ${{ github.event_name == 'workflow_dispatch' || vars.CANARY_ENABLED == 'true' }}
```

Operational behavior:

- Both repos register the Sat 07:00 UTC cron.
- smoketest: `CANARY_ENABLED=true` repo var set → job runs.
- apple-shipkit: var unset → `if:` evaluates false → single grey "skipped" marker on the Actions tab. Cosmetic noise, zero cost.
- Manual `workflow_dispatch` always runs (development override).

Variable already set as part of this PR's preparation:

```
$ gh variable set CANARY_ENABLED --body true --repo indiagrams/ios-macos-smoketest
$ gh variable list --repo indiagrams/ios-macos-smoketest
  CANARY_ENABLED  true  2026-05-12T12:46:37Z
```

apple-shipkit's variable list is empty (verified).

## Why repo variables instead of separate workflow files

The cleaner architectural alternative — move the schedule entirely into `canary-trigger.yml` (apple-shipkit-only) and have it dispatch `canary-local-mode.yml` on smoketest — was considered and rejected. `canary-local-mode.yml` has its own internal 2-generator sequential matrix; `canary-trigger.yml` has a per-cell matrix. Composing them requires conditional matrix logic. Repo variable is one line, zero additional files, and the cost is one cosmetic skipped run per week on apple-shipkit's Actions tab.

## Cross-repo mirror

`indiagrams/ios-macos-smoketest#100`. Both files now **byte-equivalent** between repos. Future cp-mirrors are safe — there is no per-fork state in either file.