### PR TITLE
chore(canary): consolidate Sat+Sun crons into one Sat 07:00 sweep

### DIFF
--- a/.github/workflows/canary-local-mode.yml
+++ b/.github/workflows/canary-local-mode.yml
@@ -101,32 +101,6 @@ on:
         required: false
         type: boolean
         default: false
-  # The schedule below is always uncommented in BOTH apple-shipkit (template)
-  # and ios-macos-smoketest (live canary). The job-level `if:` gate at the
-  # bottom of this file is what decides whether the scheduled run actually
-  # executes work: enable the canary on a fork by setting the
-  # `CANARY_ENABLED` repo variable to `true` via:
-  #
-  #   gh variable set CANARY_ENABLED --body true --repo <owner>/<fork>
-  #
-  # On forks without the variable (apple-shipkit included), the Saturday
-  # 07:00 UTC trigger fires but the job is skipped — a single grey check
-  # on the Actions tab, no work performed. This pattern keeps the workflow
-  # file byte-equivalent across template + fork (no cp-mirror divergence).
-  #
-  # Cross-canary timing: the CI canary fires Sundays 07:00 UTC via
-  # canary-trigger.yml on apple-shipkit. The doctor matrix fires Mondays
-  # 07:00 UTC via bootstrap-doctor-matrix.yml. All three at 07:00 UTC for
-  # memorability.
-  #
-  # One-time setup required on the fork before flipping the variable:
-  #   1. Configure all 5 GH Secrets enumerated in canary's
-  #      `bin/setup-github.sh --canary` flow
-  #   2. Revoke 1 spare DIST + 1 spare MAC_INSTALLER cert on the fork's
-  #      Apple team to dedicate cycling slots (see Phase 7 of
-  #      `.planning/SMOKETEST_PLAN.md` in the smoketest repo).
-  schedule:
-    - cron: '0 7 * * 6'   # Saturdays 07:00 UTC
 
 permissions:
   contents: read
@@ -143,12 +117,12 @@ concurrency:
 jobs:
   canary:
     name: Local-mode shipping path canary (${{ matrix.generator }})
-    # Gate: scheduled runs ONLY execute on forks that have flipped the
-    # repo variable CANARY_ENABLED=true (see the comment block on the
-    # schedule trigger above). Manual workflow_dispatch always runs.
-    # This keeps apple-shipkit's Actions tab quiet (single grey "skipped"
-    # marker on Sat 07:00 UTC) while the smoketest actually ships.
-    if: ${{ github.event_name == 'workflow_dispatch' || vars.CANARY_ENABLED == 'true' }}
+    # Dispatched by apple-shipkit's canary-trigger.yml on the weekly Sat 07:00
+    # UTC cron, sequenced after the two CI-mode ships. Also runs on manual
+    # workflow_dispatch for ad-hoc validation. No `schedule:` trigger on this
+    # file itself — the weekly cron lives entirely in canary-trigger.yml on
+    # apple-shipkit so both repos' canary-local-mode.yml stay byte-equivalent
+    # without per-fork divergence.
     runs-on: macos-15
     timeout-minutes: 60
 

--- a/.github/workflows/canary-trigger.yml
+++ b/.github/workflows/canary-trigger.yml
@@ -22,7 +22,7 @@ name: canary-trigger
 
 on:
   schedule:
-    - cron: '0 7 * * 0'   # Sundays 07:00 UTC (alongside the smoketest's Sat 07:00 local-mode canary and the Mon 07:00 doctor matrix — all three at 07:00 UTC for memorability)
+    - cron: '0 7 * * 6'   # Saturdays 07:00 UTC — single weekly canary cron; dispatches BOTH the CI-mode (release.yml) and local-mode (canary-local-mode.yml) ships on the smoketest in sequence. Doctor-matrix regression jobs fire Mon 07:00 UTC.
   workflow_dispatch:
     inputs:
       dry_run:
@@ -54,23 +54,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
-      # Run both generators every Monday so distribution-signing regressions
-      # specific to one generator surface here. fail-fast=false ensures the
-      # tuist cell still runs if xcodegen fails (or vice versa) — useful when
-      # one cell breaks and you want to know if the other does too.
-      # max-parallel=1 forces sequential dispatch so the timestamp-based
-      # locate step in each cell finds an unambiguous "dispatched-after-our-baseline"
-      # run. The dispatched release.yml's concurrency:group:release would
-      # serialize anyway, but explicit serialization keeps the trigger logic
-      # simpler.
+      # Three sequential cells weekly so every canary surface gets exercised:
+      #   1. CI-mode xcodegen ship (dispatches smoketest's release.yml)
+      #   2. CI-mode tuist ship    (dispatches smoketest's release.yml)
+      #   3. Local-mode ship       (dispatches canary-local-mode.yml, which
+      #                             internally iterates both generators)
+      # max-parallel=1 forces sequential dispatch. Apple's 3-distribution-cert
+      # quota is enough headroom for 1 outstanding cert at a time, and the
+      # timestamp-based `locate` step needs an unambiguous baseline per cell.
+      # fail-fast=false ensures the local-mode cell still runs even if a
+      # CI-mode cell fails (or vice versa).
       fail-fast: false
       max-parallel: 1
       matrix:
-        generator: [xcodegen, tuist]
+        include:
+          - { name: "CI-mode ship (xcodegen)",  target: release.yml,           generator: xcodegen }
+          - { name: "CI-mode ship (tuist)",     target: release.yml,           generator: tuist }
+          - { name: "Local-mode ship",          target: canary-local-mode.yml, generator: "" }
+
+    name: ${{ matrix.name }}
 
     env:
       TARGET_REPO: indiagrams/ios-macos-smoketest
-      TARGET_WORKFLOW: release.yml
+      TARGET_WORKFLOW: ${{ matrix.target }}
       TARGET_REF: main
       GH_TOKEN: ${{ secrets.SMOKETEST_DISPATCH_PAT }}
       GENERATOR: ${{ matrix.generator }}
@@ -97,18 +103,29 @@ jobs:
           echo "baseline=${baseline}" >> "${GITHUB_OUTPUT}"
           echo "Baseline (only runs created after this count): ${baseline}"
 
-      - name: Dispatch smoketest release (${{ matrix.generator }})
+      - name: Dispatch ${{ matrix.name }}
         run: |
           dry_run='${{ inputs.dry_run }}'
           dry_run="${dry_run:-false}"
-          echo "Dispatching ${TARGET_REPO} ${TARGET_WORKFLOW} on ref=${TARGET_REF} dry_run=${dry_run} generator=${GENERATOR} platforms=${PLATFORMS}"
-          gh workflow run "${TARGET_WORKFLOW}" \
-            --repo "${TARGET_REPO}" \
-            --ref "${TARGET_REF}" \
-            -f version='' \
-            -f "dry_run=${dry_run}" \
-            -f "generator=${GENERATOR}" \
-            -f "platforms=${PLATFORMS}"
+          echo "Dispatching ${TARGET_REPO} ${TARGET_WORKFLOW} on ref=${TARGET_REF} dry_run=${dry_run}"
+          if [ "${TARGET_WORKFLOW}" = "release.yml" ]; then
+            # CI-mode ship: release.yml takes per-generator + platforms inputs.
+            echo "  inputs: generator=${GENERATOR} platforms=${PLATFORMS}"
+            gh workflow run "${TARGET_WORKFLOW}" \
+              --repo "${TARGET_REPO}" \
+              --ref "${TARGET_REF}" \
+              -f version='' \
+              -f "dry_run=${dry_run}" \
+              -f "generator=${GENERATOR}" \
+              -f "platforms=${PLATFORMS}"
+          else
+            # Local-mode ship: canary-local-mode.yml only takes dry_run; it
+            # iterates both generators internally via its own matrix.
+            gh workflow run "${TARGET_WORKFLOW}" \
+              --repo "${TARGET_REPO}" \
+              --ref "${TARGET_REF}" \
+              -f "dry_run=${dry_run}"
+          fi
 
       - name: Locate the dispatched run
         id: locate
@@ -174,7 +191,7 @@ jobs:
         if: failure()
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_CANARY_WEBHOOK }}
-          GENERATOR: ${{ matrix.generator }}
+          CELL_NAME: ${{ matrix.name }}
           RUN_URL: ${{ steps.locate.outputs.run_url }}
           TRIGGER_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
@@ -187,10 +204,10 @@ jobs:
           # Discord webhook expects {"content": "..."} or {"embeds": [...]}.
           # Keep payload simple — links speak louder than prose for diagnosis.
           payload=$(jq -nc \
-            --arg gen   "${GENERATOR}"        \
             --arg run   "${RUN_URL:-(unknown)}"     \
             --arg trig  "${TRIGGER_URL}"            \
-            '{ content: ":rotating_light: **Canary failed** — generator=\($gen)\nSmoketest run: \($run)\nTrigger run: \($trig)" }')
+            --arg cell  "${CELL_NAME}"              \
+            '{ content: ":rotating_light: **Canary failed** — \($cell)\nSmoketest run: \($run)\nTrigger run: \($trig)" }')
           curl -fsSL -X POST -H 'Content-Type: application/json' -d "${payload}" "${DISCORD_WEBHOOK}" \
             && echo "Posted Discord notification." \
             || echo "::warning::Discord notification failed (webhook URL may be invalid; check secret). Continuing."

--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ The five-command journey hides:
 
 ### Continuous validation (against real Apple infrastructure)
 - **PR-time, on any change to `bin/lib/bootstrap.rb` / `bin/doctor.rb` / `fastlane/Fastfile` / `.bootstrap.env.example` / `Makefile`**: bootstrap doctor matrix (xcodegen | tuist × ci | local — 4 cells). Catches doctor/bootstrap pipeline regressions before merge. Plus weekly hermetic regression tests (parser, bundle-guard) Mondays 07:00 UTC against runner-image drift.
-- **Sundays 07:00 UTC**: full CI-mode release ship to TestFlight, both generators. Covers the mint-fresh signing pipeline + Apple infrastructure.
-- **Saturdays 07:00 UTC**: full local-mode release ship to TestFlight, both generators. Covers the local signing pipeline (sigh, fresh-cert minting, β cert SHA-1 pinning, controlled keychain).
+- **Saturdays 07:00 UTC**: full canary sweep — apple-shipkit's `canary-trigger.yml` orchestrates 3 sequential ships on the smoketest fork against real Apple infrastructure: CI-mode xcodegen (`release.yml`), CI-mode tuist (`release.yml`), then local-mode (`canary-local-mode.yml`, which internally runs both generators). ~35–40 min total. Covers the mint-fresh CI signing pipeline, the local sigh-based signing pipeline, and both project generators. Apple-side regressions surface upstream within a week.
 - **Bugs in fastlane / sigh / Apple's signing infra surface there first**, before they bite forks — patches land in this template before they hit your repo.
 
 ---

--- a/docs/CONTINUOUS-VALIDATION.md
+++ b/docs/CONTINUOUS-VALIDATION.md
@@ -7,18 +7,15 @@ public reference fork:
 
 > [`indiagrams/ios-macos-smoketest`](https://github.com/indiagrams/ios-macos-smoketest)
 
-Two canaries run there on complementary cadences:
+The canary sweep runs once weekly on a single cron, with three sequential cells:
 
-- **Sundays 07:00 UTC** — `canary-trigger.yml` dispatches `release.yml` on
-  the smoketest. Exercises the **CI-mode** shipping path (match-based
-  signing, certs sourced from a private repo via fastlane match). Pre-existing
-  shipping certs; no mint/revoke loop.
-- **Saturdays 07:00 UTC** — `canary-local-mode.yml` runs in-place on the
-  smoketest. Exercises the **local-mode** shipping path (sigh-based App Store
-  profiles minted via API key, signing certs minted fresh into a controlled
-  keychain, β cert SHA-1 pinning via `DeveloperCertificates[0]` from the
-  .mobileprovision). Mint→ship→verify→revoke loop in the same Apple team;
-  net team-cert delta per run = 0.
+- **Saturdays 07:00 UTC** — apple-shipkit's `canary-trigger.yml` orchestrates a 3-cell sequential matrix against the smoketest:
+  1. dispatch `release.yml` with `generator=xcodegen` → exercises **CI-mode** shipping with the mint-fresh-cert pattern (cert minted into a controlled keychain on the runner, revoked in an `if: always()` post-step).
+  2. dispatch `release.yml` with `generator=tuist` → same as above but against the Tuist project manifest.
+  3. dispatch `canary-local-mode.yml` → exercises **local-mode** shipping (sigh-based App Store profiles minted via API key, signing certs minted fresh into a controlled keychain, β cert SHA-1 pinning via `DeveloperCertificates[0]` from the .mobileprovision). Internally runs both generators sequentially.
+
+  Net runtime ~35–40 min; net Apple-team cert delta = 0 per run (every mint paired with a revoke).
+- (was: separate Saturday + Sunday crons through #221; consolidated to a single Saturday cron in #222 for simpler operational rhythm).
 
 Either canary going red means the pipeline has broken somewhere between
 fastlane, match (CI-mode only), Apple's signing infrastructure, the ASC API,
@@ -99,14 +96,7 @@ There are two opt-in canaries; pick whichever matches your fork's
   setup. The same `release.yml` then runs on `workflow_dispatch` and
   whenever you tag a release; `canary-trigger.yml` (template-only)
   dispatches it weekly against the smoketest from upstream.
-- **Local mode** (`RELEASE_MODE=local`, sigh-based, no match) — uncomment
-  the `schedule:` block in `.github/workflows/canary-local-mode.yml`
-  (default `0 7 * * 6` = Saturdays 07:00 UTC), configure five GH
-  Secrets on the fork (`ASC_API_KEY_ID`, `ASC_API_KEY_ISSUER_ID`,
-  `ASC_API_KEY_P8_BASE64`, `FASTLANE_TEAM_ID`, `KEYCHAIN_PASSWORD`),
-  and run the v1.5 one-time cert-slot dedication described in the
-  cert-caps bullet above. Optional `DISCORD_CANARY_WEBHOOK` for failure
-  notifications.
+- **Local mode** (`RELEASE_MODE=local`, sigh-based, no match) — apple-shipkit's `canary-trigger.yml` already dispatches `canary-local-mode.yml` on the smoketest as part of its Saturday sweep. To run the same canary against your own fork on a schedule, fork apple-shipkit, set `SMOKETEST_DISPATCH_PAT` + `DISCORD_CANARY_WEBHOOK` secrets on it, point `TARGET_REPO` at your fork, and configure the five GH Secrets on the target fork (`ASC_API_KEY_ID`, `ASC_API_KEY_ISSUER_ID`, `ASC_API_KEY_P8_BASE64`, `FASTLANE_TEAM_ID`, `KEYCHAIN_PASSWORD`). Plus the v1.5 one-time cert-slot dedication from the cert-caps bullet above. For an ad-hoc one-shot, just `gh workflow run canary-local-mode.yml --repo <your-fork>` (no apple-shipkit infrastructure required).
 
 Either way, the workflow runs against your fork's bundle ID + ASC app
 record + signing identity — same shape as the smoketest.

--- a/docs/NO-CI.md
+++ b/docs/NO-CI.md
@@ -146,11 +146,17 @@ The switch is reversible: change `RELEASE_MODE=ci`, populate `KEYCHAIN_PASSWORD_
 ## Continuous validation in local mode
 
 Local mode is no longer a "no canary" mode. The template ships
-`.github/workflows/canary-local-mode.yml`, which is dormant by default
-(workflow_dispatch only) and can be enabled by uncommenting its `schedule:`
-block (default `0 7 * * 6` = Saturdays 07:00 UTC).
+`.github/workflows/canary-local-mode.yml`, which runs on
+`workflow_dispatch` only — no `schedule:` trigger of its own. The
+weekly Sat 07:00 UTC cron lives entirely in apple-shipkit's
+`canary-trigger.yml`, which dispatches `canary-local-mode.yml` on
+the smoketest as one of its three sequential canary cells. Forks
+that want their own local-mode canary either:
 
-When enabled, the canary mints 3 throwaway signing certs into a controlled
+- **Manual / ad-hoc**: `gh workflow run canary-local-mode.yml --repo <your-fork>` whenever you want a one-shot validation. No additional setup beyond the standard 5 GH Secrets enumerated below.
+- **Scheduled**: fork apple-shipkit, point `canary-trigger.yml`'s `TARGET_REPO` at your fork, configure `SMOKETEST_DISPATCH_PAT` (a fine-grained PAT on your fork with `Actions: Read and write`), and let the apple-shipkit-fork's Saturday cron dispatch into your fork's `canary-local-mode.yml`.
+
+When the canary runs, it mints 3 throwaway signing certs into a controlled
 keychain on the GH runner, runs full `fastlane release` (sigh-based App
 Store profiles, no match), uploads to TestFlight, then revokes the 3
 just-minted certs on `always()`. Net Apple-team cert delta per run = 0;
@@ -169,8 +175,8 @@ Prerequisites for enabling on your fork:
    cycling slot per at-cap type so the canary can mint without hitting
    Apple's per-team caps. See [docs/CONTINUOUS-VALIDATION.md](CONTINUOUS-VALIDATION.md)
    for the empirical caps (DIST=3, DEV≥5, MAC_INSTALLER=2).
-3. Uncomment the `schedule:` block in
-   `.github/workflows/canary-local-mode.yml`.
+3. (Scheduled path only) fork apple-shipkit and configure
+   `SMOKETEST_DISPATCH_PAT` + `TARGET_REPO` to point at your fork.
 
 That's it. Saturday morning runs ship a clean canary build to TestFlight
 under your bundle ID + ASC app, verifying the entire local-mode shipping

--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -31,15 +31,16 @@ first and let's talk.
    warning.
 6. **The release pipeline is continuously validated by a public downstream.**
    [`indiagrams/ios-macos-smoketest`](https://github.com/indiagrams/ios-macos-smoketest)
-   runs **two** canaries weekly to TestFlight against this template's
-   signing pattern: `release.yml` (CI mode) on Sundays 07:00 UTC via
-   `canary-trigger.yml`, and `canary-local-mode.yml` (local mode) on
-   Saturdays 07:00 UTC. As of v1.6, both exercise the **same**
-   mint-fresh-cert-then-revoke code path — the architectural distinction
-   between "CI mode = match-based" and "local mode = sigh-based" that
-   prompted two separate canaries in v1.5 is gone. They remain as two
-   schedules to keep coverage cadence and as separate signals on the
-   smoketest dashboard; consolidating them is a separate workstream.
+   runs a **single weekly canary sweep** to TestFlight against this template's
+   signing pattern. Apple-shipkit's `canary-trigger.yml` fires once on
+   Saturdays 07:00 UTC and orchestrates three sequential cells against the
+   smoketest: CI-mode xcodegen (`release.yml`), CI-mode tuist (`release.yml`),
+   and local-mode (`canary-local-mode.yml`, which internally iterates both
+   generators). As of v1.6, all three exercise the **same** mint-fresh-cert-
+   then-revoke code path — the architectural distinction between "CI mode =
+   match-based" and "local mode = sigh-based" from v1.5 is gone. They remain
+   as three cells to give the smoketest dashboard separate signals per
+   shipping path.
    Because Apple's signing infra (certs, profiles, `timestamp.apple.com`,
    ASC ingestion) and the fastlane / pilot stacks drift independently
    of this template, the smoketest catches rot before forkers do.

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -97,7 +97,7 @@ There's no certs repo to clear in v1.6 — every `release.yml` run mints its own
 
 ## Reset the smoketest fork (maintainer-only)
 
-Two canaries run on the smoketest — `canary-trigger.yml` dispatching `release.yml` (Sundays 07:00 UTC) and `canary-local-mode.yml` (Saturdays 07:00 UTC). Since v1.6 both paths mint fresh certs per run and self-revoke via an `if: always()` post-step, so they're equivalent from a rollback standpoint.
+A single weekly canary sweep runs on the smoketest — apple-shipkit's `canary-trigger.yml` orchestrates 3 sequential ships on Saturdays 07:00 UTC: CI-mode xcodegen (`release.yml`), CI-mode tuist (`release.yml`), and local-mode (`canary-local-mode.yml`). All three paths mint fresh certs per run and self-revoke via `if: always()` post-steps, so they're equivalent from a rollback standpoint.
 
 To reset the smoketest:
 


### PR DESCRIPTION
## Before → After

| | Before | After |
|---|---|---|
| Cron schedules | 2 (Sat + Sun) | **1 (Sat)** |
| Orchestrator | split across two workflow files | `canary-trigger.yml` only |
| canary-local-mode.yml schedule | yes (with `vars.CANARY_ENABLED` gate) | none |
| Per-fork divergence | `vars.CANARY_ENABLED` repo var on smoketest | **zero** |
| Total weekly runtime | ~10 min Sun + ~24 min Sat = ~34 min | ~35–40 min Sat sequential |

## The new shape

Saturday 07:00 UTC fires `canary-trigger.yml`. A 3-cell sequential matrix dispatches three smoketest workflows in order:

1. **CI-mode ship (xcodegen)** → `release.yml` with `generator=xcodegen`
2. **CI-mode ship (tuist)** → `release.yml` with `generator=tuist`
3. **Local-mode ship** → `canary-local-mode.yml` (which internally runs both generators sequentially)

`max-parallel=1` enforces sequencing — Apple's 3-distribution-cert quota then has comfortable headroom (1 outstanding cert at a time). `fail-fast=false` ensures one failing cell doesn't suppress the others.

## What goes away

- The `schedule:` block in `canary-local-mode.yml` (was uncommented in both repos with a `vars.CANARY_ENABLED` job gate as of #220).
- The `vars.CANARY_ENABLED` repo variable on smoketest (deleted as part of this PR's prep — `gh variable list --repo indiagrams/ios-macos-smoketest` now empty).
- The weekly cosmetic "skipped" workflow run on apple-shipkit's Actions tab (apple-shipkit no longer has its own Saturday 07:00 schedule on `canary-local-mode.yml`).

## Architectural win

`canary-local-mode.yml` is now **truly byte-equivalent** between apple-shipkit and smoketest — no schedule, no gate, no per-fork divergence. The Sat cron lives entirely in `canary-trigger.yml`, which is apple-shipkit-only. The cp-mirror pattern for this file is now 100% safe (continuing the work of #220).

## Files changed

- `.github/workflows/canary-trigger.yml` — refactored to 3-cell matrix
- `.github/workflows/canary-local-mode.yml` — schedule + gate removed
- `README.md` — "Continuous validation" section consolidated
- `docs/CONTINUOUS-VALIDATION.md` — bullet collapse + local-mode-canary-enable refresh
- `docs/ROLLBACK.md` — single-canary phrasing
- `docs/PRINCIPLES.md` — three-cells-one-sweep phrasing
- `docs/NO-CI.md` — refreshed forker-side enable instructions (no schedule block to uncomment)

## Cross-repo mirror

`indiagrams/ios-macos-smoketest#102`. All 6 mirrored files byte-equivalent.

## First validation

Sat 2026-05-16 07:00 UTC = first natural run of the consolidated canary. Or for ad-hoc validation now: `gh workflow run canary-trigger.yml --repo indiagrams/apple-shipkit`.