### PR TITLE
fix(ci): pick the installer identity for THIS team, not whichever sorts first

### DIFF
--- a/ci/local-release-check.sh
+++ b/ci/local-release-check.sh
@@ -71,6 +71,7 @@ fi
 
 step() { printf '\n==> %s\n' "$*"; }
 ok()   { printf '    ✓ %s\n' "$*"; }
+warn() { printf '    ! %s\n' "$*" >&2; }
 fail() { printf '    ✗ %s\n' "$*" >&2; exit 1; }
 
 
@@ -427,9 +428,32 @@ if $SIGN_MACOS; then
     "$EXPANDED_APP"
 
   step "macOS: productbuild"
-  INSTALLER_CERT=$(security find-identity -v -p basic 2>/dev/null \
-    | grep -E "3rd Party Mac Developer Installer|Mac Installer Distribution" \
-    | head -1 | grep -oE '"[^"]+"' | tr -d '"')
+  # Prefer the installer identity belonging to THIS team. A keychain holding more
+  # than one "3rd Party Mac Developer Installer" — a personal team alongside an
+  # org team, or a rotated cert — previously got whichever `head -1` returned.
+  # productbuild then signed the .pkg with another team's installer cert, which
+  # App Store Connect rejects on upload, after a full build. This is the same
+  # ambiguity the code-signing path already pins away with RELEASE_MACOS_CERT_SHA1,
+  # left unhandled for the installer cert.
+  #
+  # RELEASE_MACOS_INSTALLER_SHA1 overrides the search entirely.
+  INSTALLER_LINES=$(security find-identity -v -p basic 2>/dev/null \
+    | grep -E "3rd Party Mac Developer Installer|Mac Installer Distribution")
+  if [ -n "${RELEASE_MACOS_INSTALLER_SHA1:-}" ]; then
+    INSTALLER_CERT="$RELEASE_MACOS_INSTALLER_SHA1"
+    ok "macOS installer identity pinned → $INSTALLER_CERT"
+  else
+    INSTALLER_CERT=$(printf '%s\n' "$INSTALLER_LINES" | grep -F "($TEAM_ID)" \
+      | head -1 | grep -oE '"[^"]+"' | tr -d '"')
+    if [ -z "$INSTALLER_CERT" ]; then
+      INSTALLER_CERT=$(printf '%s\n' "$INSTALLER_LINES" \
+        | head -1 | grep -oE '"[^"]+"' | tr -d '"')
+      [ -n "$INSTALLER_CERT" ] && \
+        warn "no installer identity for team $TEAM_ID; falling back to '$INSTALLER_CERT'"
+    else
+      ok "macOS installer identity → '$INSTALLER_CERT'"
+    fi
+  fi
   [ -z "$INSTALLER_CERT" ] && fail "Mac Installer Distribution cert not found in keychain — install one from developer.apple.com → Certificates → '+' → Mac Installer Distribution"
 
   PKG_DEST="$REPO_ROOT/build/HelloApp-${VERSION}.pkg"


### PR DESCRIPTION
`productbuild` was handed whatever `security find-identity | grep … | head -1` returned, **with no team filter**.

On a keychain holding more than one *3rd Party Mac Developer Installer* — a personal team alongside an org team, or a rotated cert — that is a coin flip, and the losing side signs the `.pkg` with **another team's installer certificate**. App Store Connect rejects it on upload, after a full archive and export have already run.

This is the same ambiguity the code-signing path already pins away with `RELEASE_MACOS_CERT_SHA1`. It was simply left unhandled for the installer cert.

## Change

- prefer the identity matching `$TEAM_ID` (already resolved in this script from `FASTLANE_TEAM_ID` / `APPLE_TEAM_ID`)
- warn and fall back when none matches, rather than failing outright
- accept `RELEASE_MACOS_INSTALLER_SHA1` as an explicit override, mirroring the code-signing knob
- add the missing `warn()` helper — the script had `step`/`ok`/`fail` only, so there was no way to say "proceeding, but not with what you probably meant"

## Verified

On a real keychain with two installer identities:

| `TEAM_ID` | result |
|---|---|
| org team | selects the org identity |
| personal team | selects the personal identity |
| no match | warns, falls back to the first |
| `RELEASE_MACOS_INSTALLER_SHA1` set | uses the pin, skips the search |

**The no-match case is also the proof of the bug:** its fallback line shows `head -1` returning the *personal* identity — which is exactly what an org-team build was silently getting before this change.

## Scope

Nothing app-specific. This is a property of the developer's keychain, and it keys off `$TEAM_ID`, which is already this script's own configuration.
