### PR TITLE
docs: identity is edited in app/Identity.xcconfig, and SCOPE.md names a directory that exists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,9 @@ The fork ↔ upstream sync property is the most important architectural invarian
 |---|---|---|
 | Do **not** edit `fastlane/Fastfile` | Template-owned; upstream changes will conflict on every `git pull upstream main` | Add to `fastlane/Fastfile.local` (see "Custom fastlane logic" below) |
 | Do **not** hardcode `APP_NAME` / `BUNDLE_ID` / ASC URLs in workflows or scripts | They resolve from `.bootstrap.env` (Fastfile) or repo `vars.*` (workflows) | Set the env / repo variable |
-| Do **not** edit files under `bin/`, `ci/`, `.github/workflows/`, `Makefile` | Template-owned | Override via env, or open an upstream issue at `indiagrams/apple-shipkit` |
+| Do **not** edit files under `bin/`, `ci/`, `.github/workflows/`, `Makefile` | Template-owned | Override via env, or open an upstream issue at `indiagrams/apple-shipkit` — the TEMPLATE, not your own fork. If your copy of this cell names your fork instead, a personalization sweep rewrote the one pointer that tells you where to send fixes |
 | Do **not** commit secrets | `.bootstrap.env` and `.p8` files are gitignored | Commit `.bootstrap.env.example` only; real values live in GitHub Secrets / `~/.config/secrets/` |
-| Do **not** sed-substitute `HelloApp` literals | The template uses env-driven resolution everywhere it matters | Run `bin/rename.sh MyApp com.example.myapp "My App" --email=you@example.com` once at fork creation; afterward, the value is set in `.bootstrap.env` |
+| Do **not** sed-substitute `HelloApp` literals | The template resolves identity everywhere it matters | Run `bin/rename.sh MyApp com.example.myapp "My App" --email=you@example.com` once at fork creation; afterward, edit the four keys of `app/Identity.xcconfig` — that is where `bin/rename.sh` writes them and where both generators read them as `$(VAR)`. `.bootstrap.env` keeps its own `APP_NAME` / `BUNDLE_ID` handle, which the Fastfile and the release workflows read; it is not where the build gets its identity |
 
 ## Where your code goes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`AGENTS.md` and `SCOPE.md` told an agent two things that had stopped being true.** Both are read top-down by tools that cannot cross-check them against the tree.
+
+  The critical-invariants row on identity still ended "afterward, the value is set in `.bootstrap.env`", while `bin/rename.sh` has written `app/Identity.xcconfig` since identity became a slot, and the "Where your code goes" table seventeen lines below already named that file as "the one tracked identity file". One document, two incompatible instruction sets. The row now says identity is edited in `app/Identity.xcconfig`, and says what the `.bootstrap.env` handle is still for rather than dropping it: `APP_NAME` / `BUNDLE_ID` there are what the Fastfile and the release workflows read, and they are not where the build gets its identity.
+
+  `SCOPE.md`'s one test — the sentence every contribution is filtered through — named `app/HelloApp/`, a directory that has never existed. Measured with `git ls-tree -r --name-only <ref> -- app/` at five refs including the root commit: zero entries under `app/HelloApp/` at every one of them, and `app/Shared/` present at every one. A reader who runs the test literally has to guess which directory is meant, and the guess is the whole rule. It now names `app/Shared/`.
+
+  The template-owned row's "open an upstream issue at `indiagrams/apple-shipkit`" now says outright that the slug names the TEMPLATE and not your own fork. `bin/rename.sh`'s Step D substitutes that slug wherever it appears — measured on this tree at 15 tracked files after the script's own exclusion list is applied, `AGENTS.md` among them — so in a fork the one line telling a reader where to send fixes upstream has been rewritten to point back at the fork itself. The prose makes that visible to anyone reading a personalized copy. Narrowing the sweep is a behaviour change and is not in this docs-only pull request.
+
+### Fixed
+
 - **`RELEASE_TAG_PREFIX` was unreachable from `.bootstrap.env`, and never reached fastlane.** Shipped incomplete in the commit below. `Bootstrap::Config` is parsed from the file with no `ENV` merge, and `Bootstrap::Version.tag_prefix` reads `ENV` — so setting the prefix in `.bootstrap.env` did nothing. Worse, `Bootstrap.asc_env` did not propagate it, so even with the env set, `bin/ship.rb` computed `app/v0.1.2+10` and handed it to a fastlane subprocess that still believed the prefix was `v`: `strip_release_tag_prefix` left the tag intact and every artifact name downstream was built from `app/v0.1.2+10`.
 
   Adds `Config#release_tag_prefix` (process env → `.bootstrap.env` → `"v"`, with an explicitly empty value honoured at both layers rather than falling through), lists the key in `Config::OPTIONAL`, propagates it through `asc_env`, and has `bin/ship.rb` and `bin/compute-release-tag.rb` publish the resolved value into `ENV` before computing so the resolver and fastlane cannot disagree.

--- a/SCOPE.md
+++ b/SCOPE.md
@@ -8,7 +8,7 @@ The framing was crystallized by an early forker on r/iOSProgramming: *"stuff aro
 
 Before opening an enhancement issue or PR, ask:
 
-> **Does this addition require modifying Swift source files in `app/HelloApp/` to use it?**
+> **Does this addition require modifying Swift source files in `app/Shared/` to use it?**
 
 - **No** → around the project; in scope. PRs welcome.
 - **Yes** → inside the project; deliberately out of scope.


### PR DESCRIPTION
Three corrections to the two documents an agent reads before touching anything. Docs only; no behaviour changes.

## 1. `AGENTS.md`'s identity invariant still pointed at `.bootstrap.env`

The critical-invariants row ended *"afterward, the value is set in `.bootstrap.env`"*. `bin/rename.sh` has written `app/Identity.xcconfig` since identity became a slot, and the "Where your code goes" table seventeen lines below already calls that file *"the one tracked identity file"*. An agent reading this file top-down gets two incompatible instruction sets out of one document, and the one it hits first is the wrong one.

The row now points at `app/Identity.xcconfig` **and keeps the `.bootstrap.env` mention rather than deleting it**, because deleting it would be its own kind of false: `APP_NAME` / `BUNDLE_ID` there really are read, by the Fastfile and by `release.yml` / `canary-local-mode.yml`. The row now says which of the two is which — the xcconfig is where the build gets its identity; the dotenv is a handle for fastlane and the release workflows.

## 2. `SCOPE.md`'s one test named a directory that has never existed

> **Does this addition require modifying Swift source files in `app/HelloApp/` to use it?**

Measured rather than assumed, with `git ls-tree -r --name-only <ref> -- app/` at five refs including the root commit `f9cd5a8`: **zero** entries under `app/HelloApp/` at every one of them, and `app/Shared/` present at every one. That sentence is the entire contribution rule, so a contributor who runs it literally has to guess which directory is meant — and the guess is the rule. It now names `app/Shared/`.

## 3. The template-owned row's issue pointer now says whose slug it is

`| Do not edit files under bin/, ci/, .github/workflows/, Makefile | Template-owned | Override via env, or open an upstream issue at `indiagrams/apple-shipkit` |`

Correct as it stands here. It stops being correct the moment somebody forks, because `bin/rename.sh`'s Step D substitutes that slug wherever it appears. Measured on this tree: **15 tracked files** once the script's own `PATHSPEC_EXCLUSIONS` are applied, `AGENTS.md` among them. So in a personalized fork the one line telling a reader where to send fixes *upstream* has been rewritten to point back at the fork itself, and no gate sees it happen — this was found downstream, in a fork whose copy of that row named the fork.

The cell now says outright that the slug names the TEMPLATE and not your own fork, and that a copy naming your fork means a sweep rewrote it. That makes the defect visible to whoever is reading the personalized copy.

**Narrowing the sweep is behaviour and is not in this PR.** It is in the parameterization change that follows.

## Test plan

- `git ls-tree -r --name-only <ref> -- app/` at `212b489`, `c6c324f`, `d714006`, `658bd32` and the root commit `f9cd5a8`: `app/HelloApp/` = 0 entries at all five, `app/Shared/` present at all five.
- `git grep -lw -F -e 'indiagrams/apple-shipkit' -- . <PATHSPEC_EXCLUSIONS>` = 15 files, `AGENTS.md` among them.
- Markdown only. No script, workflow, manifest or test is touched; `git diff --stat` is `AGENTS.md | 4 ++--`, `CHANGELOG.md | 10 ++++++++++`, `SCOPE.md | 2 +-`.
- CHANGELOG entry included, per CONTRIBUTING.md.
