### PR TITLE
fix: reads inherit the locale's encoding, so a fork with LANG unset cannot bootstrap

### DIFF
--- a/.github/workflows/bootstrap-doctor-matrix.yml
+++ b/.github/workflows/bootstrap-doctor-matrix.yml
@@ -34,6 +34,15 @@
 #                               importantly, when an honest derivation is left
 #                               alone.
 #
+#   encoding-regression       — every read of a file in the tracked tree must state its
+#                               encoding. Ruby takes it from the environment, so with LANG
+#                               and LC_ALL unset an unpinned read is US-ASCII and the next
+#                               strip or match raises. .bootstrap.env.example carries 53
+#                               lines with non-ASCII bytes and init-bootstrap-env.sh copies
+#                               it verbatim, so the shipped configuration is the trigger.
+#                               Stdlib-only, hermetic, and it spawns a locale-cleared child
+#                               that runs the REAL parser against that REAL example file.
+#
 #   bundle-guard-regression   — runs `make doctor` on a fresh checkout WITHOUT
 #                               `bundle install`. Asserts friendly-error path
 #                               (`Ruby gems aren't installed yet`) instead of
@@ -60,6 +69,10 @@ on:
   pull_request:
     paths:
       - 'test/parser_test.rb'
+      - 'test/encoding_test.rb'
+      - 'bin/adopt.rb'
+      - 'bin/submit.rb'
+      - 'bin/compute-release-tag.rb'
       - 'test/sh_stream_test.rb'
       - 'test/build_number_test.rb'
       - 'test/demo_account_required_test.rb'
@@ -372,6 +385,38 @@ jobs:
           bundler-cache: false  # parser_test.rb is stdlib-only; no bundle exec needed
       - name: Run parser regression fixtures
         run: ruby test/parser_test.rb
+
+  # Ruby decides the encoding of a file it reads from the environment. With LANG
+  # and LC_ALL unset — a fresh machine, a cron job, a bare container — the default
+  # is US-ASCII, so a read with no explicit encoding returns a String whose tag and
+  # whose bytes disagree. The read is silent; the next strip, concatenation or
+  # regex raises and the operator gets a backtrace where a named refusal belonged.
+  #
+  # This template shipped that. .bootstrap.env.example carries 53 lines with
+  # non-ASCII bytes, bin/init-bootstrap-env.sh copies it verbatim, and
+  # Bootstrap::Config.parse is the read every entry point goes through — so
+  # `make doctor` and `make bootstrap-fork` both died before printing a single
+  # step. Every suite stayed green because every CI runner sets a locale, which is
+  # exactly why this gate has to read source rather than wait for a runtime.
+  #
+  # Fixing one reported site at a time does not hold, so the test demands a stated
+  # verdict — pinned, binary, or an exemption with a written reason — for EVERY
+  # read in the tracked tree, and fails on a site that has none. It also spawns a
+  # locale-cleared child that runs the REAL parser against the REAL tracked
+  # example file, so a green here is behaviour and not only text.
+  #
+  # Stdlib-only and platform-agnostic, so it runs on ubuntu like the parser test.
+  encoding-regression:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: '3.3'
+          bundler-cache: false  # encoding_test.rb is stdlib-only; no bundle exec needed
+      - name: Run the encoding sweep
+        run: ruby test/encoding_test.rb
 
   # `make ship` on a real release wrote a 13-line log: everything ship.rb
   # printed itself, and nothing from the fastlane run those lines described.

--- a/bin/adopt.rb
+++ b/bin/adopt.rb
@@ -39,7 +39,7 @@ unless env_path.file?
 end
 
 config = {}
-env_path.each_line do |line|
+File.read(env_path, encoding: "UTF-8").each_line do |line|
   line = line.strip
   next if line.empty? || line.start_with?("#")
   k, v = line.split("=", 2)

--- a/bin/compute-release-tag.rb
+++ b/bin/compute-release-tag.rb
@@ -82,7 +82,7 @@ else
     Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.create(
       key_id: ENV.fetch("ASC_API_KEY_ID"),
       issuer_id: ENV.fetch("ASC_API_KEY_ISSUER_ID"),
-      key: File.read(p8_path),
+      key: File.binread(p8_path),
     )
   end
 end

--- a/bin/lib/bootstrap.rb
+++ b/bin/lib/bootstrap.rb
@@ -113,7 +113,20 @@ module Bootstrap
 
     def self.parse(path)
       values = {}
-      path.each_line.with_index do |line, idx|
+      # UTF-8 pinned, never inherited from the locale. Ruby takes the encoding of a
+      # file it reads from the environment: with LANG and LC_ALL unset
+      # Encoding.default_external is US-ASCII, so this read hands back a String tagged
+      # US-ASCII whose bytes are not, and the `strip` on the very next line raises
+      # Encoding::CompatibilityError. Every entry point -- `make doctor`,
+      # `make bootstrap-fork`, every step -- dies there with a backtrace instead of a
+      # named refusal, BEFORE any step runs.
+      #
+      # This is not a fork-specific accident. `.bootstrap.env.example` carries 53 lines
+      # with non-ASCII bytes and bin/init-bootstrap-env.sh copies it verbatim, so the
+      # configuration this template ships IS the trigger. The raising `strip` also runs
+      # BEFORE the comment-skip below, so commenting the offending line out does not
+      # help either. Every CI runner sets a locale, which is why the suites never saw it.
+      File.read(path, encoding: "UTF-8").each_line.with_index do |line, idx|
         line = line.strip
         next if line.empty? || line.start_with?("#")
         key, _, val = line.partition("=")
@@ -1066,7 +1079,7 @@ module Bootstrap
                      when metadata_dir then EN_US_FIELD_ENV[basename]
                      end
           next if env_name && !ENV[env_name].to_s.strip.empty?
-          content = File.read(f)
+          content = File.read(f, encoding: "UTF-8")
           if content.match?(PLACEHOLDER_PATTERN)
             todos << Pathname.new(f).relative_path_from(REPO_ROOT).to_s
           elsif content.strip.empty?
@@ -1079,7 +1092,7 @@ module Bootstrap
       # for ASC_COPYRIGHT works the same as the en-US URL fields.
       copyright = root_dir.join("copyright.txt")
       if copyright.file? && ENV[COPYRIGHT_FIELD_ENV].to_s.strip.empty?
-        content = File.read(copyright)
+        content = File.read(copyright, encoding: "UTF-8")
         if content.match?(PLACEHOLDER_PATTERN)
           todos << Pathname.new(copyright).relative_path_from(REPO_ROOT).to_s
         elsif content.strip.empty?
@@ -1882,7 +1895,7 @@ module Bootstrap
     Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.create(
       key_id:    ENV.fetch("ASC_API_KEY_ID"),
       issuer_id: ENV.fetch("ASC_API_KEY_ISSUER_ID"),
-      key:       File.read(p8_path),
+      key:       File.binread(p8_path),
     )
   end
 

--- a/bin/lib/version_resolver.rb
+++ b/bin/lib/version_resolver.rb
@@ -67,13 +67,13 @@ module Bootstrap
 
       yml_path = File.join(repo_root, PROJECT_YML)
       if File.exist?(yml_path)
-        from_yml = File.read(yml_path).match(/^\s*MARKETING_VERSION\s*:\s*["']?([^"'\s#]+)["']?/)
+        from_yml = File.read(yml_path, encoding: "UTF-8").match(/^\s*MARKETING_VERSION\s*:\s*["']?([^"'\s#]+)["']?/)
         return from_yml[1] if from_yml
       end
 
       swift_path = File.join(repo_root, PROJECT_SWIFT)
       if File.exist?(swift_path)
-        from_swift = File.read(swift_path).match(/"MARKETING_VERSION"\s*:\s*"([^"]+)"/)
+        from_swift = File.read(swift_path, encoding: "UTF-8").match(/"MARKETING_VERSION"\s*:\s*"([^"]+)"/)
         return from_swift[1] if from_swift
       end
 

--- a/bin/submit.rb
+++ b/bin/submit.rb
@@ -105,12 +105,12 @@ end
 # ─── Read marketing version for the preflight summary ────────────────────────
 def read_marketing_version
   if File.exist?("app/project.yml")
-    if (m = File.read("app/project.yml").match(/^\s*MARKETING_VERSION\s*:\s*["']?([^"'\s#]+)/))
+    if (m = File.read("app/project.yml", encoding: "UTF-8").match(/^\s*MARKETING_VERSION\s*:\s*["']?([^"'\s#]+)/))
       return m[1]
     end
   end
   if File.exist?("app/Project.swift")
-    if (m = File.read("app/Project.swift").match(/"MARKETING_VERSION"\s*:\s*"([^"]+)"/))
+    if (m = File.read("app/Project.swift", encoding: "UTF-8").match(/"MARKETING_VERSION"\s*:\s*"([^"]+)"/))
       return m[1]
     end
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -34,6 +34,38 @@
 
 require "shellwords"
 
+# ONE rule about encoding, in ONE place. Every read of a TEXT file in this Fastfile
+# goes through read_text; every read of key material goes through read_key_material.
+#
+# Ruby takes the encoding of a file it reads from the environment. With LANG and
+# LC_ALL unset -- normal on a fresh machine, in a cron job, in a bare container --
+# Encoding.default_external is US-ASCII, so an unpinned read hands back a String
+# tagged US-ASCII whose bytes are not. The read is silent; the strip, the scan or the
+# match on the next line raises. The subjects here are not hypothetical: CHANGELOG.md
+# carries 300 lines with non-ASCII bytes, fastlane/metadata/copyright.txt carries
+# U+00A9, app/project.yml carries 21 such lines and app/Project.swift 11.
+#
+# fastlane does NOT save you from this. It sets the default external encoding to UTF-8
+# only inside its own `sh` helper and restores it afterwards, so reads in this file run
+# under whatever the operator's environment supplied -- and in a cleared-locale run it
+# prints "WARNING: fastlane requires your locale to be set to UTF-8" and then reads the
+# file anyway.
+#
+# Key material is the exception and gets the binary form rather than a UTF-8 pin;
+# transcoding a private key is never what anyone wants. Measured against a throwaway
+# P-256 key under both a set and a cleared locale: Spaceship::ConnectAPI::Token.create
+# accepts an ASCII-8BIT string and produces a JWT, and JSON.dump round-trips those
+# bytes identically. Deliberately NOT require_relative'd from bin/lib: this file has
+# exactly one require today, and gaining a load-path dependency would change what
+# `make ship` needs on disk.
+def read_text(path)
+  File.read(path, encoding: "UTF-8")
+end
+
+def read_key_material(path)
+  File.binread(path)
+end
+
 default_platform(:ios)
 
 # In CI mode: provision a temporary keychain for match (via setup_ci) and
@@ -75,7 +107,11 @@ end
 def _fork_config
   bootstrap_env = File.join(File.dirname(__FILE__), "..", ".bootstrap.env")
   return {} unless File.exist?(bootstrap_env)
-  File.foreach(bootstrap_env).each_with_object({}) do |line, h|
+  # The one text read spelled out rather than routed through read_text: the encoding
+  # belongs on the same line as the streaming iteration, so a reader (and
+  # test/encoding_test.rb) can see the verdict at the site instead of one indirection
+  # away. Same spelling Bootstrap::Config.parse uses for the same file.
+  File.read(bootstrap_env, encoding: "UTF-8").each_line.each_with_object({}) do |line, h|
     line = line.strip
     next if line.empty? || line.start_with?("#")
     k, v = line.split("=", 2)
@@ -235,7 +271,7 @@ end
 # every block is empty.
 def extract_changelog_section(path)
   return nil unless File.exist?(path)
-  text = File.read(path)
+  text = read_text(path)
   # Greedy across blocks; pick the first one with non-empty body.
   text.scan(/^## \[[^\]]+\][^\n]*\n(.*?)(?=^## \[|\z)/m).each do |(body)|
     body = body.to_s.strip
@@ -327,7 +363,7 @@ def annotate_testflight_whats_new(app_identifier:, marketing_version:, ship_star
   Spaceship::ConnectAPI.token ||= Spaceship::ConnectAPI::Token.create(
     key_id:    ENV.fetch("ASC_API_KEY_ID"),
     issuer_id: ENV.fetch("ASC_API_KEY_ISSUER_ID"),
-    key:       File.read(@asc_p8_path),
+    key:       read_key_material(@asc_p8_path),
   )
 
   app = Spaceship::ConnectAPI::App.find(app_identifier)
@@ -501,7 +537,7 @@ def read_review_field(env_name, file_path)
   raw = if !env_val.empty?
           env_val
         elsif File.exist?(file_path)
-          File.read(file_path).strip
+          read_text(file_path).strip
         end
   return nil if raw.nil? || raw.empty?
   return nil if raw.start_with?("TODO")
@@ -578,7 +614,7 @@ def build_asc_metadata_args(metadata_dir)
   primary_locale = ENV["ASC_PRIMARY_LOCALE"].to_s.strip
   primary_locale = "en-US" if primary_locale.empty?
   en_us_dir = File.join(metadata_dir, primary_locale)
-  en_us  = ->(name) { File.read(File.join(en_us_dir, "#{name}.txt")).strip }
+  en_us  = ->(name) { read_text(File.join(en_us_dir, "#{name}.txt")).strip }
   locale = primary_locale
   asc_field = ->(env_name, default_block) {
     v = ENV[env_name].to_s.strip
@@ -588,7 +624,7 @@ def build_asc_metadata_args(metadata_dir)
     privacy_url:   { locale => asc_field.call("ASC_PRIVACY_URL",   -> { en_us.call("privacy_url") }) },
     support_url:   { locale => asc_field.call("ASC_SUPPORT_URL",   -> { en_us.call("support_url") }) },
     marketing_url: { locale => asc_field.call("ASC_MARKETING_URL", -> { en_us.call("marketing_url") }) },
-    copyright:     asc_field.call("ASC_COPYRIGHT", -> { File.read(File.join(metadata_dir, "copyright.txt")).strip }),
+    copyright:     asc_field.call("ASC_COPYRIGHT", -> { read_text(File.join(metadata_dir, "copyright.txt")).strip }),
   }
   args[:primary_category]   = ENV["ASC_PRIMARY_CATEGORY"].to_s.strip   unless ENV["ASC_PRIMARY_CATEGORY"].to_s.strip.empty?
   args[:secondary_category] = ENV["ASC_SECONDARY_CATEGORY"].to_s.strip unless ENV["ASC_SECONDARY_CATEGORY"].to_s.strip.empty?
@@ -635,7 +671,7 @@ def do_upload_metadata(platform:)
   # such submissions without them. For no-auth apps both stay blank.
   review_info = build_review_info(review_info_dir)
 
-  en_us  = ->(name) { File.read(File.join(en_us_dir, "#{name}.txt")).strip }
+  en_us  = ->(name) { read_text(File.join(en_us_dir, "#{name}.txt")).strip }
   locale = primary_locale
 
   # Org-stable App Store metadata (privacy/support/marketing URLs, copyright,
@@ -683,13 +719,13 @@ end
 def project_marketing_version(repo_root)
   yml = File.join(repo_root, "app/project.yml")
   if File.exist?(yml)
-    if (m = File.read(yml).match(/^\s*MARKETING_VERSION\s*:\s*["']?([^"'\s#]+)/))
+    if (m = read_text(yml).match(/^\s*MARKETING_VERSION\s*:\s*["']?([^"'\s#]+)/))
       return m[1]
     end
   end
   swift = File.join(repo_root, "app/Project.swift")
   if File.exist?(swift)
-    if (m = File.read(swift).match(/"MARKETING_VERSION"\s*:\s*"([^"]+)"/))
+    if (m = read_text(swift).match(/"MARKETING_VERSION"\s*:\s*"([^"]+)"/))
       return m[1]
     end
   end
@@ -1504,7 +1540,7 @@ lane :adopt_existing_app do |options|
   File.write(api_key_json_path, JSON.dump(
     "key_id"    => ENV.fetch("ASC_API_KEY_ID"),
     "issuer_id" => ENV.fetch("ASC_API_KEY_ISSUER_ID"),
-    "key"       => File.read(@asc_p8_path),
+    "key"       => read_key_material(@asc_p8_path),
     "duration"  => 1200,
     "in_house"  => false,
   ))
@@ -1527,7 +1563,7 @@ lane :adopt_existing_app do |options|
   Spaceship::ConnectAPI.token ||= Spaceship::ConnectAPI::Token.create(
     key_id:    ENV.fetch("ASC_API_KEY_ID"),
     issuer_id: ENV.fetch("ASC_API_KEY_ISSUER_ID"),
-    key:       File.read(@asc_p8_path),
+    key:       read_key_material(@asc_p8_path),
   )
 
   app = Spaceship::ConnectAPI::App.find(app_identifier)

--- a/test/encoding_test.rb
+++ b/test/encoding_test.rb
@@ -1,0 +1,345 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Every read of a file in this tree must state its encoding, and this test is
+# what makes that a rule rather than a habit.
+#
+# WHY THIS EXISTS
+#
+# Ruby decides the encoding of a file it reads from the environment. With LANG
+# and LC_ALL unset -- normal on a fresh machine, inside a cron job, inside a bare
+# container -- Encoding.default_external is US-ASCII, so a read with no explicit
+# encoding hands back a String tagged US-ASCII whose bytes are not. The read
+# itself is silent. The next strip, the next concatenation, or the next regex
+# raises ArgumentError or Encoding::CompatibilityError, and the operator gets a
+# backtrace where a named refusal belonged.
+#
+# That is not a hypothetical for this template. It is the shipped configuration:
+#
+#   .bootstrap.env.example carries 53 lines with non-ASCII bytes, and
+#   bin/init-bootstrap-env.sh copies it VERBATIM to .bootstrap.env. So every fork
+#   starts from a file that trips it, and Bootstrap::Config.parse is the read
+#   every entry point goes through -- `make doctor` and `make bootstrap-fork`
+#   both died there, with a backtrace, before any step ran. The `strip` that
+#   raises runs BEFORE the comment-skip, so commenting the line out did not help.
+#   Reproduced under both a cleared and a set locale, and against both the shipped
+#   example file and a pure-ASCII copy of it: the crash needs the non-ASCII bytes
+#   AND the missing locale, and either one alone is green. A control that varied
+#   only one of them would have proved nothing.
+#
+# Every suite here ran green throughout, because every CI runner sets a locale.
+# That is precisely why a source-level gate is worth having: the runtime cannot
+# see this, and the operator's machine can.
+#
+# Fixing one reported site at a time does not hold -- the next unpinned read is
+# simply the next crash. So this file demands a stated verdict for EVERY read of
+# a file in the tracked tree: pinned, binary, or an entry in EXEMPTIONS carrying
+# a written reason. A read with no verdict fails.
+#
+# HOW IT AVOIDS TURNING ITSELF GREEN
+#
+# This is a scanner whose subject is the syntax its own source would otherwise
+# have to contain, so a literal pattern here would match itself and quietly
+# change what the gate reports. Every pattern below is ASSEMBLED FROM FRAGMENTS
+# at runtime and no call form is ever spelled out -- not in code, not in a
+# comment, not in an exemption reason -- and even this file's own reader goes
+# through File.method rather than a literal call. There is NO self-exclusion
+# entry: this file is enumerated exactly like every other, and group E5 MEASURES
+# that it yields zero candidates. Self-exclusion would be a permanent hole;
+# a measurement is not.
+#
+# FAILURE-LINE CONTRACT. One line per failure, no leading whitespace:
+#
+#     FAIL <group> <path>: <message>
+#
+#   E1  every candidate call site carries a verdict
+#   E2  every exemption still matches exactly one real site
+#   E3  non-vacuity: the enumeration and the candidate set are not empty
+#   E4  the dynamic discriminator: real code, real bytes, locale cleared
+#   E5  this file yields no candidates, and does so without excluding itself
+#
+# DEPENDENCIES: Ruby core only. The job that runs it uses bundler-cache: false,
+# so a gem here would break it.
+
+ROOT = File.expand_path("..", __dir__)
+
+# --- fragments -----------------------------------------------------------
+# Nothing below is ever written as a whole token. Receiver, separator, verb and
+# paren are only ever composed at runtime, which is what keeps this file out of
+# its own candidate set for a reason that can be measured rather than asserted.
+SEP   = "."
+OPEN  = "("
+UTF8  = "UTF" + "-8"
+ENC_K = "encod" + "ing"
+
+RECEIVERS   = %w[File IO].freeze
+TEXT_VERBS  = %w[read readlines foreach open].freeze
+BIN_VERBS   = %w[binread binreadlines].freeze
+STREAM_VERB = %w[each line].join("_")
+
+def call_forms(verbs)
+  RECEIVERS.product(verbs).map { |recv, verb| recv + SEP + verb + OPEN }
+end
+
+TEXT_CALLS   = call_forms(TEXT_VERBS).freeze
+BIN_CALLS    = call_forms(BIN_VERBS).freeze
+STREAM_CALL  = (SEP + STREAM_VERB).freeze
+ENC_ARGUMENT = (ENC_K + ":").freeze
+# A mode string naming an encoding after a colon, a binary mode, and a
+# write/append mode. Assembled, never spelled.
+MODE_WITH_ENC = /["'][rwa][b+]*:[A-Za-z0-9_-]+/.freeze
+MODE_BINARY   = /["'][rwa][+]*b[+]*["']/.freeze
+MODE_WRITE    = /["'][wa][b+]*["']/.freeze
+
+# --- the private reader --------------------------------------------------
+# This gate must read files, and must do so without spelling a call form.
+# File.method(:...) produces the same Method object the literal call would, so
+# the behaviour is identical and the source text is not a match.
+READER = File.method(("op" + "en").to_sym)
+
+def slurp(abs)
+  READER.call(abs, "r:" + UTF8, &:read)
+end
+
+# --- assertions ----------------------------------------------------------
+@checks   = 0
+@failures = 0
+
+def assert(condition, group, path, label)
+  @checks += 1
+  if condition
+    puts "  ok #{group} #{path}: #{label}"
+  else
+    # One line, always. A message that put the group on one line and the path on
+    # another would make every grep for a specific failure vacuous.
+    puts "FAIL #{group} #{path}: #{label.to_s.gsub(/\s*\n\s*/, ' ')}"
+    @failures += 1
+  end
+end
+
+def no_verdict(message)
+  # Refusing a verdict is not the same as passing. Exit 2, never 0.
+  puts "FAIL E3 -: cannot run -- #{message}"
+  puts
+  puts "encoding gate CANNOT RUN: #{message}"
+  exit 2
+end
+
+# --- the exemption table -------------------------------------------------
+# Keyed by path plus a CONTENT ANCHOR, never by line number: a line number goes
+# stale the moment anything above it moves, and a stale key silently stops
+# matching, which is a hole rather than a failure. Group E2 asserts every entry
+# matches EXACTLY ONE candidate in the current tree -- zero is stale, more than
+# one is ambiguous, and both fail.
+#
+# Every reason below was measured under a cleared locale on Ruby 3.3 and 4.0,
+# not reasoned about.
+EXEMPTIONS = [
+  {
+    path:   "bin/lib/bootstrap.rb",
+    anchor: "out_err",
+    reason: "Not a file read. This iterates the combined-output handle yielded by " \
+            "Open3.popen2e, so the encoding comes from the child spawn rather than from a " \
+            "path on disk, and no encoding argument is accepted here. Measured under a " \
+            "cleared locale: the iteration, the echo to the caller's IO and the append to " \
+            "the capture buffer all complete without raising. Worth knowing rather than " \
+            "hiding: the buffer this returns is tagged US-ASCII and reports valid_encoding? " \
+            "false, so a caller that later matches a regex against it would raise. That is a " \
+            "separate question about process output, not about reading a tracked file."
+  },
+  {
+    path:   "test/sh_stream_test.rb",
+    anchor: "body",
+    reason: "The subject under test is stream buffering, and this test writes the bytes it " \
+            "later reads back into its own temporary file, so it controls them and they are " \
+            "pure ASCII. Pinning here would change what is being measured rather than fix " \
+            "anything."
+  },
+  {
+    path:   "test/sh_stream_test.rb",
+    anchor: "mid_run",
+    reason: "Same temporary file, same test-controlled ASCII bytes, mid-run assertion."
+  },
+  {
+    path:   "test/sh_stream_test.rb",
+    anchor: "empty?",
+    reason: "Same temporary file, same test-controlled ASCII bytes; this is the control " \
+            "assertion proving the redirect assertions discriminate."
+  }
+].freeze
+
+# --- enumeration ---------------------------------------------------------
+# git ls-files, as an argv array through IO.popen -- never a shell string, and
+# never a shell `git grep`, because quoting silently changes a candidate set. An
+# exit code other than zero, or an empty list, is a reason to refuse a verdict
+# rather than to report a clean tree.
+listing = begin
+  IO.popen(%w[git ls-files -z], chdir: ROOT, err: File::NULL, &:read)
+rescue SystemCallError => e
+  no_verdict("git ls-files could not run in #{ROOT}: #{e.message}")
+end
+no_verdict("git ls-files exited #{$?&.exitstatus.inspect} in #{ROOT}") unless $?&.success?
+
+tracked = listing.to_s.split("\0").reject(&:empty?).sort
+no_verdict("git ls-files listed no tracked files in #{ROOT}") if tracked.empty?
+
+RUBYISH = ->(rel) { rel.end_with?(".rb") || rel == "fastlane/Fastfile" }
+scanned = tracked.select { |rel| RUBYISH.call(rel) }
+
+# --- the candidate scan --------------------------------------------------
+Candidate = Struct.new(:rel, :line_no, :text)
+
+candidates = []
+unreadable = []
+scanned.each do |rel|
+  abs = File.join(ROOT, rel)
+  next unless File.file?(abs)
+
+  content = begin
+    slurp(abs)
+  rescue SystemCallError => e
+    unreadable << [rel, e.message]
+    next
+  end
+
+  content.lines.each_with_index do |text, idx|
+    hit = TEXT_CALLS.any? { |form| text.include?(form) } ||
+          BIN_CALLS.any?  { |form| text.include?(form) } ||
+          text.include?(STREAM_CALL)
+    candidates << Candidate.new(rel, idx + 1, text.chomp) if hit
+  end
+end
+
+# --- E3: non-vacuity, BEFORE any iteration over the collections ----------
+# An `each` over an empty collection asserts nothing and reports success, so
+# these come first rather than last.
+assert scanned.length >= 20, "E3", "-",
+       "the enumeration found #{scanned.length} Ruby-ish tracked files (floor 20); an " \
+       "empty or tiny enumeration would make every assertion below vacuous"
+assert candidates.length >= 15, "E3", "-",
+       "the scan found #{candidates.length} candidate call sites (floor 15); a scan that " \
+       "found none would pass silently while checking nothing"
+%w[bin/lib/bootstrap.rb bin/adopt.rb fastlane/Fastfile test/encoding_test.rb].each do |known|
+  assert scanned.include?(known), "E3", known,
+         "known-positive path is present in the enumeration; if it were absent, a clean " \
+         "result about it would mean only that nobody looked"
+end
+assert candidates.any? { |c| c.rel == "bin/lib/bootstrap.rb" }, "E3", "bin/lib/bootstrap.rb",
+       "the file carrying the parser every entry point uses yields at least one candidate; " \
+       "zero would mean the patterns stopped matching reality"
+assert unreadable.empty?, "E3", "-",
+       "every enumerated file was readable (#{unreadable.map(&:first).join(', ')})"
+
+# --- E2: exemption integrity, before they are trusted as verdicts --------
+exempt_lines = {}
+EXEMPTIONS.each do |entry|
+  matches = candidates.select { |c| c.rel == entry[:path] && c.text.include?(entry[:anchor]) }
+  assert matches.length == 1, "E2", entry[:path],
+         "exemption anchored on '#{entry[:anchor]}' matches exactly one candidate (found " \
+         "#{matches.length}); zero means the exemption is STALE and has become a silent " \
+         "hole, more than one means it is ambiguous and covers a site nobody read"
+  assert !entry[:reason].to_s.strip.empty?, "E2", entry[:path],
+         "exemption anchored on '#{entry[:anchor]}' carries a written reason"
+  matches.each { |m| exempt_lines[[m.rel, m.line_no]] = entry }
+end
+
+# --- E1: every candidate carries a verdict -------------------------------
+candidates.each do |c|
+  verdict =
+    if exempt_lines.key?([c.rel, c.line_no])
+      "exempt"
+    elsif BIN_CALLS.any? { |form| c.text.include?(form) } || c.text.match?(MODE_BINARY)
+      "binary"
+    elsif c.text.include?(ENC_ARGUMENT) || c.text.match?(MODE_WITH_ENC)
+      "pinned"
+    elsif c.text.match?(MODE_WRITE)
+      # Measured on both interpreters with LANG, LC_ALL and LC_CTYPE all cleared:
+      # the WRITE side does not raise. Ruby does not transcode a String to the
+      # default external encoding on the way out; it emits the String's own bytes.
+      # The falsifiable half of this class is the READ.
+      "write"
+    end
+
+  assert !verdict.nil?, "E1", c.rel,
+         verdict ? "line #{c.line_no} carries the verdict #{verdict}" :
+         "line #{c.line_no} reads a file with the encoding inherited from the environment " \
+         "and no stated verdict. With the locale unset that String is tagged US-ASCII and " \
+         "the next strip, concatenation or regex raises. Give the call an explicit encoding, " \
+         "use the binary form for key material, or add an EXEMPTIONS entry in " \
+         "test/encoding_test.rb with a measured reason: #{c.text.strip}"
+end
+
+# --- E5: this file is scanned, and yields nothing, without excluding itself
+own = candidates.select { |c| c.rel == "test/encoding_test.rb" }
+assert own.empty?, "E5", "test/encoding_test.rb",
+       "the gate's own source yields zero candidates (found #{own.length}: " \
+       "#{own.map(&:line_no).join(', ')}). It is enumerated like every other file and there " \
+       "is no self-exclusion entry anywhere in this file; it is clean because every pattern " \
+       "is composed from fragments at runtime and no call form is ever spelled out. A " \
+       "scanner that had to exclude itself would carry a permanent hole"
+assert EXEMPTIONS.none? { |e| e[:path] == "test/encoding_test.rb" }, "E5", "test/encoding_test.rb",
+       "there is no exemption entry for this file, so E5 above is a measurement rather than " \
+       "a consequence of opting out"
+
+# --- E4: the dynamic discriminator ---------------------------------------
+# Source text is not behaviour. This spawns a locale-cleared child that loads the
+# real library and runs the REAL parser against the REAL tracked example dotenv --
+# the file bin/init-bootstrap-env.sh copies verbatim into every fork, and the
+# exact pair (those bytes, that missing locale) that used to raise. It needs no
+# .bootstrap.env, no secret and no Xcode, so it is safe in a bare checkout.
+#
+# The child rescues Exception and prints a sentinel either way, so a LoadError or
+# a missing file surfaces as a named failure instead of as an exception with zero
+# FAIL lines -- easy to walk into here, because the subject of this gate IS a crash.
+child_script = <<~CHILD
+  require "pathname"
+  puts "EXT=" + Encoding.default_external.to_s
+  begin
+    require File.expand_path("bin/lib/bootstrap.rb", Dir.pwd)
+    keys = Bootstrap::Config.parse(Pathname.new(".bootstrap.env.example")).length
+    puts "PARSE=ok keys=" + keys.to_s
+  rescue Exception => e
+    puts "PARSE=raised " + e.class.to_s + ": " + e.message.lines.first.to_s.strip
+  end
+CHILD
+
+ruby_bin = File.join(RbConfig::CONFIG["bindir"], RbConfig::CONFIG["ruby_install_name"])
+cleared  = { "LANG" => nil, "LC_ALL" => nil, "LC_CTYPE" => nil }
+child_out = begin
+  IO.popen([cleared, ruby_bin, "-e", child_script], chdir: ROOT, err: [:child, :out], &:read).to_s
+rescue SystemCallError => e
+  "SPAWN_FAILED #{e.message}"
+end
+
+ext_line   = child_out.lines.find { |l| l.start_with?("EXT=") }.to_s.strip
+parse_line = child_out.lines.find { |l| l.start_with?("PARSE=") }.to_s.strip
+
+# Assert the discriminator is LIVE before asserting the result. On a machine whose
+# Ruby reports UTF-8 with the locale cleared, "it did not raise" is trivially true
+# and proves nothing.
+discriminator_live = ext_line == "EXT=US-ASCII"
+assert discriminator_live, "E4", "-",
+       "the locale-cleared child reports #{ext_line.empty? ? '(no EXT line at all)' : ext_line}, " \
+       "and this discriminator is only meaningful when that is US-ASCII; anything else means " \
+       "the assertion below proves nothing and must be repaired, not believed"
+assert !parse_line.empty?, "E4", "-",
+       "the locale-cleared child produced a PARSE verdict line (got: " \
+       "#{child_out.strip.lines.last.to_s.strip.inspect}); no verdict means the child died " \
+       "before reporting, and a silent pass there would be exactly the failure this gate exists " \
+       "to catch"
+if discriminator_live && !parse_line.empty?
+  assert parse_line.start_with?("PARSE=ok"), "E4", "bin/lib/bootstrap.rb",
+         "with LANG, LC_ALL and LC_CTYPE all cleared, the real parser reads the real tracked " \
+         ".bootstrap.env.example -- the file every fork starts from -- and completes: #{parse_line}"
+end
+
+# --- verdict -------------------------------------------------------------
+puts
+puts "candidates=#{candidates.length} files=#{scanned.length} exemptions=#{EXEMPTIONS.length}"
+if @failures.zero?
+  puts "All #{@checks} encoding assertions passed."
+  exit 0
+else
+  puts "#{@failures} of #{@checks} encoding assertion(s) failed."
+  exit 1
+end

--- a/test/tag_prefix_test.rb
+++ b/test/tag_prefix_test.rb
@@ -102,7 +102,7 @@ end
 
 # asc_env is what reaches the fastlane subprocess.
 assert_eq Bootstrap.method(:asc_env).source_location.nil?, false, "asc_env exists"
-asc_env_src = File.read(File.expand_path("../bin/lib/bootstrap.rb", __dir__))
+asc_env_src = File.read(File.expand_path("../bin/lib/bootstrap.rb", __dir__), encoding: "UTF-8")
 assert_eq asc_env_src.include?('"RELEASE_TAG_PREFIX"      => config.release_tag_prefix'), true,
           "asc_env propagates RELEASE_TAG_PREFIX to fastlane"
 


### PR DESCRIPTION
## What breaks

Ruby decides the encoding of a file it reads from the environment. With `LANG` and `LC_ALL`
unset — a fresh machine, a cron job, a bare container — `Encoding.default_external` is
`US-ASCII`, so a read with no explicit encoding hands back a String tagged US-ASCII whose bytes
are not. The read itself is silent. The next `strip`, concatenation or regex raises.

This template ships the trigger. `.bootstrap.env.example` carries **53 lines with non-ASCII
bytes**, `bin/init-bootstrap-env.sh:36` copies it **verbatim** to `.bootstrap.env`, and
`Bootstrap::Config.parse` is the read every entry point goes through. So `make doctor` and
`make bootstrap-fork` die with a backtrace before printing a single pipeline step:

```
$ env -u LANG -u LC_ALL make doctor
bin/lib/bootstrap.rb:117:in `strip': invalid byte sequence in US-ASCII (Encoding::CompatibilityError)
	from bin/lib/bootstrap.rb:116:in `foreach'
```

Zero status lines. The `strip` that raises also runs **before** the comment-skip, so commenting
the offending line out does not help either.

Every suite here stays green because every CI runner sets a locale. That is exactly why this
needs a source-level gate and not a runtime one.

## Driven with both discriminators

The crash needs the non-ASCII bytes **and** the missing locale. Either alone is green, so a
control that varied only one would have proved nothing. Against the shipped example file, on
Ruby 3.3.12 and 4.0.6 (both report `US-ASCII` with the locale cleared):

| input | result |
|---|---|
| `.bootstrap.env.example` + locale cleared | `Encoding::CompatibilityError` |
| `.bootstrap.env.example` + `LANG` set | parses, 39 keys — *the locale is a trigger* |
| pure-ASCII copy of it + locale cleared | parses — *the bytes are a trigger* |

And end to end, with a fixture config and the locale cleared:

| | status lines printed | encoding error |
|---|---|---|
| before | **0** | yes |
| after | **21**, then a verdict | no |

## Why this is a sweep and not two lines

Fixing one reported site at a time does not hold — the next unpinned read is simply the next
crash. So every read of a file in the tracked tree now carries a stated verdict. Derived with:

```
git grep -nE 'File\.read\(|File\.readlines\(|IO\.read\(|File\.foreach\(|\.each_line' \
  -- '*.rb' 'fastlane/Fastfile' | grep -v 'encoding:'
```

**26 sites: 17 pinned, 5 binread, 4 exempt.** Measured subjects, not guessed:
`.bootstrap.env.example` 53 non-ASCII lines, `CHANGELOG.md` 300, `app/project.yml` 21,
`app/Project.swift` 11, `bin/lib/bootstrap.rb` 120, `fastlane/metadata/copyright.txt` carries
U+00A9.

The five App Store Connect private-key reads get the **binary** form rather than a UTF-8 pin —
transcoding a private key is never what anyone wants. Measured before changing them, against a
throwaway P-256 key under both a set and a cleared locale: `Spaceship::ConnectAPI::Token.create`
accepts an `ASCII-8BIT` string and produces a JWT, and `JSON.dump` round-trips those bytes
identically. The second check matters because the adopt path serialises the key into JSON rather
than handing it to Spaceship.

`fastlane/Fastfile` gets one `read_text` and one `read_key_material` instead of eleven repeated
keywords — one rule that cannot drift, and no `require_relative` into `bin/lib`, because this
file has exactly one `require` today and a load-path dependency would change what `make ship`
needs on disk. Driven through real fastlane with the locale cleared: the changelog-section
reader, the marketing-version reader and the App Store metadata builder all raised before and all
return now. fastlane does not protect these reads — it sets UTF-8 only inside its own `sh` helper
and restores it afterwards, and in the same run it printed *"WARNING: fastlane requires your
locale to be set to UTF-8"* and then read the file anyway.

## The gate

`test/encoding_test.rb` runs as `encoding-regression` in `bootstrap-doctor-matrix.yml`, modelled
on the `parser-regression` job beside it: `ubuntu-latest`, stdlib-only, `bundler-cache: false`,
three minutes. It enumerates through `git ls-files` and fails on any read with no verdict, naming
the file, the line and the text.

Four properties, each because its absence is how a gate like this becomes quietly worthless:

- **It does not exclude itself.** A scanner whose subject is the syntax its own source would have
  to contain is the sharpest case of a check that turns itself green by existing. Every pattern is
  composed from fragments at runtime and no call form is ever spelled out — not in code, not in a
  comment, not in an exemption reason — and even the file's own reader goes through `File.method`.
  One group then *measures* that the file yields zero candidates while another proves it was
  enumerated at all. A self-exclusion entry would have been a permanent hole.
- **Exemptions cannot go stale silently.** Keyed by content anchor, never line number, and each
  must match exactly one candidate: zero fails as stale, more than one as ambiguous. Driven by
  pointing an anchor at nothing and observing the named red.
- **It is not vacuous.** The enumeration and the candidate set are asserted non-empty and above a
  floor, and four known-positive paths asserted present, before anything iterates.
- **It proves behaviour, not text.** It spawns a locale-cleared child that runs the real parser
  against the real tracked `.bootstrap.env.example`, after first asserting the child reports
  `US-ASCII` so that assertion cannot be trivially true.

It earned its keep during this change: it caught an unpinned stream read that the Fastfile commit
had itself introduced.

## Verification

- `ruby test/encoding_test.rb` — exit 0, 50 assertions, on 3.3.12 and 4.0.6
- Whole `test/` suite green on both interpreters
- `bundle exec fastlane lanes` exit 0 — the Fastfile loads, not merely parses
- `env -u LANG -u LC_ALL make doctor` reaches a verdict; before this branch it printed nothing

## Notes for review

- No behaviour changes beyond encoding. No dependency added; the new test requires nothing.
- Whether `encoding-regression` should become a required check is your call — the branch only
  adds the job.
- Found while running a downstream fork with an unset locale; the same defect is present here at
  `42a1abb`, reproduced against this repository's own bytes rather than the fork's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
