### PR TITLE
release: cut v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [1.9.0] - 2026-07-08
+
+CI/release reliability + release automation. **(1) Tuist `libswiftCompatibilitySpan.dylib` dyld fix** (#253 / #254 / #255): the Homebrew `tuist` cask shipped a broken 4.198.1 (a Swift CLI referencing the `Span` back-deployment shim without embedding it) that aborted at `tuist generate`; GitHub runner images cached that stale cask and don't reliably auto-update it, so every tuist CI cell — and both tuist canary cells (2026-06-20) — went red. Fix: `brew update` before installing the tuist cask across `pr.yml`, `canary-local-mode.yml`, and `release.yml` (the last refreshes before `make bootstrap`, whose `brew bundle` installs the cask first), pulling the upstream-fixed ≥ 4.199.0 (cask now 4.200.5). Verified green via a full `canary-trigger` dry-run. **(2) Opt-in Dependabot auto-merge** (#260): `dependabot-automerge.yml` enables GitHub-native auto-merge so routine bumps land themselves once the required checks pass, gated behind the `DEPENDABOT_AUTOMERGE` repo variable (patch/minor by default, majors held). Plus routine dependency bumps (#251, #252, #257, #258, #259).
+
+### Added
+
 - `.github/workflows/dependabot-automerge.yml` — opt-in workflow that enables GitHub-native auto-merge on Dependabot PRs, so routine weekly dependency bumps land themselves once pr.yml's 8 required checks pass instead of the maintainer merging each by hand. Reads Dependabot metadata via `dependabot/fetch-metadata` and, when allowed, runs `gh pr merge --auto --squash`; a red check blocks the merge (the PR waits for a human), and no approval step is involved (main requires 0 reviews). Fork-safe and inert until opted in via the `DEPENDABOT_AUTOMERGE` repo variable: `true` auto-merges semver patch + minor and leaves majors for manual review (posts a one-time "held for review" comment); `all` also auto-merges majors; unset = disabled. Bundler majors stay out of scope regardless — the Gemfile's `fastlane ~> 2.224` pin keeps Dependabot from proposing an out-of-range major gem. Uses `pull_request` (never `pull_request_target`) and only calls the GitHub API — it never checks out or runs PR content — so the `contents: write` + `pull-requests: write` grants can't be abused by a malicious payload.
 
 ### Changed


### PR DESCRIPTION
Moves `[Unreleased]` into `[1.9.0] - 2026-07-08`.

**MINOR, not a patch** (corrects my earlier v1.8.1 suggestion): this release adds a new forker-inherited feature, so semver-wise it's a minor.

## In v1.9.0

| Change | PRs | Type |
|---|---|---|
| Tuist `libswiftCompatibilitySpan.dylib` dyld CI fix (brew update before installing the cask) | #253 #254 #255 | Fixed |
| Opt-in Dependabot auto-merge workflow | #260 | Added |
| fastlane, ruby/setup-ruby, actions/* bumps | #251 #252 #257 #258 #259 | deps |

## Validation
- CHANGELOG-only diff; `ci/local-check.sh` passed via pre-push.
- Tuist fix already verified green (full canary-trigger dry-run, all 3 cells).
- After squash-merge: annotated tag `v1.9.0` per the CHANGELOG Tagging runbook, then `gh release create v1.9.0 --notes-from-tag --verify-tag`.