### PR TITLE
fix(submit): create the version record and attach the build before deliver

### DIFF
--- a/bin/submit.rb
+++ b/bin/submit.rb
@@ -7,8 +7,9 @@
 # Two-stage cadence:
 #
 #   `SUBMIT_FOR_REVIEW=false` (default in `.bootstrap.env.example`)
-#     Stages the version: uploads screenshots + metadata + attaches the build
-#     + fills export-compliance answers, but does NOT click "Submit for
+#     Stages the version: creates the App Store version record if missing,
+#     attaches the newest VALID build, uploads screenshots + metadata, and
+#     fills export-compliance answers, but does NOT click "Submit for
 #     Review". The version sits in App Store Connect's "Prepare for
 #     Submission" state — review the prepared listing in the web UI, then
 #     click Submit yourself. Recommended for first releases until you trust
@@ -137,6 +138,84 @@ unless auto_submit
   puts Bootstrap::UI.dim("  3. To auto-submit on future runs, set SUBMIT_FOR_REVIEW=true in .bootstrap.env")
   puts
 end
+
+# ─── Pre-flight: version record exists, with a build attached ────────────────
+#
+# deliver writes metadata INTO an existing editable App Store version; it does
+# not create one, and nothing else in this pipeline does either (`bootstrap_asc`
+# verifies the *App* record, not a version). So the first `make submit` after a
+# marketing bump failed with deliver retrying "Cannot find edit app store
+# version" until it gave up.
+#
+# Neither deliver call passes `build_number`, so no build was attached either.
+# That produced the worse failure of the two: a green "staged" run whose version
+# had build=NONE and therefore could not be submitted at all -- visible only by
+# querying ASC, never from the exit code.
+#
+# Both are prerequisites rather than metadata, so they are settled here, before
+# any lane runs. Idempotent: an existing version is reused, an already-attached
+# build is left alone, so re-running `make submit` is safe.
+if marketing.nil? || marketing.to_s.strip.empty?
+  Bootstrap::UI.fail!("Could not read MARKETING_VERSION from app/project.yml or app/Project.swift.")
+end
+
+require "spaceship"
+Bootstrap.ensure_asc_token!(config)
+asc_app = Spaceship::ConnectAPI::App.find(config["BUNDLE_ID"])
+Bootstrap::UI.fail!("ASC App record not found for #{config['BUNDLE_ID']}.") unless asc_app
+
+asc_platform_of = { "ios" => "IOS", "macos" => "MAC_OS" }.freeze
+# States whose metadata deliver can still write. READY_FOR_SALE is the common
+# miss: a released train is closed, and the fix is a marketing bump, not a retry.
+editable_states = %w[
+  PREPARE_FOR_SUBMISSION DEVELOPER_REJECTED REJECTED METADATA_REJECTED INVALID_BINARY
+].freeze
+
+puts Bootstrap::UI.bold("→ App Store version records (#{marketing})")
+platforms.each do |p|
+  plat = asc_platform_of.fetch(p)
+
+  versions = Spaceship::ConnectAPI.get_app_store_versions(
+    app_id: asc_app.id, filter: {}, includes: "build", limit: 50
+  ).to_models
+  v = versions.find { |x| x.platform == plat && x.version_string == marketing }
+
+  if v.nil?
+    v = Spaceship::ConnectAPI.post_app_store_version(
+      app_id: asc_app.id, attributes: { versionString: marketing, platform: plat }
+    ).to_models.first
+    puts Bootstrap::UI.ok("  #{p}: created version #{marketing}")
+  elsif !editable_states.include?(v.app_store_state)
+    Bootstrap::UI.fail!(
+      "#{p}: version #{marketing} is #{v.app_store_state}, which deliver cannot edit. " \
+      "If it is READY_FOR_SALE the train is closed -- bump MARKETING_VERSION."
+    )
+  else
+    puts Bootstrap::UI.ok("  #{p}: version #{marketing} exists (#{v.app_store_state})")
+  end
+
+  if v.build&.version
+    puts Bootstrap::UI.ok("  #{p}: build #{v.build.version} already attached")
+    next
+  end
+
+  builds = Spaceship::ConnectAPI.get_builds(
+    filter: { app: asc_app.id }, includes: "preReleaseVersion", limit: 50, sort: "-uploadedDate"
+  ).to_models
+  b = builds.find do |x|
+    pv = x.pre_release_version
+    pv && pv.platform == plat && pv.version == marketing &&
+      x.processing_state == "VALID" && !x.expired
+  end
+  if b.nil?
+    Bootstrap::UI.fail!("#{p}: no VALID unexpired build for #{marketing}. Run `make ship` first.")
+  end
+  Spaceship::ConnectAPI.patch_app_store_version_with_build(
+    app_store_version_id: v.id, build_id: b.id
+  )
+  puts Bootstrap::UI.ok("  #{p}: attached build #{b.version}")
+end
+puts
 
 # ─── Dispatch per platform ───────────────────────────────────────────────────
 lane = auto_submit ? "submit_for_review" : "stage_for_review"


### PR DESCRIPTION
`make submit` cannot stage a new marketing version — and reports success while
failing. Found while shipping a fork's `0.1.1`; both gaps are in the template, so
every fork hits them on its first version bump.

## Gap 1 — nothing creates the App Store version record

`deliver` writes metadata **into** an existing editable version; it does not
create one. `bootstrap_asc` only verifies the *App* record. So with the previous
version `READY_FOR_SALE` (not editable) and the new one absent, deliver retried:

```
Cannot find edit app store version... Retrying after 20 seconds (remaining: 6)
Cannot find edit app store version... Retrying after 40 seconds (remaining: 5)
...
```

## Gap 2 — nothing attaches a build (the worse one)

Neither `deliver` call passes `build_number`, in staging **or** submit mode. So
the run prints *"All configured platforms staged"*, exits **0**, and leaves:

```
IOS     0.1.1  PREPARE_FOR_SUBMISSION  build=NONE
MAC_OS  0.1.1  PREPARE_FOR_SUBMISSION  build=NONE
```

A version with no build cannot be submitted. Nothing in the output says so — it
is visible only by querying App Store Connect.

## Fix

A pre-flight before any lane runs, since both are prerequisites rather than
metadata:

- ensure an editable version exists for `MARKETING_VERSION`, creating it if not;
- attach the newest `VALID`, unexpired build for that marketing version.

**Idempotent** — an existing version is reused, an already-attached build left
alone, so re-running is safe.

A non-editable version now fails with an actionable message rather than a retry
loop: `READY_FOR_SALE` means the train is closed and the answer is a marketing
bump, not a retry.

The header comment claimed the stage path "attaches the build". It did not. It
does now, and the header documents the record creation too.

## Verified against a live app

- created both `0.1.1` records from nothing (iOS + macOS);
- attached build 9 on both;
- re-ran: `version 0.1.1 exists (PREPARE_FOR_SUBMISSION)` / `build 9 already
  attached`, nothing duplicated;
- `ruby -c` clean; no fork-specific values in the diff.