### PR TITLE
feat(ci): ASC-agreement preflight (fail fast on expired Apple agreement)

### DIFF
--- a/.github/workflows/canary-local-mode.yml
+++ b/.github/workflows/canary-local-mode.yml
@@ -280,6 +280,14 @@ jobs:
         # use the same Ruby that built the extensions.
         run: echo "/opt/homebrew/opt/ruby@3.3/bin" >> "$GITHUB_PATH"
 
+      - name: Verify ASC agreements are in effect
+        # Preflight (sibling of canary-trigger.yml's PAT preflight, #248): probe
+        # App Store Connect before cert mint / build / upload. Apple gates the
+        # whole ASC API behind an in-effect agreement; when one lapses this
+        # fails fast with an actionable runbook instead of surfacing deep in
+        # bootstrap_asc / mint / pilot. Uses job-level ASC_API_KEY_* env.
+        run: bundle exec ruby bin/verify-asc-agreements.rb
+
       - name: Pre-install Apple WWDR intermediate certs
         # See release.yml's identical step (G4). fastlane match's auto-install
         # path can hang for 5+ min on GH Actions runners. We pre-install via

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,6 +222,17 @@ jobs:
         # so we keep it — we just don't want its Ruby at runtime.
         run: echo "/opt/homebrew/opt/ruby@3.3/bin" >> "$GITHUB_PATH"
 
+      - name: Verify ASC agreements are in effect
+        # Preflight (sibling of canary-trigger.yml's PAT preflight, #248):
+        # probe App Store Connect before the expensive/irreversible work
+        # (generator switch, cert mint, build, upload). Apple gates the whole
+        # ASC API behind an in-effect agreement; when one lapses this fails
+        # fast with an actionable runbook (which ASC screens the Account
+        # Holder must accept) instead of surfacing cryptically at compute tag
+        # or mid-cert-mint. Uses job-level ASC_API_KEY_* env; env-var auth path
+        # (no .bootstrap.env synthesized yet at this point).
+        run: bundle exec ruby bin/verify-asc-agreements.rb
+
       - name: Apply generator override
         # Optional input that overrides whatever generator the Makefile is
         # currently using. Mirrors canary-local-mode.yml's pattern: if

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `bin/verify-asc-agreements.rb` + a "Verify ASC agreements are in effect" preflight step in `release.yml` and `canary-local-mode.yml` — probe App Store Connect up front and, if a required Apple agreement is missing/expired, fail fast with an actionable runbook (which ASC screens the Account Holder must accept) instead of surfacing cryptically deep in `compute-release-tag.rb` / mid-cert-mint / at upload. Surfaced 2026-07-11 when the Saturday canary went red across **all** cells (both generators, CI-mode and local-mode) with `A required agreement is missing or has expired` — Apple gates the entire ASC API behind an in-effect agreement, so the failure was account-wide (even the xcodegen cell, unrelated to the concurrent tuist work, failed). Mirrors `canary-trigger.yml`'s PAT-expiry preflight (#248). Implementation: `Bootstrap::AscAgreementError` (detects Apple's agreement-gate message and carries the runbook), `Bootstrap.verify_asc_agreements!` (minimal account-wide `App.all` probe), and `Bootstrap.setup_asc_token_from_env!` (shared ASC-token-from-env setup for the CI path). `bin/lib/version_resolver.rb`'s `next_build_number` now also translates the agreement error to the same actionable message, so a human running `make ship` gets it too — not just the CI preflight step.
+
 ### Changed
 
 ### Fixed

--- a/bin/lib/bootstrap.rb
+++ b/bin/lib/bootstrap.rb
@@ -37,6 +37,41 @@ module Bootstrap
     FASTLANE_TEAM_ID
   ].freeze
 
+  # Raised when an App Store Connect API call is rejected because a required
+  # Apple agreement (Program License Agreement, Paid Applications Agreement,
+  # or freshly-updated terms) is unsigned or expired. Apple gates the ENTIRE
+  # ASC API behind an in-effect agreement, so this blocks every call
+  # account-wide — cert mint, build lookup, upload — until the Account Holder
+  # accepts it in the ASC web UI. No API or automation can accept it.
+  # Surfaced 2026-07-11 when the Saturday canary went red across all cells at
+  # the compute-release-tag step. The message is the actionable runbook.
+  class AscAgreementError < StandardError
+    # Apple raises this as a generic Spaceship::UnexpectedResponse (no typed
+    # class to rescue on), so detection is by message. Both phrases appear in
+    # the real error: "A required agreement is missing or has expired. - This
+    # request requires an in-effect agreement that has not been signed…".
+    def self.match?(err)
+      err.message.to_s =~ /(required|in-effect) agreement|agreement (is missing|has expired|has not been signed)/i
+    end
+
+    def initialize(original_message = nil)
+      detail = original_message ? "\n\n  ASC said: #{original_message.to_s.strip[0, 300]}" : ""
+      super(<<~MSG.chomp + detail)
+        App Store Connect rejected the request: a required Apple agreement is missing or has expired.
+        This blocks ALL ASC API calls for the account until it is accepted — no API or automation can do it.
+
+        Fix (Account Holder only, ~2 min):
+          1. Sign in at https://appstoreconnect.apple.com
+          2. Accept the pending banner on the home page, AND check
+             Business -> Agreements, Tax, and Banking for a pending agreement.
+          3. Also check https://developer.apple.com/account (Membership) for a
+             Program License Agreement banner.
+        Apple periodically updates these; acceptance unblocks every ship (the
+        canary AND your real app).
+      MSG
+    end
+  end
+
   # ─── Config loader ──────────────────────────────────────────────────────────
 
   class Config
@@ -1431,6 +1466,54 @@ module Bootstrap
       issuer_id: config["ASC_API_KEY_ISSUER_ID"],
       filepath:  p8_path.to_s
     )
+  end
+
+  # Create the Spaceship ASC token from ASC_API_KEY_* env vars — the CI path,
+  # where no .bootstrap.env exists yet (release.yml exports the creds before
+  # invoking bin scripts). Idempotent. Accepts ASC_API_KEY_P8_PATH (a PEM
+  # file) or ASC_API_KEY_P8_BASE64 (base64 PEM, decoded to a 0600 tmpfile).
+  # Mirrors bin/compute-release-tag.rb's env branch so both share one path.
+  def setup_asc_token_from_env!
+    require "spaceship"
+    return if Spaceship::ConnectAPI.token
+
+    %w[ASC_API_KEY_ID ASC_API_KEY_ISSUER_ID].each do |k|
+      raise "#{k} env var not set (and no .bootstrap.env present)." if ENV[k].to_s.empty?
+    end
+
+    p8_path = ENV["ASC_API_KEY_P8_PATH"]
+    if p8_path.to_s.empty?
+      b64 = ENV["ASC_API_KEY_P8_BASE64"]
+      raise "neither ASC_API_KEY_P8_PATH nor ASC_API_KEY_P8_BASE64 set." if b64.to_s.empty?
+
+      require "base64"
+      require "tmpdir"
+      p8_path = File.join(Dir.tmpdir, "asc_api_key_#{ENV.fetch('ASC_API_KEY_ID')}_verify.p8")
+      File.write(p8_path, Base64.decode64(b64))
+      File.chmod(0o600, p8_path)
+    end
+
+    Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.create(
+      key_id:    ENV.fetch("ASC_API_KEY_ID"),
+      issuer_id: ENV.fetch("ASC_API_KEY_ISSUER_ID"),
+      key:       File.read(p8_path),
+    )
+  end
+
+  # Minimal account-wide ASC probe. Apple gates the entire ASC API behind an
+  # in-effect agreement, so App.all trips the same rejection that would
+  # otherwise surface deep in compute-release-tag / cert mint / upload — but
+  # here we translate it to an actionable AscAgreementError. Caller must have
+  # set the Spaceship token first (ensure_asc_token! or setup_asc_token_from_env!).
+  # Returns nil on success; re-raises non-agreement errors unchanged.
+  def verify_asc_agreements!
+    require "spaceship"
+    Spaceship::ConnectAPI::App.all(limit: 1)
+    nil
+  rescue StandardError => e
+    raise AscAgreementError.new(e.message) if AscAgreementError.match?(e)
+
+    raise
   end
 
 

--- a/bin/lib/version_resolver.rb
+++ b/bin/lib/version_resolver.rb
@@ -110,7 +110,18 @@ module Bootstrap
       max_build = builds.map { |b| b.version.to_i }.max || 0
       max_build + 1
     rescue Spaceship::AccessForbiddenError, Spaceship::UnauthorizedAccessError => e
+      # Apple gates the whole ASC API behind an in-effect agreement; when it
+      # lapses, surface the actionable runbook instead of a raw denial.
+      raise Bootstrap::AscAgreementError.new(e.message) if defined?(Bootstrap::AscAgreementError) && Bootstrap::AscAgreementError.match?(e)
+
       raise "Bootstrap::Version: ASC denied access while resolving build number — #{e.message[0, 200]}"
+    rescue StandardError => e
+      # The agreement error arrives as a generic Spaceship::UnexpectedResponse
+      # (not AccessForbidden), so catch it here too and translate; re-raise
+      # everything else unchanged.
+      raise Bootstrap::AscAgreementError.new(e.message) if defined?(Bootstrap::AscAgreementError) && Bootstrap::AscAgreementError.match?(e)
+
+      raise
     end
 
     # Compose the full release tag. Caller must have ensured the ASC

--- a/bin/verify-asc-agreements.rb
+++ b/bin/verify-asc-agreements.rb
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Preflight: confirm the App Store Connect account has an in-effect agreement
+# BEFORE the release pipeline does any real work (toolchain bootstrap, project
+# generation, cert minting, build, upload).
+#
+# Apple gates the ENTIRE ASC API behind a signed, non-expired agreement
+# (Program License Agreement, Paid Applications Agreement, or freshly-updated
+# terms). When one lapses, every ASC call fails account-wide — and without
+# this preflight the failure surfaces deep inside compute-release-tag.rb (or
+# later, mid-cert-mint) as a one-line generic error. This probes ASC up front
+# and, on the agreement gate, prints an actionable runbook naming the exact
+# ASC screens the Account Holder must visit. Mirrors canary-trigger.yml's
+# "Verify dispatch PAT is valid" preflight (apple-shipkit #248) for the ASC side.
+#
+# Auth resolution mirrors bin/compute-release-tag.rb:
+#   - .bootstrap.env present (local shippers, canary's synthesized env) →
+#     Bootstrap::Config + ensure_asc_token!.
+#   - .bootstrap.env absent (CI: release.yml exports ASC_API_KEY_* before this
+#     runs) → Bootstrap.setup_asc_token_from_env!.
+#
+# The probe is account-wide (App.all limit:1) — it needs no BUNDLE_ID and trips
+# the same agreement gate every downstream ASC call would.
+#
+# Usage: bundle exec ruby bin/verify-asc-agreements.rb
+#
+# Exit:
+#   0  an agreement is in effect (ASC API reachable)
+#   1  agreement missing/expired (actionable runbook printed), or auth error
+
+require_relative "lib/bootstrap"
+
+require "spaceship"
+
+if Bootstrap::ENV_FILE.exist?
+  config = Bootstrap::Config.load!
+  config.validate!
+  Bootstrap.ensure_asc_token!(config)
+else
+  Bootstrap.setup_asc_token_from_env!
+end
+
+begin
+  Bootstrap.verify_asc_agreements!
+  puts Bootstrap::UI.ok("App Store Connect agreements are in effect (ASC API reachable).")
+  exit 0
+rescue Bootstrap::AscAgreementError => e
+  warn Bootstrap::UI.miss("App Store Connect agreement check failed.")
+  warn e.message
+  exit 1
+rescue StandardError => e
+  # Not the agreement gate — surface the raw error (auth, network, etc.) so it
+  # isn't silently swallowed, but keep the exit contract.
+  warn Bootstrap::UI.miss("App Store Connect preflight could not complete: #{e.class}: #{e.message[0, 300]}")
+  exit 1
+end


### PR DESCRIPTION
## Why

The 2026-07-11 Saturday canary went red across **all** cells (both generators, CI-mode + local-mode):

```
A required agreement is missing or has expired.
- This request requires an in-effect agreement that has not been signed or has expired.
```

Apple gates the **entire** ASC API behind an in-effect agreement, so the failure is account-wide (even the xcodegen cell failed) and surfaced cryptically deep in `compute-release-tag.rb`. There's no CI/code fix for the agreement itself — only the Account Holder can accept it in the ASC web UI — but we can make the failure **fail fast and self-explanatory**.

## What

A preflight (sibling of #248's PAT-expiry preflight) that probes ASC up front and, on the agreement gate, prints an actionable runbook naming the exact ASC screens to accept.

- **`bin/verify-asc-agreements.rb`** — dual-path ASC token (`.bootstrap.env` config *or* `ASC_API_KEY_*` env for CI), minimal account-wide `App.all(limit:1)` probe, actionable exit on the agreement gate.
- **`release.yml` + `canary-local-mode.yml`** — "Verify ASC agreements are in effect" step, before generator switch / cert mint / upload.
- **`bin/lib/bootstrap.rb`** — `AscAgreementError` (message detection + runbook), `verify_asc_agreements!`, `setup_asc_token_from_env!` (shared env-token path).
- **`bin/lib/version_resolver.rb`** — `next_build_number` translates the agreement error too, so a human `make ship` gets the actionable message, not just CI.

## Validation

- Logic unit-tested against the **real** Apple message: detection, `AscAgreementError` translation, runbook content (ASC URL + Agreements screen + original detail), and non-agreement pass-through — all pass.
- YAML valid; `actionlint` clean on both workflows (only pre-existing SC2012 infos on unrelated Xcode-select steps).
- **Live end-to-end**: ASC is currently agreement-blocked, so after merge a canary run will hit this preflight and fail early with the actionable message — I'll confirm that, then it stays the early gate once the agreement is accepted.

Mirror PR: indiagrams/ios-macos-smoketest (same change).