### PR TITLE
feat(release): RELEASE_TAG_PREFIX, so app tags can leave SwiftPM's namespace

### DIFF
--- a/.bootstrap.env.example
+++ b/.bootstrap.env.example
@@ -80,6 +80,28 @@ PLATFORMS=ios,macos
 #   SUBMIT_FOR_REVIEW=false make submit   # one-off stage when this says true
 SUBMIT_FOR_REVIEW=false
 
+# RELEASE_TAG_PREFIX — what `make ship` prefixes the release tag with.
+#
+# Default `v`, giving `v1.0.0+5`. Leave it alone unless this repo ALSO publishes
+# a SwiftPM package, because then the two collide: SwiftPM claims every tag that
+# parses as a version, so `v1.0.0+5` is simultaneously the app's release marker
+# and package version 1.0.0. An App Store metadata bump then publishes a package
+# version, and adopters get a bump from a commit that never mentioned SwiftPM.
+#
+# Measured, not assumed: with `v0.2`, `pkg-0.3.0`, `package/0.4.0` and
+# `release/0.5.0` all tagged, `.upToNextMajor(from: "0.1.0")` resolved to
+# `0.1.1+9` — every PREFIXED tag was ignored, while a bare `v0.2` resolved as
+# 0.2.0. SwiftPM cannot be pointed at a different tag series, so move the APP
+# tags out of its way instead:
+#
+#   RELEASE_TAG_PREFIX=app/v    ->  app/v1.0.0+5   invisible to SwiftPM
+#                                   1.2.0          a package release you chose to cut
+#
+# Tags cut before a change here still parse: the readers strip the configured
+# prefix, then fall back to a bare `v`. Set it to the empty string for bare
+# `1.0.0+5` tags (still SwiftPM-visible — that is not a fix for the above).
+RELEASE_TAG_PREFIX=v
+
 # ─── Apple credentials ────────────────────────────────────────────────────────
 # Get these from your Apple Developer account. The team id is at
 # https://developer.apple.com/account/#/membership. The ASC API key is

--- a/.github/workflows/bootstrap-doctor-matrix.yml
+++ b/.github/workflows/bootstrap-doctor-matrix.yml
@@ -63,6 +63,7 @@ on:
       - 'test/sh_stream_test.rb'
       - 'test/build_number_test.rb'
       - 'test/demo_account_required_test.rb'
+      - 'test/tag_prefix_test.rb'
       - 'test/xcconfig_test.rb'
       - 'bin/lib/review_detail.rb'
       - 'bin/lib/xcconfig.rb'
@@ -362,6 +363,22 @@ jobs:
           bundler-cache: false  # review_detail.rb has zero require lines
       - name: Run demo_account_required regression tests
         run: ruby test/demo_account_required_test.rb
+
+  # RELEASE_TAG_PREFIX moves the app's release tags out of the namespace SwiftPM
+  # resolves, for repos that are both an app and a package. The property this
+  # job protects is the DEFAULT: unset must behave exactly as the old hardcoded
+  # `v` did, or every fork's release path changes underneath it.
+  tag-prefix-regression:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: '3.3'
+          bundler-cache: false  # stdlib-only; spaceship is stubbed in test/stubs/
+      - name: Run release tag prefix tests
+        run: ruby test/tag_prefix_test.rb
 
   # Regression test for #108's BLOCKER 1: `make doctor` crashed with a
   # Bundler::GemNotFound stack trace on a fresh fork because no path in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`RELEASE_TAG_PREFIX` — release tags can move out of the namespace SwiftPM resolves.** A repo that is both an app *and* a SwiftPM package publishes both from one tag namespace, because SwiftPM claims every tag that parses as a version. So `v1.0.0+5` is simultaneously the app's release marker and package version `1.0.0`: an App Store metadata bump publishes a package version, adopters get a bump from a commit that never mentions SwiftPM, and the package cannot be versioned on its own merits.
+
+  **Measured rather than assumed.** With `v0.2`, `pkg-0.3.0`, `package/0.4.0` and `release/0.5.0` all tagged on a real repo, `.upToNextMajor(from: "0.1.0")` resolved to `0.1.1+9` — every *prefixed* tag was ignored — while a bare `v0.2` resolved as `0.2.0`. SwiftPM cannot be pointed at a different tag series, so the leverage runs the other way: move the **app** tags where SwiftPM cannot see them.
+
+  ```
+  RELEASE_TAG_PREFIX=app/v   ->  app/v1.0.0+5   invisible to SwiftPM
+                                 1.2.0          a package release you chose to cut
+  ```
+
+  **Unset means `v`, so no fork that ignores this changes at all** — that is the property the new `tag-prefix-regression` job exists to protect, and the reason `strip_release_tag_prefix` strips only the prefix rather than reparsing: the old `sub(/^v/, "")` preserved a canary tag's `-canary-N` suffix, and equivalence at the default was checked against all four tag shapes before the change landed.
+
+  Threaded through every reader: `Bootstrap::Version.tag_prefix` (canonical), `compute_release_tag`, `parse_tag`, the Fastfile's inlined `parse_release_tag` plus its GH-release tag glob and release-lane version, `ci/local-release-check.sh`, and `ci/bump-asc-version.rb`. Readers strip the configured prefix and then **fall back to a bare `v`**, so tags cut before a prefix change stay parseable. The tag-format check now validates the stripped version body rather than matching `^v`, which would have rejected every tag the moment a repo set a prefix.
+
+  `test/tag_prefix_test.rb` — 16 assertions across the default, a custom prefix, an explicitly empty one, and prefixes that could collide with the version body.
+
 - **`ci/check-shell.sh` — `bash -n` + ShellCheck over every tracked shell script, on every PR.** This template's release path is shell: `ci/local-release-check.sh` alone is ~470 lines of signing, packaging and re-signing. Nothing in CI executed any of it. The `app (...)` cells build the app; they never source `bin/rename.sh` or run the ship path, so **a PR that broke a shell script outright merged green** and failed later, on somebody's release.
 
   `bash -n` is the floor — a script that cannot be parsed should never reach main. ShellCheck at `warning` catches the tier above it, the constructs that run but do the wrong thing. It found 7 on first run, all now fixed:

--- a/bin/lib/version_resolver.rb
+++ b/bin/lib/version_resolver.rb
@@ -161,23 +161,61 @@ module Bootstrap
       raise
     end
 
+    # The release tag's prefix. `v` unless RELEASE_TAG_PREFIX says otherwise.
+    #
+    # WHY THIS IS CONFIGURABLE
+    #
+    # A repo that is BOTH an app and a SwiftPM package publishes both from one
+    # tag namespace, and SwiftPM claims every tag that parses as a version. So
+    # an App Store metadata bump that produces `v0.1.1+9` also publishes package
+    # version 0.1.1 — adopters get a version bump from a commit that says
+    # nothing about SwiftPM, and the package cannot be versioned on its own
+    # merits.
+    #
+    # Measured, not assumed: with tags `v0.2`, `pkg-0.3.0`, `package/0.4.0` and
+    # `release/0.5.0` all present, `.upToNextMajor(from: "0.1.0")` resolved to
+    # `0.1.1+9` — SwiftPM ignored every PREFIXED tag and took the bare one. It
+    # also resolved a bare `v0.2` as 0.2.0. There is no way to point SwiftPM at
+    # a non-default tag series; the leverage runs the other way, by moving the
+    # APP tags somewhere SwiftPM cannot see:
+    #
+    #   RELEASE_TAG_PREFIX=app/v    ->  app/v0.1.2+10   invisible to SwiftPM
+    #                                   0.2.0           a deliberate package release
+    #
+    # Unset means `v`, so every fork that does not set it is byte-for-byte
+    # unchanged. Set it to the empty string to get bare `1.0.0+5` tags.
+    def self.tag_prefix
+      ENV.fetch("RELEASE_TAG_PREFIX", "v")
+    end
+
     # Compose the full release tag. Caller must have ensured the ASC
     # token is set (or set RELEASE_BUILD_NUMBER env to skip the ASC
     # query path).
     def self.compute_release_tag(bundle_id, repo_root: Dir.pwd)
       marketing = read_marketing_version(repo_root: repo_root)
       build = next_build_number(bundle_id, marketing)
-      "v#{marketing}+#{build}"
+      "#{tag_prefix}#{marketing}+#{build}"
     end
 
-    # Parse a tag (with or without leading `v`) into [marketing, build].
-    # Build is nil when the tag has no `+` suffix (legacy tags).
+    # Parse a tag into [marketing, build]. Build is nil when the tag has no `+`
+    # suffix (legacy tags).
     #
     #   parse_tag("v1.0.0+5")             → ["1.0.0", "5"]
     #   parse_tag("v2026.19.1357")        → ["2026.19.1357", nil]
     #   parse_tag("v0.2026.19-canary-7")  → ["0.2026.19", nil]
+    #
+    # Strips the configured prefix, then falls back to a bare leading `v`. The
+    # fallback is what keeps tags cut BEFORE a prefix change readable: a repo
+    # that switches to `app/v` still has `v0.1.1+9` in its history, and
+    # `ci/bump-asc-version.rb` may be handed either.
     def self.parse_tag(tag)
-      body = tag.to_s.sub(/^v/, "")
+      raw = tag.to_s
+      pfx = tag_prefix
+      body = if !pfx.empty? && raw.start_with?(pfx)
+               raw[pfx.length..]
+             else
+               raw.sub(/^v/, "")
+             end
       if body.include?("+")
         marketing, build = body.split("+", 2)
         [marketing, build]

--- a/bin/submit.rb
+++ b/bin/submit.rb
@@ -126,7 +126,11 @@ puts "  marketing version: #{marketing || '(could not read from project file)'}"
 puts "  platforms:         #{platforms.join(', ')}"
 puts "  mode:              #{auto_submit ? 'submit_for_review=true (auto-submit)' : 'submit_for_review=false (stage only)'}"
 if auto_submit
-  puts "  GH Release:        will be created at v#{marketing}+<latest-build> if `gh` CLI is available"
+  # Read directly rather than via Bootstrap::Version.tag_prefix: this script does
+  # not load bin/lib/version_resolver.rb, and requiring it here would pull
+  # spaceship into startup for one display string. Canonical definition and
+  # rationale live in that file.
+  puts "  GH Release:        will be created at #{ENV.fetch('RELEASE_TAG_PREFIX', 'v')}#{marketing}+<latest-build> if `gh` CLI is available"
   puts "                     (set RELEASE_SKIP_GH_RELEASE=true to disable)"
 else
   puts "  GH Release:        skipped (only created on actual submit, not staging)"

--- a/ci/bump-asc-version.rb
+++ b/ci/bump-asc-version.rb
@@ -21,7 +21,11 @@ if ARGV.empty?
   exit 2
 end
 
-target = ARGV[0].sub(/^v/, '')
+# Strip the configured release-tag prefix, then fall back to a bare `v` so a tag
+# cut before a prefix change still resolves. See Bootstrap::Version.tag_prefix.
+_pfx = ENV.fetch("RELEASE_TAG_PREFIX", "v")
+_raw = ARGV[0].to_s
+target = (!_pfx.empty? && _raw.start_with?(_pfx)) ? _raw[_pfx.length..] : _raw.sub(/^v/, '')
 
 token = Spaceship::ConnectAPI::Token.create(
   key_id:    ENV.fetch("ASC_API_KEY_ID"),

--- a/ci/local-release-check.sh
+++ b/ci/local-release-check.sh
@@ -102,7 +102,13 @@ with_timestamp_retry() {
 # Apple Distribution cert SHA-1 resolver — shared library; SHA-pinned across consumer repos.
 . "$(dirname "${BASH_SOURCE[0]}")/lib/resolve-dist-cert-sha.sh"
 
-VERSION="${TAG#v}"
+# Release tag prefix. `-` not `:-`, so an explicitly empty RELEASE_TAG_PREFIX
+# (bare `1.0.0+5` tags) is honoured rather than coerced back to `v`. Canonical
+# definition and rationale: Bootstrap::Version.tag_prefix.
+RELEASE_TAG_PREFIX="${RELEASE_TAG_PREFIX-v}"
+VERSION="${TAG#"$RELEASE_TAG_PREFIX"}"
+# Fall back to a bare `v` so a tag cut BEFORE a prefix change still parses.
+[ "$VERSION" = "$TAG" ] && VERSION="${TAG#v}"
 # Tag carries marketing version and (new format) build number:
 #   v1.0.0+5                  → MARKETING=1.0.0, BUILD=5  (apple-shipkit v1.7+ default)
 #   v0.YYYY.WW-canary-N-gen   → MARKETING=0.YYYY.WW, BUILD=$RELEASE_BUILD_NUMBER (canary)
@@ -186,10 +192,13 @@ esac
 # ── Tag format check ──────────────────────────────────────────────────────────
 
 step "Tag format"
-if echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+([-+].+)?$'; then
+# Checked on the STRIPPED version rather than the raw tag, so the rule is about
+# the version body and holds for any RELEASE_TAG_PREFIX. Matching a hardcoded
+# `^v` here would reject every tag the moment a repo set a prefix.
+if echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([-+].+)?$'; then
   ok "$TAG"
 else
-  fail "Tag '$TAG' does not match v[0-9]+.[0-9]+.[0-9]+(...) (e.g. v0.1.0, v0.1.0-rc1)"
+  fail "Tag '$TAG' (version body '$VERSION') does not match [0-9]+.[0-9]+.[0-9]+(...) — e.g. ${RELEASE_TAG_PREFIX}0.1.0, ${RELEASE_TAG_PREFIX}0.1.0-rc1"
 fi
 
 # ── App icon ──────────────────────────────────────────────────────────────────

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -293,8 +293,27 @@ end
 # Fastfile loads in fastlane's own context where load paths are
 # unstable across runners. Five-line helper isn't worth the cross-tree
 # require headache.
+# Mirrors Bootstrap::Version.tag_prefix (bin/lib/version_resolver.rb), which is
+# the canonical definition — see its header for why the prefix is configurable at
+# all. Duplicated for the same load-path reason as parse_release_tag below.
+def release_tag_prefix
+  ENV.fetch("RELEASE_TAG_PREFIX", "v")
+end
+
+# Strip only the prefix, leaving the rest of the tag untouched. Exactly
+# equivalent to the old `sub(/^v/, "")` when the prefix is the default `v`,
+# which matters because canary tags carry a `-canary-N` suffix that callers
+# still need.
+def strip_release_tag_prefix(tag)
+  raw = tag.to_s
+  pfx = release_tag_prefix
+  # Configured prefix first, then a bare `v` so tags cut BEFORE a prefix change
+  # stay readable.
+  (!pfx.empty? && raw.start_with?(pfx)) ? raw[pfx.length..] : raw.sub(/^v/, "")
+end
+
 def parse_release_tag(tag)
-  body = tag.to_s.sub(/^v/, "")
+  body = strip_release_tag_prefix(tag)
   if body.include?("+")
     body.split("+", 2)
   else
@@ -726,15 +745,18 @@ def create_github_release_if_missing(repo_root:)
   system("git", "-C", repo_root, "fetch", "--tags", "--quiet", "origin",
          out: File::NULL, err: File::NULL)
 
-  # Find the most-recent `vMARKETING+*` tag (the actual build being submitted).
-  tag = `cd #{repo_root.shellescape} && git tag --sort=-creatordate --list 'v#{marketing}+*' 2>/dev/null`.lines.first&.strip
+  # Find the most-recent `<prefix>MARKETING+*` tag (the actual build being
+  # submitted). Globbing a hardcoded `v` here would silently find nothing once a
+  # repo sets RELEASE_TAG_PREFIX, and the GH release would just be "skipped".
+  pfx = release_tag_prefix
+  tag = `cd #{repo_root.shellescape} && git tag --sort=-creatordate --list '#{pfx}#{marketing}+*' 2>/dev/null`.lines.first&.strip
   if tag.nil? || tag.empty?
-    # Fall back to bare `vMARKETING` if no `+BUILD` variants exist (e.g. a
+    # Fall back to bare `<prefix>MARKETING` if no `+BUILD` variants exist (e.g. a
     # marketing version that pre-dates the v1.7 tag scheme).
-    tag = `cd #{repo_root.shellescape} && git tag --sort=-creatordate --list 'v#{marketing}' 2>/dev/null`.lines.first&.strip
+    tag = `cd #{repo_root.shellescape} && git tag --sort=-creatordate --list '#{pfx}#{marketing}' 2>/dev/null`.lines.first&.strip
   end
   if tag.nil? || tag.empty?
-    UI.important("GH Release: no `v#{marketing}*` tag found locally (run `make ship` first or fetch tags); skipping.")
+    UI.important("GH Release: no `#{pfx}#{marketing}*` tag found locally (run `make ship` first or fetch tags); skipping.")
     return
   end
 
@@ -1652,7 +1674,7 @@ platform :ios do
     changelog_arg  = options[:changelog]
 
     repo_root = File.expand_path("..", __dir__)
-    version   = tag.sub(/^v/, "")
+    version   = strip_release_tag_prefix(tag)
     dry_run   = skip_upload || skip_tag
 
     # PLATFORMS gates which targets get built/signed/uploaded.

--- a/test/tag_prefix_test.rb
+++ b/test/tag_prefix_test.rb
@@ -1,0 +1,86 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Contract test for Bootstrap::Version.tag_prefix / parse_tag.
+#
+# Why this exists: a repo that is both an app and a SwiftPM package publishes
+# both from one tag namespace, and SwiftPM claims every tag that parses as a
+# version. Measured on tunnelless: a bare `v0.2` tag made
+# `.upToNextMajor(from: "0.1.0")` resolve to 0.2.0, while `pkg-0.3.0`,
+# `package/0.4.0` and `release/0.5.0` were all ignored. SwiftPM cannot be pointed
+# at a non-default tag series, so the app tags move instead.
+#
+# The property that matters most here is the DEFAULT: unset RELEASE_TAG_PREFIX
+# must behave exactly as before, or every fork's release path changes under it.
+#
+# Runnable locally:
+#   ruby test/tag_prefix_test.rb
+
+$LOAD_PATH.unshift File.expand_path("stubs", __dir__)
+$LOAD_PATH.unshift File.expand_path("../bin", __dir__)
+require "lib/bootstrap"
+require "lib/version_resolver"
+
+V = Bootstrap::Version
+@failures = 0
+
+def assert_eq(actual, expected, label)
+  if actual == expected
+    puts "  ✓ #{label}"
+  else
+    @failures += 1
+    puts "  ✗ #{label}\n      expected: #{expected.inspect}\n      actual:   #{actual.inspect}"
+  end
+end
+
+def with_prefix(value)
+  had = ENV.key?("RELEASE_TAG_PREFIX")
+  old = ENV["RELEASE_TAG_PREFIX"]
+  value.nil? ? ENV.delete("RELEASE_TAG_PREFIX") : ENV["RELEASE_TAG_PREFIX"] = value
+  yield
+ensure
+  had ? ENV["RELEASE_TAG_PREFIX"] = old : ENV.delete("RELEASE_TAG_PREFIX")
+end
+
+puts "default (unset) — must be indistinguishable from before"
+with_prefix(nil) do
+  assert_eq V.tag_prefix,                       "v",                  "prefix defaults to v"
+  assert_eq V.parse_tag("v1.0.0+5"),            ["1.0.0", "5"],       "v1.0.0+5"
+  assert_eq V.parse_tag("v2026.19.1357"),       ["2026.19.1357", nil], "legacy CalVer, no build"
+  assert_eq V.parse_tag("v0.2026.19-canary-7"), ["0.2026.19", nil],   "canary tag"
+  assert_eq V.parse_tag("1.0.0+5"),             ["1.0.0", "5"],       "bare tag still parses"
+end
+
+puts "\ncustom prefix"
+with_prefix("app/v") do
+  assert_eq V.tag_prefix,                    "app/v",         "prefix is read from the env"
+  assert_eq V.parse_tag("app/v1.0.0+5"),     ["1.0.0", "5"],  "app/v1.0.0+5 round-trips"
+  assert_eq V.parse_tag("app/v0.1.2+10"),    ["0.1.2", "10"], "two-digit build"
+  # The reason the fallback exists: tags cut before the switch are still around.
+  assert_eq V.parse_tag("v0.1.1+9"),         ["0.1.1", "9"],  "pre-switch v-tag still readable"
+  assert_eq V.parse_tag("app/v2026.19.1357"), ["2026.19.1357", nil], "prefixed legacy CalVer"
+end
+
+puts "\nempty prefix — bare tags, an explicit choice rather than the default"
+with_prefix("") do
+  assert_eq V.tag_prefix,            "",             "empty string is honoured, not coerced to v"
+  assert_eq V.parse_tag("1.0.0+5"),  ["1.0.0", "5"], "bare tag"
+  assert_eq V.parse_tag("v1.0.0+5"), ["1.0.0", "5"], "v-tag still readable via the fallback"
+end
+
+puts "\nprefixes that could collide with the version body"
+with_prefix("release/") do
+  assert_eq V.parse_tag("release/1.0.0+5"), ["1.0.0", "5"], "slash prefix, no v"
+end
+with_prefix("v") do
+  # "v" is both the default and a legal explicit value; must not strip twice.
+  assert_eq V.parse_tag("v1.0.0+5"), ["1.0.0", "5"], "explicit v behaves like the default"
+end
+
+if @failures.zero?
+  puts "\nAll 16 tag prefix tests passed."
+  exit 0
+else
+  puts "\n#{@failures} test(s) failed."
+  exit 1
+end


### PR DESCRIPTION
## The problem

A repo that is both an app **and** a SwiftPM package publishes both from one tag namespace, because SwiftPM claims every tag that parses as a version.

So `v1.0.0+5` is simultaneously the app's release marker *and* package version `1.0.0`. An App Store metadata bump publishes a package version; adopters get a version bump from a commit that never mentions SwiftPM; and the package cannot be versioned on its own merits.

## Measured, not assumed

I tagged a real repo and resolved against it rather than reasoning about SwiftPM's rules:

| tags present | `.upToNextMajor(from: "0.1.0")` resolved to |
|---|---|
| `pkg-0.3.0`, `package/0.4.0`, `release/0.5.0`, `milestone/v0.2` | **`0.1.1+9`** — every prefixed tag ignored |
| `v0.2` | **`0.2.0`** — a bare tag is claimed immediately |

So SwiftPM cannot be pointed at a different tag series — the third option people reach for does not exist. The leverage runs the other way: move the **app** tags where SwiftPM cannot see them.

```
RELEASE_TAG_PREFIX=app/v   ->  app/v1.0.0+5   invisible to SwiftPM
                               1.2.0          a package release you chose to cut
```

## The safety property

**Unset means `v`, so a fork that ignores this is byte-for-byte unchanged.** That is the whole contract, and it is what the new `tag-prefix-regression` job exists to protect.

It is also why `strip_release_tag_prefix` strips *only* the prefix rather than reparsing and reassembling. The old `sub(/^v/, "")` preserved a canary tag's `-canary-N` suffix; my first attempt dropped it. Equivalence at the default was then checked across all four tag shapes before this landed:

| tag | old `sub(/^v/,"")` | new | |
|---|---|---|---|
| `v1.0.0+5` | `1.0.0+5` | `1.0.0+5` | same |
| `v2026.19.1357` | `2026.19.1357` | `2026.19.1357` | same |
| `v0.2026.19-canary-7` | `0.2026.19-canary-7` | `0.2026.19-canary-7` | same |
| `1.0.0+5` | `1.0.0+5` | `1.0.0+5` | same |

## Threaded through every reader

`Bootstrap::Version.tag_prefix` (canonical), `compute_release_tag`, `parse_tag`, the Fastfile's inlined `parse_release_tag` plus **its GH-release tag glob** and release-lane version, `ci/local-release-check.sh`, and `ci/bump-asc-version.rb`.

Two details worth calling out:

- Every reader strips the configured prefix and then **falls back to a bare `v`** — so tags cut *before* a prefix change stay parseable. A repo switching to `app/v` still has `v0.1.1+9` in its history.
- The tag-format check now validates the **stripped version body** instead of matching `^v`, which would have rejected every tag the moment a repo set a prefix.
- The GH-release lookup globs `'#{pfx}#{marketing}+*'`. Left hardcoded, it would have silently found nothing and merely reported "skipping".

`bin/submit.rb` reads the env directly rather than via `Bootstrap::Version` — it does not load `version_resolver`, and requiring it there would pull `spaceship` into startup for one display string. **Caught by a runtime probe, not by reading**: the first version raised `NameError: uninitialized constant Bootstrap::Version`.

## Verification

- `test/tag_prefix_test.rb` — **16/16**: the default, a custom prefix, an explicitly empty one, prefixes that collide with the version body, and pre-switch tags still parsing
- shell-side stripping exercised for unset / `app/v` / empty across all four tag shapes
- siblings unaffected: parser 9/9, `Sh.stream` 10/10, build number 11/11, xcconfig 51 checks, demo-account 14/14
- `ci/check-shell.sh` clean

Documented in `.bootstrap.env.example` with the measurement, so the next reader does not have to re-derive why it exists.