### PR TITLE
fix(workflows): wire vars.APP_NAME + vars.BUNDLE_ID into fastlane env

### DIFF
--- a/.github/workflows/canary-local-mode.yml
+++ b/.github/workflows/canary-local-mode.yml
@@ -102,6 +102,13 @@ on:
         type: boolean
         default: false
 
+# Workflow-level env: bring fork identity from repo variables (see release.yml
+# header for the rationale + the two required `gh variable set` invocations).
+# Same pattern; same fail-loud behavior if unset.
+env:
+  APP_NAME:  ${{ vars.APP_NAME }}
+  BUNDLE_ID: ${{ vars.BUNDLE_ID }}
+
 permissions:
   contents: read
   actions: read   # required for actions/cache to read prior cache entries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,22 @@ on:
         type: string
         default: ''
 
+# Workflow-level env: bring fork identity (APP_NAME, BUNDLE_ID) from repo
+# variables into every step's env. The fastlane Fastfile's APP_NAME +
+# APP_IDENTIFIER constants resolve via ENV first; .bootstrap.env is
+# gitignored so the CI runner can't read it on disk. Forks enabling CI
+# release must configure these two repo variables:
+#
+#   gh variable set APP_NAME  --body <YourApp> --repo <owner>/<fork>
+#   gh variable set BUNDLE_ID --body <com.you.app> --repo <owner>/<fork>
+#
+# If unset, the Fastfile falls through to its template defaults
+# (HelloApp / com.example.helloapp) which Apple rejects at bundle-id
+# registration (com.example.* is reserved) — fail-loud by design.
+env:
+  APP_NAME:  ${{ vars.APP_NAME }}
+  BUNDLE_ID: ${{ vars.BUNDLE_ID }}
+
 # Serialize releases. cancel-in-progress: false → if a manual dispatch lands
 # during another release run, the dispatch waits rather than aborting mid-mint
 # (a cancelled mint can leave orphans even with the always()-post-step,
@@ -259,20 +275,21 @@ jobs:
         # Manual override: workflow_dispatch's `version` input wins. Useful
         # when re-shipping a previously-tagged version or when ASC is
         # unreachable.
-        env:
-          BUNDLE_ID: ${{ secrets.BUNDLE_ID }}
         run: |
           set -euo pipefail
           if [ -n "${{ inputs.version }}" ]; then
             VERSION="${{ inputs.version }}"
           else
-            # Bundle id from .bootstrap.env (real shippers commit this) or
-            # from fastlane/Fastfile's APP_IDENTIFIER (the canonical source
-            # bin/rename.sh sets during fork creation). Either works for
-            # bin/compute-release-tag.rb's pure-env mode.
+            # BUNDLE_ID comes from the workflow-level env block at the top of
+            # this file, which reads vars.BUNDLE_ID. The check below is a
+            # defensive guard for forks that haven't configured the variable
+            # yet — fail loud with an actionable error instead of falling
+            # through to a build that tags the wrong bundle ID.
             if [ -z "${BUNDLE_ID:-}" ]; then
-              BUNDLE_ID=$(grep '^APP_IDENTIFIER' fastlane/Fastfile | head -1 | sed 's/.*= *"\(.*\)"/\1/')
-              export BUNDLE_ID
+              echo "::error::vars.BUNDLE_ID is not set on this repo. Configure it via:"
+              echo "::error::  gh variable set BUNDLE_ID --body <com.you.app> --repo \${{ github.repository }}"
+              echo "::error::Also set APP_NAME the same way."
+              exit 1
             fi
             VERSION=$(bundle exec ruby bin/compute-release-tag.rb)
           fi


### PR DESCRIPTION
Closes the canary regression surfaced by #222's first end-to-end test on 2026-05-12.

## What broke

#220's Fastfile refactor moved `APP_NAME` + `APP_IDENTIFIER` to a runtime resolution chain:

1. `ENV["APP_NAME"]` / `ENV["BUNDLE_ID"]`
2. `.bootstrap.env` file in repo root
3. Template fallback (`HelloApp` / `com.example.helloapp`)

On a developer's Mac, `.bootstrap.env` exists in the working tree and Fastfile reads from it. **On a CI runner, `.bootstrap.env` is gitignored and absent** — Fastfile falls through to the fallback, which Apple rejects at bundle-id registration (`com.example.*` is reserved namespace per RFC 2606).

Surfaced on the first end-to-end test of #222's consolidated canary:

```
[!] {
      "errors" : [ {
        "code" : "ENTITY_ERROR.ATTRIBUTE.INVALID",
        "detail" : "An App ID with Identifier 'com.example.helloapp' is not available.
                     Please enter a different string."
      } ]
    }
```

All three matrix cells failed at the same point. The trigger logic itself is fine — this is a downstream Fastfile-environment issue.

## The fix

Workflow-level `env:` block in both `release.yml` and `canary-local-mode.yml`:

```yaml
env:
  APP_NAME:  ${{ vars.APP_NAME }}
  BUNDLE_ID: ${{ vars.BUNDLE_ID }}
```

Forks enabling CI release configure two repo variables:

```
gh variable set APP_NAME  --body <YourApp>     --repo <owner>/<fork>
gh variable set BUNDLE_ID --body <com.you.app> --repo <owner>/<fork>
```

These are **not secrets** — they appear on App Store listings and TestFlight URLs anyway. `vars.*` is the correct primitive.

The smoketest's vars are already set:

```
$ gh variable list --repo indiagrams/ios-macos-smoketest
APP_NAME    SmokeApp                   2026-05-12T14:34:51Z
BUNDLE_ID   com.indiagram.smoke-app    2026-05-12T14:34:51Z
```

apple-shipkit (the template repo) doesn't set these because it never ships.

## Additional cleanup

Also drops a stale step-level `secrets.BUNDLE_ID` reference in `compute release tag` step (was always unset; was a dead fallback). Replaces the grep-based BUNDLE_ID extraction from Fastfile (which extracted the fallback literal after #220's refactor) with a fail-loud guard pointing at the required `gh variable set` invocations.

## Cross-repo mirror

`indiagrams/ios-macos-smoketest#103`. Both workflow files byte-equivalent. After merge, I'll re-dispatch `canary-trigger.yml` to validate end-to-end.