### PR TITLE
fix(release): plumb RELEASE_TAG_PREFIX from .bootstrap.env into fastlane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `bin/refork-smoketest.sh` — added `--skip-cert-revoke` to skip step 2's team-wide "revoke all `Created via API` certs" residue cleanup. That step is safe only when the smoketest owns its Apple team alone; once the team is **shared** (e.g. the canary reforked onto the Indiagram LLC account alongside a real app), a blanket revoke would kill the co-tenant's API-minted certs — verified against the LLC, where an `Apple Development: Created via API` cert belonging to another app would have matched the filter. With the flag, step 2 no-ops (the canary mints + revokes its own certs each run, and a shared team has no smoketest residue to clean anyway).
 
+### Fixed
+
+- **`RELEASE_TAG_PREFIX` was unreachable from `.bootstrap.env`, and never reached fastlane.** Shipped incomplete in the commit below. `Bootstrap::Config` is parsed from the file with no `ENV` merge, and `Bootstrap::Version.tag_prefix` reads `ENV` — so setting the prefix in `.bootstrap.env` did nothing. Worse, `Bootstrap.asc_env` did not propagate it, so even with the env set, `bin/ship.rb` computed `app/v0.1.2+10` and handed it to a fastlane subprocess that still believed the prefix was `v`: `strip_release_tag_prefix` left the tag intact and every artifact name downstream was built from `app/v0.1.2+10`.
+
+  Adds `Config#release_tag_prefix` (process env → `.bootstrap.env` → `"v"`, with an explicitly empty value honoured at both layers rather than falling through), lists the key in `Config::OPTIONAL`, propagates it through `asc_env`, and has `bin/ship.rb` and `bin/compute-release-tag.rb` publish the resolved value into `ENV` before computing so the resolver and fastlane cannot disagree.
+
+  `test/tag_prefix_test.rb` grows to 23 assertions covering exactly this. Mutation-verified: removing the `asc_env` propagation fails 1, and making the accessor ignore the file fails 2.
+
 ### Added
 
 - **`RELEASE_TAG_PREFIX` — release tags can move out of the namespace SwiftPM resolves.** A repo that is both an app *and* a SwiftPM package publishes both from one tag namespace, because SwiftPM claims every tag that parses as a version. So `v1.0.0+5` is simultaneously the app's release marker and package version `1.0.0`: an App Store metadata bump publishes a package version, adopters get a bump from a commit that never mentions SwiftPM, and the package cannot be versioned on its own merits.

--- a/bin/compute-release-tag.rb
+++ b/bin/compute-release-tag.rb
@@ -40,6 +40,10 @@ if Bootstrap::ENV_FILE.exist?
   config = Bootstrap::Config.load!
   config.validate!
   bundle_id = config["BUNDLE_ID"]
+  # Version.tag_prefix reads ENV; the setting lives in .bootstrap.env. Publish it
+  # so a plain `ruby bin/compute-release-tag.rb` and `make ship` agree on the
+  # prefix. config.release_tag_prefix already gives the process env precedence.
+  ENV["RELEASE_TAG_PREFIX"] = config.release_tag_prefix
 
   # Skip the ASC token setup entirely when RELEASE_BUILD_NUMBER short-
   # circuits the ASC query. Useful in CI environments that want

--- a/bin/lib/bootstrap.rb
+++ b/bin/lib/bootstrap.rb
@@ -85,7 +85,7 @@ module Bootstrap
       KEYCHAIN_PASSWORD_FILE
     ].freeze
 
-    OPTIONAL = %w[ICON_1024_PATH ASC_APP_SKU ASC_APP_NAME PLATFORMS SUBMIT_FOR_REVIEW].freeze
+    OPTIONAL = %w[ICON_1024_PATH ASC_APP_SKU ASC_APP_NAME PLATFORMS SUBMIT_FOR_REVIEW RELEASE_TAG_PREFIX].freeze
 
     attr_reader :values
 
@@ -198,6 +198,23 @@ module Bootstrap
     def release_mode
       m = self["RELEASE_MODE"]
       m.empty? ? "ci" : m
+    end
+
+    # Prefix for the release tag `make ship` pushes. See
+    # Bootstrap::Version.tag_prefix for WHY this is configurable.
+    #
+    # Precedence: process env, then .bootstrap.env, then "v". The env layer is
+    # what makes a one-off `RELEASE_TAG_PREFIX=app/v make ship` work, and it
+    # matches how SUBMIT_FOR_REVIEW already behaves.
+    #
+    # An explicitly EMPTY value is honoured at both layers rather than falling
+    # through to "v" — empty means bare `1.0.0+5` tags, which is a choice
+    # somebody can legitimately make.
+    def release_tag_prefix
+      return ENV["RELEASE_TAG_PREFIX"] if ENV.key?("RELEASE_TAG_PREFIX")
+      return @values["RELEASE_TAG_PREFIX"] if @values.key?("RELEASE_TAG_PREFIX")
+
+      "v"
     end
 
     # Returns the active platforms as an array of strings.
@@ -1683,6 +1700,11 @@ module Bootstrap
       # path since v1.6 (#158). We still propagate it here so any future
       # lane logic that wants to know the invocation context can read it.
       "RELEASE_MODE"            => config.release_mode,
+      # Without this, bin/ship.rb computes the tag with the configured prefix
+      # and then hands it to a fastlane subprocess that still believes the
+      # prefix is "v" — so `strip_release_tag_prefix` leaves `app/v0.1.2+10`
+      # intact and every artifact name downstream is built from it.
+      "RELEASE_TAG_PREFIX"      => config.release_tag_prefix,
       "FASTLANE_HIDE_CHANGELOG" => "1",
       "FASTLANE_SKIP_UPDATE_CHECK" => "1"
     }

--- a/bin/ship.rb
+++ b/bin/ship.rb
@@ -80,6 +80,10 @@ if config.local_mode?
   require_relative "lib/version_resolver"
   require "spaceship"
   Bootstrap.ensure_asc_token!(config)
+  # Version.tag_prefix reads ENV, while the setting lives in .bootstrap.env, so
+  # publish it before computing. Assigned rather than ||=: config.release_tag_prefix
+  # already gives ENV precedence, so this is a no-op when the caller set it.
+  ENV["RELEASE_TAG_PREFIX"] = config.release_tag_prefix
   begin
     tag = Bootstrap::Version.compute_release_tag(config["BUNDLE_ID"])
   rescue StandardError => e

--- a/test/tag_prefix_test.rb
+++ b/test/tag_prefix_test.rb
@@ -77,8 +77,37 @@ with_prefix("v") do
   assert_eq V.parse_tag("v1.0.0+5"), ["1.0.0", "5"], "explicit v behaves like the default"
 end
 
+# The setting lives in .bootstrap.env, but Version.tag_prefix reads ENV — so the
+# value has to be plumbed from one to the other, and then into the fastlane
+# subprocess. The first version of this feature did neither: ship.rb computed
+# `app/v0.1.2+10` and handed it to a fastlane process that still thought the
+# prefix was "v", leaving the tag unstripped and every artifact name built from
+# it. These are the assertions that would have caught that.
+puts "\nconfig plumbing"
+cfg = Bootstrap::Config.new("RELEASE_TAG_PREFIX" => "app/v")
+with_prefix(nil) do
+  assert_eq cfg.release_tag_prefix, "app/v", ".bootstrap.env value is read"
+end
+with_prefix("release/") do
+  assert_eq cfg.release_tag_prefix, "release/", "process env beats .bootstrap.env"
+end
+with_prefix(nil) do
+  assert_eq Bootstrap::Config.new({}).release_tag_prefix, "v", "absent everywhere defaults to v"
+  assert_eq Bootstrap::Config.new("RELEASE_TAG_PREFIX" => "").release_tag_prefix, "",
+            "explicit empty in the file is honoured, not coerced to v"
+end
+with_prefix("") do
+  assert_eq cfg.release_tag_prefix, "", "explicit empty in env is honoured"
+end
+
+# asc_env is what reaches the fastlane subprocess.
+assert_eq Bootstrap.method(:asc_env).source_location.nil?, false, "asc_env exists"
+asc_env_src = File.read(File.expand_path("../bin/lib/bootstrap.rb", __dir__))
+assert_eq asc_env_src.include?('"RELEASE_TAG_PREFIX"      => config.release_tag_prefix'), true,
+          "asc_env propagates RELEASE_TAG_PREFIX to fastlane"
+
 if @failures.zero?
-  puts "\nAll 16 tag prefix tests passed."
+  puts "\nAll 23 tag prefix tests passed."
   exit 0
 else
   puts "\n#{@failures} test(s) failed."


### PR DESCRIPTION
Follow-up to [#286](https://github.com/indiagrams/apple-shipkit/pull/286), which shipped the knob incomplete. Found while adopting it downstream, not by re-reading the diff.

## Two gaps

**1. The setting was unreachable from `.bootstrap.env`.** `Bootstrap::Config` is parsed from the file with no `ENV` merge, while `Bootstrap::Version.tag_prefix` reads `ENV`. So the field documented in `.bootstrap.env.example` did nothing — the one place a user would naturally set it.

**2. `asc_env` did not propagate it.** This is the worse one. Even with the env var set correctly, `bin/ship.rb` computes the tag in *its own* process and then launches fastlane with `Bootstrap.asc_env(config)` — which did not carry `RELEASE_TAG_PREFIX`. So:

```
ship.rb   → computes  app/v0.1.2+10
fastlane  → prefix is "v", tag does not start with it, `sub(/^v/,"")` no-ops
          → version = "app/v0.1.2+10"
          → every artifact name downstream built from that
```

A silent, wrong-output failure of exactly the kind this repo keeps running into: both processes succeed, and only the artifacts are wrong.

## The fix

- `Config#release_tag_prefix` — process env → `.bootstrap.env` → `"v"`. An explicitly **empty** value is honoured at both layers rather than falling through to `"v"`, since empty is a legitimate choice (bare `1.0.0+5` tags).
- `RELEASE_TAG_PREFIX` added to `Config::OPTIONAL`.
- `asc_env` propagates it to the fastlane subprocess.
- `bin/ship.rb` and `bin/compute-release-tag.rb` publish the resolved value into `ENV` *before* computing, so the resolver and fastlane cannot disagree.

## Verification

`test/tag_prefix_test.rb` grows 16 → **23**, the new ones covering precisely this plumbing.

Mutation-verified:

| mutation | assertions killed |
|---|---|
| drop the `asc_env` propagation (*gap 2, as shipped*) | 1 |
| make the accessor ignore `.bootstrap.env` (*gap 1*) | 2 |

`ci/check-shell.sh` clean.