### PR TITLE
feat(ci): opt-in Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,87 @@
+name: dependabot-automerge
+
+# Enables GitHub's native auto-merge on Dependabot PRs so routine dependency
+# bumps land themselves once the required checks (pr.yml's 8 contexts) pass,
+# instead of the maintainer merging each one by hand every week.
+#
+# HOW IT WORKS
+#   On every Dependabot PR this workflow reads the update metadata and, when
+#   the update tier is allowed, calls `gh pr merge --auto --squash`. That flips
+#   on branch-native auto-merge: GitHub holds the PR until all required status
+#   checks are green (branch protection: 8 contexts, 0 reviews, non-strict),
+#   then squash-merges and deletes the branch. If a check goes red, nothing
+#   merges — the PR just sits until a human intervenes. No approval step is
+#   involved (main requires 0 reviews; GITHUB_TOKEN cannot self-approve anyway).
+#
+# OPT-IN (fork-safe)
+#   Inert unless the `DEPENDABOT_AUTOMERGE` repo variable is set. Forks inherit
+#   this file but nothing auto-merges until they opt in:
+#     gh variable set DEPENDABOT_AUTOMERGE --body true   # patch + minor (recommended)
+#     gh variable set DEPENDABOT_AUTOMERGE --body all    # patch + minor + major
+#   Unset / any other value = disabled.
+#
+# TIERS
+#   'true' auto-merges semver-patch and semver-minor only; semver-major bumps
+#   are left for a human (a major — e.g. actions/checkout v6 -> v7 — can carry
+#   behavioral change the PR matrix doesn't fully exercise, e.g. fastlane's
+#   ship/upload path). Set 'all' to also auto-merge majors. Bundler majors are
+#   already unreachable here: the Gemfile pins fastlane `~> 2.224`, so
+#   Dependabot never proposes an out-of-range major gem.
+#
+# SECURITY
+#   Uses `pull_request` (not `pull_request_target`) and never checks out or
+#   executes PR content — it only calls the GitHub API — so the elevated
+#   token grants can't be abused by a malicious PR payload.
+
+on:
+  pull_request:
+    branches: [main, master]
+
+# Least-privilege, but enough to enable auto-merge on the PR. The repo's
+# default workflow token is read-only; these declarations override that for
+# this workflow only. Honored for Dependabot-triggered runs.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    # Only Dependabot's own PRs, and only when the opt-in variable is set.
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      (vars.DEPENDABOT_AUTOMERGE == 'true' || vars.DEPENDABOT_AUTOMERGE == 'all')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge (squash)
+        # Merge tier gate: always allow patch/minor; allow major only in 'all'
+        # mode. `gh pr merge --auto` is idempotent — re-running on a PR that
+        # already has auto-merge enabled is a no-op, not an error.
+        if: >-
+          steps.meta.outputs.update-type != 'version-update:semver-major' ||
+          vars.DEPENDABOT_AUTOMERGE == 'all'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Note held major bump
+        # Leaves a one-time breadcrumb so a held major is visible in the PR
+        # instead of silently waiting. Only fires for majors in the default
+        # ('true') tier.
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-major' &&
+          vars.DEPENDABOT_AUTOMERGE != 'all'
+        run: |
+          gh pr comment "$PR_URL" --body \
+            "🤖 Held for manual review: this is a **major** bump (\`${{ steps.meta.outputs.update-type }}\`) and \`DEPENDABOT_AUTOMERGE\` is \`true\` (patch/minor only). Review and merge by hand, or set the variable to \`all\` to auto-merge majors too." \
+            || echo "::warning::could not post held-major comment (continuing)"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `.github/workflows/dependabot-automerge.yml` — opt-in workflow that enables GitHub-native auto-merge on Dependabot PRs, so routine weekly dependency bumps land themselves once pr.yml's 8 required checks pass instead of the maintainer merging each by hand. Reads Dependabot metadata via `dependabot/fetch-metadata` and, when allowed, runs `gh pr merge --auto --squash`; a red check blocks the merge (the PR waits for a human), and no approval step is involved (main requires 0 reviews). Fork-safe and inert until opted in via the `DEPENDABOT_AUTOMERGE` repo variable: `true` auto-merges semver patch + minor and leaves majors for manual review (posts a one-time "held for review" comment); `all` also auto-merges majors; unset = disabled. Bundler majors stay out of scope regardless — the Gemfile's `fastlane ~> 2.224` pin keeps Dependabot from proposing an out-of-range major gem. Uses `pull_request` (never `pull_request_target`) and only calls the GitHub API — it never checks out or runs PR content — so the `contents: write` + `pull-requests: write` grants can't be abused by a malicious payload.
+
 ### Changed
 
 ### Fixed


### PR DESCRIPTION
## Why

Routine weekly Dependabot bumps (fastlane, ruby/setup-ruby, actions/\*) have been merged by hand every week. This wires up GitHub-native auto-merge so they land themselves once `pr.yml`'s 8 required checks pass — the maintainer only gets involved when something actually needs a human.

## How it works

`dependabot-automerge.yml` runs on each Dependabot PR, reads the update metadata (`dependabot/fetch-metadata`, SHA-pinned to v3.1.0), and calls `gh pr merge --auto --squash`. That enables branch-native auto-merge: GitHub holds the PR until the required checks are green, then squash-merges + deletes the branch. **A red check blocks the merge** — the PR waits for a human. No approval step (main requires 0 reviews; `GITHUB_TOKEN` can't self-approve).

## Opt-in (fork-safe)

Inert until the `DEPENDABOT_AUTOMERGE` repo variable is set — forks inherit the file but nothing auto-merges until they opt in:

| value | behavior |
|---|---|
| `true` | auto-merge semver **patch + minor**; hold **majors** for manual review (posts a one-time comment) |
| `all` | auto-merge patch + minor + **major** |
| unset / other | disabled |

Bundler majors are unreachable regardless — the Gemfile's `fastlane ~> 2.224` pin keeps Dependabot from proposing an out-of-range major gem.

## Safety

`pull_request` (not `pull_request_target`); the job only calls the GitHub API — never checks out or runs PR content — so the `contents: write` + `pull-requests: write` grants can't be abused by a malicious payload.

## Rollout

After merge I'll set `DEPENDABOT_AUTOMERGE=true`. Next Monday's Dependabot batch is the live test.

actionlint clean; CHANGELOG updated.