### PR TITLE
ci(shell): gate every tracked shell script on bash -n + ShellCheck

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -102,6 +102,23 @@ jobs:
   # `--strict` treats warnings as errors so the signal is binary.
   # Excluded paths (Tuist Derived, fastlane SnapshotHelper, build outputs)
   # are configured in .swiftlint.yml itself, not here.
+  shellcheck:
+    name: shell scripts
+    # ubuntu, not macos: this needs git + bash + shellcheck and nothing from
+    # Xcode, and shellcheck is preinstalled on the ubuntu image. Runs on every
+    # PR rather than behind a paths filter -- a shell script is reachable from
+    # almost any change here, and the job takes seconds.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: shellcheck present
+        # Preinstalled on ubuntu-latest today; install rather than assume, so a
+        # future image change downgrades to a slower job and not a silent skip.
+        run: command -v shellcheck >/dev/null || sudo apt-get install -y shellcheck
+      - name: bash -n + shellcheck
+        run: ./ci/check-shell.sh
+
   swiftlint:
     name: swiftlint
     runs-on: macos-15

--- a/Brewfile
+++ b/Brewfile
@@ -10,6 +10,7 @@ brew "xcbeautify"      # nicer xcodebuild logs
 brew "xcresultparser"  # parse .xcresult bundles in CI
 
 # Git workflow
+brew "shellcheck"      # ci/check-shell.sh — bash -n + shellcheck over every tracked *.sh
 brew "lefthook"        # pre-push hook → ci/local-check.sh --fast
 brew "gh"              # PR / release CLI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `bin/refork-smoketest.sh` — added `--skip-cert-revoke` to skip step 2's team-wide "revoke all `Created via API` certs" residue cleanup. That step is safe only when the smoketest owns its Apple team alone; once the team is **shared** (e.g. the canary reforked onto the Indiagram LLC account alongside a real app), a blanket revoke would kill the co-tenant's API-minted certs — verified against the LLC, where an `Apple Development: Created via API` cert belonging to another app would have matched the filter. With the flag, step 2 no-ops (the canary mints + revokes its own certs each run, and a shared team has no smoketest residue to clean anyway).
 
+### Added
+
+- **`ci/check-shell.sh` — `bash -n` + ShellCheck over every tracked shell script, on every PR.** This template's release path is shell: `ci/local-release-check.sh` alone is ~470 lines of signing, packaging and re-signing. Nothing in CI executed any of it. The `app (...)` cells build the app; they never source `bin/rename.sh` or run the ship path, so **a PR that broke a shell script outright merged green** and failed later, on somebody's release.
+
+  `bash -n` is the floor — a script that cannot be parsed should never reach main. ShellCheck at `warning` catches the tier above it, the constructs that run but do the wrong thing. It found 7 on first run, all now fixed:
+
+  | code | where | why it matters |
+  |---|---|---|
+  | SC2164 ×2 | `ci/check-app-icon.sh`, `ci/check-identity.sh` | `cd "$(dirname "$0")/.."` with no `|| exit`. In a **guard**, a failed `cd` means the script keeps going in the wrong directory and then passes files that are not the ones it exists to check |
+  | SC1087 ×3 | `bin/rename.sh`, `ci/test-rename.sh` ×2 | `$var[[:space:]]` parses as array indexing, not "expand, then a literal bracket" |
+  | SC2046 ×1 | `ci/local-release-check.sh` | `$($PATCH_MACOS_PLIST && echo "" || echo …)` unquoted. Rewritten to the `${ARR[@]+"${ARR[@]}"}` idiom the two lines above it already use, so the "pass nothing" branch is zero arguments rather than one empty one |
+  | SC2088 ×1 | `bin/refork-smoketest.sh` | false positive — a tilde in an error *message*. Suppressed with the reason inline rather than reworded |
+
+  Severity is capped at `warning` on purpose. `info`/`style` (19 remaining) are reported each run for visibility but never fail: they are dominated by SC2012 and SC1091, neither a defect here, and a gate that cries wolf gets switched off.
+
+  `ci/lib/` is covered via `shellcheck -s bash` rather than exempted. Those are sourced libraries with no shebang, pinned byte-for-byte by `ci/lib/SHA256SUMS` across this template **and every consumer** — so adding a `# shellcheck shell=bash` directive would force a re-pin in every downstream repo for the sake of a comment. Passing the shell on the command line gets identical coverage and touches nothing.
+
+  Mutation-verified rather than assumed: a deliberate syntax break fails it, reintroducing the `cd` bug fails it, and removing shellcheck from `PATH` fails it instead of skipping. It also caught a defect **in its own header** on first run — prose wrapped so a line began `# shellcheck`, which ShellCheck reads as a malformed directive. Wired as pr.yml's `shell scripts` job (ubuntu, seconds, no paths filter) and into `ci/local-check.sh` on the pre-push path; `shellcheck` added to the Brewfile.
+
 ### Fixed
 
 - **`deliver` rewrote `demo_account_required` from credentials it was never given, and `bin/submit.rb` let it.** `review_information()` strips every review field and omits the empty ones from its `appStoreReviewDetail` PATCH — correct, and precisely what the Fastfile's `" "` sentinel depends on to keep the `+10000000000` phone placeholder from reaching Apple. But it then finishes with an `else` branch that **writes** `demo_account_required = false` rather than omitting it, deriving the flag from the two values it had just decided not to send.

--- a/bin/refork-smoketest.sh
+++ b/bin/refork-smoketest.sh
@@ -123,6 +123,9 @@ set +a
 for k in FASTLANE_TEAM_ID ASC_API_KEY_ID ASC_API_KEY_ISSUER_ID ASC_API_KEY_P8_BASE64 \
          MATCH_PASSWORD MATCH_GIT_BASIC_AUTHORIZATION KEYCHAIN_PASSWORD; do
   v="${!k:-}"
+  # SC2088: the tilde here is display text naming the file we just sourced (see
+  # the `source "$HOME/..."` above), not a path this line expands or uses.
+  # shellcheck disable=SC2088
   [ -n "$v" ] || { echo "~/.config/secrets.env missing $k" >&2; exit 1; }
 done
 

--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -555,7 +555,7 @@ apply_substitutions() {
   # DISPLAY_NAME to the APP_NAME (forker's code-name) instead of the
   # DISPLAY_NAME (forker's user-facing name). One site: the xcconfig feeds
   # CFBundleDisplayName on both platforms through both generators.
-  sed -i '' "s#^\([[:space:]]*DISPLAY_NAME[[:space:]]*=[[:space:]]*\)$current_display[[:space:]]*\$#\1$DISPLAY_PLACEHOLDER#" app/Identity.xcconfig
+  sed -i '' "s#^\([[:space:]]*DISPLAY_NAME[[:space:]]*=[[:space:]]*\)${current_display}[[:space:]]*\$#\1$DISPLAY_PLACEHOLDER#" app/Identity.xcconfig
   grep -q "$DISPLAY_PLACEHOLDER" app/Identity.xcconfig || \
     fail "DISPLAY placeholder was not set in app/Identity.xcconfig — sed regression"
   ok "DISPLAY placeholder set in app/Identity.xcconfig (DISPLAY_NAME)"

--- a/ci/check-app-icon.sh
+++ b/ci/check-app-icon.sh
@@ -43,7 +43,7 @@
 #   ALLOW_PLACEHOLDER_ICON=true
 
 set -uo pipefail
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")/.." || exit 1
 
 fail=0
 

--- a/ci/check-identity.sh
+++ b/ci/check-identity.sh
@@ -26,7 +26,7 @@
 # app/Local.xcconfig is never present).
 
 set -uo pipefail
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")/.." || exit 1
 
 echo "==> Identity preflight"
 

--- a/ci/check-shell.sh
+++ b/ci/check-shell.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# ci/check-shell.sh — every tracked shell script must parse, and must survive
+# ShellCheck at warning severity.
+#
+# (Note the capital S above. A comment line whose first word is `shellcheck` is
+# parsed as a directive, so prose that happens to wrap onto one becomes a syntax
+# error. This gate caught exactly that in its own header on its first run.)
+#
+# WHY THIS EXISTS
+#
+# This template's release path is shell. `local-release-check.sh` alone is ~470
+# lines of signing, packaging and re-signing, and a fork's CI can be green
+# across every job while a script in that path is syntactically broken -- because
+# nothing ever ran it. The `app (...)` cells build the app; they do not source
+# `bin/rename.sh` or execute the ship path. A PR that breaks a shell script
+# outright therefore merges clean and fails later, on someone's release.
+#
+# `bash -n` is the floor: it catches a script that cannot even be parsed, which
+# is the failure that should never reach main. shellcheck at `warning` catches
+# the class above that -- the constructs that run but do the wrong thing:
+#
+#   SC2164  `cd foo` without `|| exit`. In a GUARD script this is the worst
+#           case: cd fails, the script keeps going in the wrong directory, and
+#           then checks -- and passes -- files that are not the ones it exists
+#           to check.
+#   SC1087  `$var[...]` reads as array indexing rather than "expand var, then a
+#           literal bracket". Ambiguous today, wrong the moment someone makes
+#           `var` an array.
+#   SC2046  unquoted command substitution that word-splits.
+#
+# Severity is capped at `warning` deliberately. `info` and `style` are reported
+# for visibility but do not fail: they are dominated by SC2012 (`ls | grep`) and
+# SC1091 (cannot follow `source`), neither of which is a defect here, and a gate
+# that cries wolf gets disabled.
+#
+# ci/lib/ is checked with `-s bash` rather than exempted. Those files are sourced
+# libraries with no shebang, and they are pinned byte-for-byte by
+# `ci/lib/SHA256SUMS` across this template and every consumer -- so adding a
+# `# shellcheck shell=bash` directive to them would force a re-pin in every
+# downstream repo for a comment. Passing the shell on the command line gets the
+# same coverage and touches nothing.
+
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+  echo "  FAIL shellcheck is not installed." >&2
+  echo "       brew install shellcheck   (it is in the Brewfile)" >&2
+  echo "       Not skipping: this gate exists because nothing else runs these scripts." >&2
+  exit 1
+fi
+
+# Read into an array without `mapfile`: that is bash 4+, and macOS still ships
+# bash 3.2 as /bin/bash, so a runner without a newer bash on PATH would fail
+# here rather than in the checks below.
+SCRIPTS=()
+while IFS= read -r _f; do
+  [ -n "$_f" ] && SCRIPTS+=("$_f")
+done < <(git ls-files '*.sh')
+if [ "${#SCRIPTS[@]}" -eq 0 ]; then
+  echo "  FAIL no tracked *.sh files found -- this gate went blind." >&2
+  exit 1
+fi
+
+echo "==> Shell script check (${#SCRIPTS[@]} tracked scripts)"
+fail=0
+
+# 1. Parse. A script that does not parse cannot be reasoned about at all.
+syntax_bad=0
+for f in "${SCRIPTS[@]}"; do
+  if ! err="$(bash -n "$f" 2>&1)"; then
+    echo "  FAIL $f does not parse:" >&2
+    echo "$err" | sed 's/^/         /' >&2
+    syntax_bad=$((syntax_bad + 1))
+    fail=1
+  fi
+done
+[ "$syntax_bad" -eq 0 ] && echo "  ok   all ${#SCRIPTS[@]} scripts parse (bash -n)"
+
+# 2. shellcheck at warning severity. -s bash covers the shebang-less sourced
+#    libraries in ci/lib/ without editing them; see the header.
+if out="$(shellcheck -s bash --severity=warning -f gcc "${SCRIPTS[@]}" 2>&1)" && [ -z "$out" ]; then
+  echo "  ok   shellcheck clean at warning severity"
+else
+  if [ -n "$out" ]; then
+    echo "  FAIL shellcheck found error/warning-level problems:" >&2
+    echo "$out" | sed 's/^/         /' >&2
+    fail=1
+  fi
+fi
+
+# 3. Advisory only -- reported so it stays visible, never fails the build.
+advisory="$(shellcheck -s bash --severity=style -f gcc "${SCRIPTS[@]}" 2>/dev/null | wc -l | tr -d ' ')"
+echo "  note $advisory info/style finding(s), not gated (see this script's header)"
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "FAILED: a tracked shell script is broken or has a warning-level defect." >&2
+  echo "Nothing else in CI executes these scripts, so this is the only place it shows up." >&2
+  exit 1
+fi
+echo "passed"
+exit 0

--- a/ci/local-check.sh
+++ b/ci/local-check.sh
@@ -110,6 +110,11 @@ verify_helpers_in_sync
 # named here before xcodegen would silently generate around it.
 ci/check-identity.sh || fail "app/Identity.xcconfig incomplete — see ci/check-identity.sh"
 
+# Same check pr.yml's `shell scripts` job runs. Cheap (seconds) and worth having
+# on the pre-push path: a broken shell script is otherwise invisible until a
+# release runs it. Needs shellcheck, which is in the Brewfile.
+ci/check-shell.sh || fail "a tracked shell script is broken — see ci/check-shell.sh"
+
 case "$mode" in
   --fast)
     ensure_xcodeproj

--- a/ci/local-release-check.sh
+++ b/ci/local-release-check.sh
@@ -405,6 +405,14 @@ if $SIGN_MACOS; then
       "$EXPORT_OPTS_MACOS"
   fi
 
+  # CODE_SIGN_STYLE: when we patch the plist ourselves the project's own setting
+  # is left alone; otherwise Automatic is forced. An array rather than an
+  # unquoted `$(... && echo "" || echo ...)` so the "pass nothing" branch really
+  # is zero arguments instead of one empty one, which xcodebuild would see as a
+  # stray empty setting (SC2046). Matches the ASC_AUTH_ARGS idiom below it.
+  MACOS_SIGN_STYLE_ARGS=()
+  $PATCH_MACOS_PLIST || MACOS_SIGN_STYLE_ARGS=(CODE_SIGN_STYLE=Automatic)
+
   xcodebuild archive \
     -project app/App.xcodeproj \
     -scheme App-macOS \
@@ -414,7 +422,7 @@ if $SIGN_MACOS; then
     ${ASC_AUTH_ARGS[@]+"${ASC_AUTH_ARGS[@]}"} \
     ${MACOS_SIGN_ARGS[@]+"${MACOS_SIGN_ARGS[@]}"} \
     -allowProvisioningUpdates \
-    $($PATCH_MACOS_PLIST && echo "" || echo "CODE_SIGN_STYLE=Automatic") \
+    ${MACOS_SIGN_STYLE_ARGS[@]+"${MACOS_SIGN_STYLE_ARGS[@]}"} \
     DEVELOPMENT_TEAM="$TEAM_ID" \
     MARKETING_VERSION="$MARKETING_VERSION" \
     CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \

--- a/ci/test-rename.sh
+++ b/ci/test-rename.sh
@@ -174,9 +174,9 @@ test ! -f "app/Shared/$TEST_APP.swift" || fail "app/Shared/$TEST_APP.swift was c
 ok "constant structure intact (App.swift, App.entitlements x2, App*Tests.swift)"
 
 # Identity landed in the xcconfig, and the Team ID did not land in a tracked file
-grep -qE "^[[:space:]]*APP_PRODUCT_NAME[[:space:]]*=[[:space:]]*$TEST_APP[[:space:]]*$" app/Identity.xcconfig || \
+grep -qE "^[[:space:]]*APP_PRODUCT_NAME[[:space:]]*=[[:space:]]*${TEST_APP}[[:space:]]*$" app/Identity.xcconfig || \
   fail "app/Identity.xcconfig: APP_PRODUCT_NAME is not '$TEST_APP'"
-grep -qE "^[[:space:]]*BUNDLE_ID[[:space:]]*=[[:space:]]*$TEST_BUNDLE[[:space:]]*$" app/Identity.xcconfig || \
+grep -qE "^[[:space:]]*BUNDLE_ID[[:space:]]*=[[:space:]]*${TEST_BUNDLE}[[:space:]]*$" app/Identity.xcconfig || \
   fail "app/Identity.xcconfig: BUNDLE_ID is not '$TEST_BUNDLE'"
 grep -qF "DISPLAY_NAME     = $TEST_DISPLAY" app/Identity.xcconfig || \
   fail "app/Identity.xcconfig: DISPLAY_NAME is not '$TEST_DISPLAY'"


### PR DESCRIPTION
## The hole

This template's release path is shell. `ci/local-release-check.sh` alone is ~470 lines of signing, packaging and re-signing — and **nothing in CI ever executed any of it**. The `app (...)` cells build the app; they never source `bin/rename.sh` or run the ship path.

So a PR that broke a shell script outright merged green, and failed later on somebody's release. There was no `shellcheck` and no `bash -n` anywhere in this repo.

## The gate

`ci/check-shell.sh`, run on every PR:

1. **`bash -n`** over every tracked `*.sh` — a script that cannot be parsed must never reach main.
2. **ShellCheck at `warning`** — the tier above that: constructs that run but do the wrong thing.

Seven findings on the first run, all fixed in this PR:

| code | where | why it matters |
|---|---|---|
| SC2164 ×2 | `check-app-icon.sh`, `check-identity.sh` | `cd "$(dirname "$0")/.."` with no `\|\| exit`. In a **guard** this is the worst case — `cd` fails, the script keeps going in the wrong directory, and then passes files that are not the ones it exists to check |
| SC1087 ×3 | `rename.sh`, `test-rename.sh` ×2 | `$var[[:space:]]` parses as array indexing, not expand-then-literal-bracket |
| SC2046 ×1 | `local-release-check.sh` | unquoted command substitution. Rewritten to the `${ARR[@]+"${ARR[@]}"}` idiom the two lines directly above it already use, so the "pass nothing" branch is zero arguments rather than one empty one |
| SC2088 ×1 | `refork-smoketest.sh` | false positive — a tilde in an error *message*. Suppressed inline with the reason rather than reworded |

## Two deliberate calls

**Severity capped at `warning`.** The 19 remaining `info`/`style` findings are printed every run for visibility but never fail. They are dominated by SC2012 (`ls \| grep`) and SC1091 (cannot follow `source`), neither a defect here — and a gate that cries wolf gets switched off.

**`ci/lib/` is covered, not exempted** — via `shellcheck -s bash`. Those are sourced libraries with no shebang, and they are pinned byte-for-byte by `ci/lib/SHA256SUMS` across this template *and every consumer*. Adding a `# shellcheck shell=bash` directive would force a re-pin in every downstream repo for the sake of a comment. The command-line flag gets identical coverage and touches nothing.

## Verification

Mutation-verified, because a check that cannot fail is not evidence:

| mutation | result |
|---|---|
| deliberate syntax break in a script | **fails** |
| reintroduce the SC2164 `cd` bug | **fails**, naming the file and code |
| remove `shellcheck` from `PATH` | **fails** — never a silent skip |

It also caught a defect **in its own header** on the first run: prose wrapped so a line began `# shellcheck`, which ShellCheck parses as a malformed directive (SC1073/SC1072). That is noted in the header now, since the next person writing a comment about shellcheck will hit it too.

Portable to bash 3.2 (`mapfile` avoided) so it behaves the same if it ever runs on a macOS runner. Sibling suites unaffected: parser 9/9, `Sh.stream` 10/10, build number 11/11, xcconfig 51 checks / 0 failures, demo-account 14/14.

Wired as pr.yml's `shell scripts` job (ubuntu, seconds, no paths filter — a shell script is reachable from almost any change here) and into `ci/local-check.sh` on the pre-push path. `shellcheck` added to the Brewfile.