### PR TITLE
fix(canary): use env-driven BUNDLE_ID in verify-testflight step

### DIFF
--- a/.github/workflows/canary-local-mode.yml
+++ b/.github/workflows/canary-local-mode.yml
@@ -499,11 +499,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          # BUNDLE_ID — the canonical source for any fork is fastlane/Fastfile's
-          # APP_IDENTIFIER constant (set by bin/rename.sh during fork creation).
-          BUNDLE_ID=$(grep '^APP_IDENTIFIER' fastlane/Fastfile | head -1 | sed 's/.*= *"\(.*\)"/\1/')
+          # BUNDLE_ID comes from the workflow-level env block at the top of
+          # this file, which reads vars.BUNDLE_ID. Fail-loud guard if a fork
+          # hasn't configured the repo variable yet.
           if [ -z "${BUNDLE_ID:-}" ]; then
-            echo "::error::Could not extract APP_IDENTIFIER from fastlane/Fastfile"
+            echo "::error::vars.BUNDLE_ID is not set on this repo. Configure it via:"
+            echo "::error::  gh variable set BUNDLE_ID --body <com.you.app> --repo ${{ github.repository }}"
+            echo "::error::Also set APP_NAME the same way."
             exit 1
           fi
 


### PR DESCRIPTION
Closes the second-half failure surfaced by #223's first end-to-end test on 2026-05-12. Both CI-mode cells went green; local-mode cells failed at 'Verify TestFlight ingestion'.

Root cause: the 'Populate .bootstrap.env' step extracted BUNDLE_ID by grepping APP_IDENTIFIER from `fastlane/Fastfile`. #220's Fastfile refactor changed that line from a literal to an expression with multiple double-quoted substrings, and the sed pattern no longer matches. BUNDLE_ID got set to the raw Ruby line.

Fix: use `BUNDLE_ID` from env (already populated by #223's workflow-level env block from `vars.BUNDLE_ID`). Fail-loud guard for unconfigured forks.

Mirror: `indiagrams/ios-macos-smoketest#104`.