### PR TITLE
chore(doctor-matrix): drop redundant cron trigger for doctor job

### DIFF
--- a/.github/workflows/bootstrap-doctor-matrix.yml
+++ b/.github/workflows/bootstrap-doctor-matrix.yml
@@ -5,7 +5,14 @@
 #                               (xcodegen|tuist × ci|local), against real GH +
 #                               Apple state via the smoketest fork. Catches
 #                               schema breaks, mode-branching bugs, side state
-#                               drift. Runs on Mondays 07:00 UTC.
+#                               drift. Runs on PR (any change to bootstrap
+#                               surface) and workflow_dispatch; SKIPPED on
+#                               cron because the Sat (local-mode) + Sun (CI-mode)
+#                               destructive canary ships already exercise this
+#                               surface via fastlane. The cron trigger remains
+#                               on the workflow for the two regression jobs
+#                               below — those are hermetic and cheap, worth
+#                               weekly sanity coverage against runner-image drift.
 #
 #   parser-regression         — hermetic test of Bootstrap::Config.parse against
 #                               a fixture that mimics the .bootstrap.env.example
@@ -33,7 +40,7 @@ name: bootstrap doctor matrix
 
 on:
   schedule:
-    - cron: '0 7 * * 1' # Mondays 07:00 UTC — read-only sweep after the Sat (local-mode) + Sun (CI-mode) canary ships. All three at 07:00 UTC for memorability.
+    - cron: '0 7 * * 1' # Mondays 07:00 UTC — fires `parser-regression` + `bundle-guard-regression` only. The `doctor` matrix is SKIPPED on cron (see `if:` gate on that job — its surface is covered by Sat + Sun destructive canary ships).
   workflow_dispatch:
   pull_request:
     paths:
@@ -81,7 +88,17 @@ jobs:
     # `workflow_dispatch` re-run cover post-merge verification of action-version
     # bumps. Maintainers who want PR-time doctor coverage on Dependabot bumps
     # can populate the parallel Dependabot secret store with the same 6 secrets.
-    if: github.repository == 'indiagrams/apple-shipkit' && github.actor != 'dependabot[bot]'
+    # SKIP on schedule events: the Sat (local-mode) + Sun (CI-mode) destructive
+    # canary ships already exercise this surface via fastlane within 24-48h of
+    # any Monday cron run. The doctor matrix's unique value is PR-time pre-merge
+    # feedback on changes to bootstrap.rb / doctor.rb / Fastfile / Makefile.
+    # Cron-triggered runs of this workflow only fire the two regression jobs below.
+    #
+    # Other gates: skip on forks (workflow references indiagrams/ios-macos-smoketest
+    # by hardcoded path and uses secrets configured only on this repo). Skip on
+    # Dependabot PRs (those runs don't expose Actions secrets — GitHub security
+    # policy). Manual workflow_dispatch on this repo always runs.
+    if: github.event_name != 'schedule' && github.repository == 'indiagrams/apple-shipkit' && github.actor != 'dependabot[bot]'
     runs-on: macos-15
     timeout-minutes: 15
     strategy:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The five-command journey hides:
 - **`bin/preflight.sh`** — one-shot prerequisite checker; clone temporarily, run, get a report on what's missing and how to install it.
 
 ### Continuous validation (against real Apple infrastructure)
-- **Mondays 07:00 UTC**: bootstrap doctor matrix (xcodegen | tuist × ci | local — 4 cells). Covers the toolchain.
+- **PR-time, on any change to `bin/lib/bootstrap.rb` / `bin/doctor.rb` / `fastlane/Fastfile` / `.bootstrap.env.example` / `Makefile`**: bootstrap doctor matrix (xcodegen | tuist × ci | local — 4 cells). Catches doctor/bootstrap pipeline regressions before merge. Plus weekly hermetic regression tests (parser, bundle-guard) Mondays 07:00 UTC against runner-image drift.
 - **Sundays 07:00 UTC**: full CI-mode release ship to TestFlight, both generators. Covers the mint-fresh signing pipeline + Apple infrastructure.
 - **Saturdays 07:00 UTC**: full local-mode release ship to TestFlight, both generators. Covers the local signing pipeline (sigh, fresh-cert minting, β cert SHA-1 pinning, controlled keychain).
 - **Bugs in fastlane / sigh / Apple's signing infra surface there first**, before they bite forks — patches land in this template before they hit your repo.


### PR DESCRIPTION
## What

Adds `github.event_name != 'schedule'` to the `doctor` job's `if:` clause so it stops running on the Monday 07:00 UTC cron. The workflow's `schedule:` trigger stays — the two hermetic regression jobs (`parser-regression`, `bundle-guard-regression`) keep firing weekly.

## Why

The Sat (local-mode) + Sun (CI-mode) destructive canary ships exercise the same Apple/GH surface that the doctor matrix probes — and within 24-48h of any Monday cron run. The doctor matrix's cron coverage was almost fully redundant.

What stays valuable:
- **PR-time pre-merge feedback** — full 4-cell matrix on any PR touching bootstrap surface (`bin/lib/bootstrap.rb`, `bin/doctor.rb`, `.bootstrap.env.example`, `Makefile`, `fastlane/Fastfile`)
- **workflow_dispatch on demand** — maintainers can re-run any time
- **Hermetic regression jobs on Monday cron** — they're cheap (seconds, no secrets) and protect against runner-image Ruby/Bundler drift

## Cosmetic effect

Monday 07:00 UTC workflow runs show **4 grey "skipped" doctor cells + 2 green regression cells**, instead of all 6 running. Same gate-by-condition pattern as `canary-local-mode.yml`'s `CANARY_ENABLED` on apple-shipkit.

## Net

Removes ~5 min/week of Apple+GH probe runtime. Preserves all unique value of the workflow.

## Cross-repo mirror

`indiagrams/ios-macos-smoketest#101` (README docs-only mirror — `bootstrap-doctor-matrix.yml` lives only on apple-shipkit).