### PR TITLE
fix(migrate-identity): rewire a fork that pinned PRODUCT_NAME (#293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `bin/migrate-identity.rb` — **a fork that pinned `PRODUCT_NAME` migrates instead of exiting 4** (#293). The only fix App Review accepts for a Guideline 5.2.5 rejection of `<N>-macOS` is a literal `PRODUCT_NAME: <N>` on each app target, usually with `TEST_HOST` spelled from the same literal and `PRODUCT_MODULE_NAME` pinned so the module every test imports keeps its name. The rewriter's post-conditions counted only the `$(APP_PRODUCT_NAME)` spellings, so exactly that fork was refused — `yml-product-name`, `yml-test-host` and `yml-bundle-loader` at 0 — and had the counters been met, the substring residual scan would have refused it again over `<N>_iOS` and a usage-description string.
+
+  A literal `PRODUCT_NAME` equal to the value the build resolves now becomes `$(APP_PRODUCT_NAME)` in place, on both generators; a literal that disagrees is refused by name (it is a third opinion about the fork's identity, never rewritten to a reference it would not resolve to), and so is a `PRODUCT_NAME` above `targets:`. The two host paths XcodeGen and Tuist derive are respelled from `$(APP_PRODUCT_NAME)` and `BUNDLE_LOADER: $(TEST_HOST)` is authored beside a host the fork had already spelled. `PRODUCT_MODULE_NAME` is claimed unchanged. The residual check now reads the token as a whole identifier in a structural position — comments, the module name and prose are not residuals — and prose that still names the token is reported rather than refused.
+
+  Measured on the fork the issue came from: exit 0; both platforms build Release; `CFBundleName`, `CFBundleExecutable`, `CFBundleDisplayName` and `CFBundleIdentifier` read off the built `Info.plist`s unchanged from the pre-migration table; the macOS scheme builds for testing with `TEST_HOST` and `BUNDLE_LOADER` resolving to the built app. `test/migrate_identity_test.rb` M10 carries the shape plus both refusals, and fails by name against the previous command.
+
 ### Added
 
 - `Bootstrap::LocalSigningTeam` — **`make bootstrap-fork` writes your Apple Team ID into the gitignored `app/Local.xcconfig`**, from `FASTLANE_TEAM_ID` in `.bootstrap.env`. `bin/rename.sh --team-id=…` used to write that file and is retired in the same release; without this step the value would have no writer at all, and every fresh fork would meet the gap at its first signed build.

--- a/bin/migrate-identity.rb
+++ b/bin/migrate-identity.rb
@@ -1606,10 +1606,67 @@ def rewrite_comment_token(line, token)
   end
 end
 
+# A YAML scalar as written: a trailing ` # comment` dropped, one layer of
+# matching quotes removed. `PRODUCT_NAME: "Tunnelless"  # 5.2.5` is the same
+# pin as `PRODUCT_NAME: Tunnelless`, and a rule that read the comment as part of
+# the value would refuse a fork over its own explanation of the pin.
+def manifest_scalar(raw)
+  value = raw.to_s.sub(/\s+#.*\z/, "").strip
+  return value[1..-2] if value.length >= 2 && value[0] == value[-1] && %w[" '].include?(value[0])
+
+  value
+end
+
+def pinned_product_name_disagrees(relative, value, token)
+  "#{relative} pins PRODUCT_NAME to #{value.inspect}, which is neither the product name the " \
+    "build resolves on both platforms (#{token.inspect}) nor $(APP_PRODUCT_NAME). " \
+    "#{REL_IDENTITY} is about to hold APP_PRODUCT_NAME = #{token}; a literal that says " \
+    "otherwise is a third opinion about this fork's identity, and this command will not " \
+    "rewrite it into a reference that resolves to something it never said. Reconcile the two " \
+    "and re-run. Nothing was written to #{relative}."
+end
+
 def project_yml_rules(token, bundle_id, insert_product_name)
   escaped = Regexp.escape(token)
   [
     # ── identity, always ahead of structure ──────────────────────────────────
+    #
+    # A pinned PRODUCT_NAME (#293). A fork that shipped and drew a Guideline
+    # 5.2.5 rejection pins PRODUCT_NAME to a literal on each app target, because
+    # the default — the TARGET name, platform suffix included — is the thing
+    # Apple refused. That literal IS the value app/Identity.xcconfig is about to
+    # hold: collapse_product_name has already required the build to resolve it
+    # on both platforms. So it becomes the reference, in place, and the app
+    # target keeps the line it already had. A literal that says anything else is
+    # a third opinion about this fork's identity and is refused BY NAME — never
+    # swept to `App` by the structural rule below, which is what a literal equal
+    # to the token would otherwise meet.
+    ["yml-product-name-literal", /\A(\s*)PRODUCT_NAME:\s*(\S.*?)\s*\z/,
+     lambda { |match, _line|
+       value = manifest_scalar(match[2])
+       next nil if value == "$(APP_PRODUCT_NAME)"
+       next ["#{match[1]}PRODUCT_NAME: $(APP_PRODUCT_NAME)"] if value == token
+
+       fail_with 4, pinned_product_name_disagrees(REL_PROJECT_YML, value, token)
+     }],
+    # PRODUCT_MODULE_NAME is the Swift module every source and test file imports
+    # (`@testable import <N>_iOS`, measured on the fork #293 came from). It is
+    # neither identity nor structure, and renaming it is a source-wide edit this
+    # command does not make — so the line is CLAIMED here, unchanged, where a
+    # value equal to the bare token would otherwise be swept to `App` by
+    # yml-value-token and every import in the fork would stop compiling.
+    ["yml-module-name", /\A\s*PRODUCT_MODULE_NAME:\s*\S/,
+     ->(_match, line) { [line] }],
+    # The same fork spelled TEST_HOST from the literal, for the reason
+    # yaml_insert_test_host documents: XcodeGen derives it from the host TARGET
+    # name and the pinned product never builds there. Only the exact two shapes
+    # XcodeGen's own derivation produces are rewired; any other literal host is
+    # the forker's and is left, and the yml-test-host count then names it.
+    ["yml-test-host-literal",
+     %r{\A(\s*)TEST_HOST:\s*\$\(BUILT_PRODUCTS_DIR\)/#{escaped}\.app/(Contents/MacOS/)?#{escaped}\s*\z},
+     lambda { |match, _line|
+       ["#{match[1]}TEST_HOST: $(BUILT_PRODUCTS_DIR)/$(APP_PRODUCT_NAME).app/#{match[2]}$(APP_PRODUCT_NAME)"]
+     }],
     ["yml-bundle-id", /\A(\s*)PRODUCT_BUNDLE_IDENTIFIER:\s*(\S.*?)\s*\z/,
      lambda { |match, _line|
        reference = bundle_reference(match[2], bundle_id)
@@ -1659,6 +1716,27 @@ end
 def project_swift_rules(token, bundle_id)
   escaped = Regexp.escape(token)
   [
+    # The Tuist spellings of the three pinned-fork lines project_yml_rules
+    # documents (#293): the literal PRODUCT_NAME becomes the reference when it
+    # equals the value the build resolves and is refused by name otherwise; the
+    # module name is claimed unchanged; the two host paths XcodeGen/Tuist derive
+    # are respelled from the product name. Each sits ahead of
+    # swift-structural-literal, which would otherwise rewrite "<N>" to "App"
+    # inside the first and the last of them.
+    ["swift-product-name-literal", /\A(\s*"PRODUCT_NAME":\s*")([^"]*)("\s*,?)\s*\z/,
+     lambda { |match, _line|
+       next nil if match[2] == "$(APP_PRODUCT_NAME)"
+       next ["#{match[1]}$(APP_PRODUCT_NAME)#{match[3]}"] if match[2] == token
+
+       fail_with 4, pinned_product_name_disagrees(REL_PROJECT_SWIFT, match[2], token)
+     }],
+    ["swift-module-name", /\A\s*"PRODUCT_MODULE_NAME":\s*"/,
+     ->(_match, line) { [line] }],
+    ["swift-test-host-literal",
+     %r{\A(\s*"TEST_HOST":\s*"\$\(BUILT_PRODUCTS_DIR\)/)#{escaped}(\.app/(?:Contents/MacOS/)?)#{escaped}("\s*,?)\s*\z},
+     lambda { |match, _line|
+       ["#{match[1]}$(APP_PRODUCT_NAME)#{match[2]}$(APP_PRODUCT_NAME)#{match[3]}"]
+     }],
     ["swift-bundle-id", /\A(\s*(?:bundleId:|"PRODUCT_BUNDLE_IDENTIFIER":)\s*")([^"]*)("\s*,?)\s*\z/,
      lambda { |match, _line|
        reference = bundle_reference(match[2], bundle_id)
@@ -1846,7 +1924,8 @@ def yaml_insert_test_host(body)
     block = lines[(index + 1)..last] || []
     if block.any? { |row| row.match?(/\A\s*type:\s*bundle\.unit-test\s*\z/) }
       unit_tests += 1
-      unless block.any? { |row| row.match?(/\A\s*TEST_HOST:/) }
+      host_row = block.index { |row| row.match?(/\A\s*TEST_HOST:/) }
+      if host_row.nil?
         host_at = block.index { |row| row.match?(/\A\s*TEST_TARGET_NAME:/) }
         unless host_at.nil?
           mac    = block.any? { |row| row.match?(/\A\s*platform:\s*macOS\s*\z/) } ||
@@ -1863,6 +1942,16 @@ def yaml_insert_test_host(body)
                        "#{indent}BUNDLE_LOADER: $(TEST_HOST)\n")
           inserted += 1
         end
+      elsif block.none? { |row| row.match?(/\A\s*BUNDLE_LOADER:/) }
+        # A fork that spelled TEST_HOST itself (#293) had no BUNDLE_LOADER to
+        # spell — the literal host path was complete without one — so there is
+        # nothing to rewrite and the yml-bundle-loader count cannot be met by a
+        # rewrite. It is AUTHORED, beside the host it follows, so the migrated
+        # manifest has the one shape the post-conditions and this template's
+        # own app/project.yml describe.
+        indent = block[host_row][/\A */]
+        block  = block.dup
+        block.insert(host_row + 1, "#{indent}BUNDLE_LOADER: $(TEST_HOST)\n")
       end
     end
 
@@ -1938,14 +2027,74 @@ end
 # BODY, because "the rule ran" and "the file now says this" are different claims
 # and only the second one is what ships. A fork that already carried one of these
 # keys would make a fired-rule count zero and the file correct.
-def residual_token_lines(body, token)
+# A residual is the token in a STRUCTURAL position after the rewrite: a whole
+# identifier — not the head of a longer one, so `<N>_iOS` is not one — on a line
+# that is neither a comment nor prose. The plain substring scan this replaced
+# refused a real fork (#293) over lines none of which was a half-rewired
+# manifest: `PRODUCT_MODULE_NAME: <N>_iOS` (the module every test imports, kept
+# by the rule above), `NSLocalNetworkUsageDescription: <N> connects to ...` (the
+# forker's own user-visible text), and a comment the comment rule had already
+# reworded as far as a comment rule goes. Prose is REPORTED by
+# report_prose_token_lines and never rewritten: the forker's words are theirs.
+def token_identifier(token)
+  /(?<![A-Za-z0-9_])#{Regexp.escape(token)}(?![A-Za-z0-9_])/
+end
+
+def comment_line?(line)
+  line.match?(%r{\A\s*(?:#|//)})
+end
+
+# In the Tuist manifest the token can only be prose INSIDE a string literal
+# whose content has whitespace; a token outside every literal is an identifier
+# and structural by definition. In the XcodeGen manifest the value after `key:`
+# is prose when it has whitespace once a trailing comment is dropped.
+def prose_line?(line, token, kind)
+  pattern = token_identifier(token)
+  if kind == :swift
+    outside  = line.gsub(/"(?:[^"\\]|\\.)*"/, '""')
+    return false if outside.match?(pattern)
+
+    literals = line.scan(/"((?:[^"\\]|\\.)*)"/).flatten.select { |text| text.match?(pattern) }
+    return !literals.empty? && literals.all? { |text| text.strip.match?(/\s/) }
+  end
+
+  value = line.sub(/\A\s*(?:-\s+)?[A-Za-z_][A-Za-z0-9_.-]*:\s*/, "").sub(/\s+#.*\z/, "").strip
+  value.match?(/\s/)
+end
+
+def token_bearing_lines(body, token)
+  pattern = token_identifier(token)
   body.lines.each_with_index.filter_map do |line, index|
-    "#{index + 1}: #{line.strip}" if line.include?(token)
+    next if comment_line?(line) || line.match?(/\A\s*"?PRODUCT_MODULE_NAME"?:/) || !line.match?(pattern)
+
+    [index + 1, line.strip]
   end
 end
 
+def manifest_kind(relative)
+  relative == REL_PROJECT_SWIFT ? :swift : :yaml
+end
+
+def residual_token_lines(body, token, kind = :yaml)
+  token_bearing_lines(body, token).reject { |_, line| prose_line?(line, token, kind) }
+                                   .map { |number, line| "#{number}: #{line}" }
+end
+
+def prose_token_lines(body, token, kind)
+  token_bearing_lines(body, token).select { |_, line| prose_line?(line, token, kind) }
+                                   .map { |number, line| "#{number}: #{line}" }
+end
+
+def report_prose_token_lines(relative, body, token)
+  prose = prose_token_lines(body, token, manifest_kind(relative))
+  return if prose.empty?
+
+  say "left #{prose.length} line(s) of #{relative} that name #{token.inspect} inside " \
+      "user-visible text unchanged — the forker's own words are not structure: #{prose.join(' | ')}"
+end
+
 def require_no_residual_token(relative, body, token)
-  residual = residual_token_lines(body, token)
+  residual = residual_token_lines(body, token, manifest_kind(relative))
   return if residual.empty?
 
   fail_with 4, "#{relative} still names the fork's structural token #{token.inspect} on " \
@@ -1959,6 +2108,23 @@ def rewrite_project_yml(root, token, bundle_id)
   path     = File.join(root, relative)
   body     = read_utf8(path)
   counts   = {}
+
+  # A PRODUCT_NAME above `targets:` is project level: it leaks into all four
+  # test bundles and collides the two iOS .xctest bundles at one path, which is
+  # why yml-bundle-id only ever emits it beside a per-target app bundle id. A
+  # fork that pinned it there (#293 pins per target; this is the other place a
+  # hand could put it) is refused by name rather than rewired in place.
+  targets_at    = body.lines.index { |line| line.chomp == "targets:" }
+  project_level = body.lines.each_with_index.filter_map do |line, index|
+    "#{index + 1}: #{line.strip}" if (targets_at.nil? || index < targets_at) && line.match?(/\A\s*PRODUCT_NAME:/)
+  end
+  unless project_level.empty?
+    fail_with 4, "#{relative} sets PRODUCT_NAME above `targets:`, at project level, on " \
+                 "#{project_level.join(' | ')}. A project-level PRODUCT_NAME leaks into all four " \
+                 "test bundles and collides the two iOS .xctest bundles at one path, so this " \
+                 "command only rewires it per app target. Move it under each app target's " \
+                 "settings and re-run. Nothing was written to #{relative}."
+  end
 
   insert_product_name = !body.match?(/^\s*PRODUCT_NAME:/)
   body = apply_line_rules(body, project_yml_rules(token, bundle_id, insert_product_name), counts)
@@ -1992,6 +2158,7 @@ def rewrite_project_yml(root, token, bundle_id)
                       "yml-test-host"       => unit_tests,
                       "yml-bundle-loader"   => unit_tests)
   require_no_residual_token(relative, body, token)
+  report_prose_token_lines(relative, body, token)
 
   File.binwrite(path, body)
   counts
@@ -2027,6 +2194,7 @@ def rewrite_project_swift(root, token, bundle_id)
                       "swift-xcconfig-rows"      => 2,
                       "swift-bundle-ref"         => 2)
   require_no_residual_token(relative, body, token)
+  report_prose_token_lines(relative, body, token)
 
   File.binwrite(path, body)
   counts

--- a/docs/MIGRATING-FROM-RENAME.md
+++ b/docs/MIGRATING-FROM-RENAME.md
@@ -122,6 +122,32 @@ The built name is not the only thing derived from `PRODUCT_NAME`. Expect to revi
   searches for `"$SCHEME_IOS.app"`; after the migration your iOS scheme is `App-iOS` while
   the built bundle is `<N>.app`, so that search finds nothing.
 
+### A fork that already pins `PRODUCT_NAME`
+
+Some forks set `PRODUCT_NAME` themselves before migrating — most often because App Review
+rejected `<N>-macOS` under Guideline 5.2.5 ("Terms for macOS in the app name that displays
+on the device"), and the only fix Apple accepts is a literal `PRODUCT_NAME: <N>` on each app
+target. Such a fork usually also spells `TEST_HOST` from that literal (XcodeGen derives it
+from the host *target* name, which no longer builds) and pins `PRODUCT_MODULE_NAME` so the
+module every test file imports keeps its name.
+
+The command migrates that shape (#293), and the collapse above is a **no-op** for it: the
+build already resolves one `PRODUCT_NAME` on both platforms, so `APP_PRODUCT_NAME` takes
+that value and the built filenames do not change. What the rewrite does, per app target:
+
+| You had | You get |
+|---|---|
+| `PRODUCT_NAME: <N>` (equal to the value the build resolves) | `PRODUCT_NAME: $(APP_PRODUCT_NAME)`, in place |
+| `PRODUCT_NAME: <something else>` | **exit 4**, naming the literal — a literal that disagrees with the resolved product name is a third opinion about the fork's identity, and it is never rewritten to a reference it would not resolve to |
+| `PRODUCT_NAME:` above `targets:` (project level) | **exit 4**, naming the line — a project-level value leaks into all four test bundles |
+| `TEST_HOST: $(BUILT_PRODUCTS_DIR)/<N>.app/<N>` (or the `Contents/MacOS` form) | the same path spelled from `$(APP_PRODUCT_NAME)`, and `BUNDLE_LOADER: $(TEST_HOST)` authored beside it |
+| `PRODUCT_MODULE_NAME: <N>_iOS` | left byte-for-byte; the module name is neither identity nor structure |
+| `<N>` inside user-visible text (`NS…UsageDescription`) | left byte-for-byte, and **reported** in the run's output so you know it is still there |
+
+The Tuist manifest gets the same treatment for `"PRODUCT_NAME"`, `"PRODUCT_MODULE_NAME"`
+and `"TEST_HOST"` settings. Read the four plist keys off a Release build of the migrated
+tree anyway, as the table at the top of this section asks; the fork this was measured on did.
+
 ---
 
 ## Prerequisites

--- a/test/migrate_identity_test.rb
+++ b/test/migrate_identity_test.rb
@@ -1121,10 +1121,13 @@ end
 # backtrace where a named refusal belongs.
 def build_migration_fixture(dir, branch: "main", team_id: FIXTURE_TEAM_ID,
                             ignore_local_xcconfig: true, with_local_xcconfig: true,
-                            with_xcodeproj: true, entry_points: nil)
+                            with_xcodeproj: true, entry_points: nil,
+                            project_yml: nil, project_swift: nil)
   FileUtils.mkdir_p(dir)
-  write_file(dir, "app/project.yml", fixture_project_yml(TOKEN, team_id))
-  write_file(dir, "app/Project.swift", fixture_project_swift(TOKEN, team_id))
+  # M10 hands in the two manifests of a fork that pinned PRODUCT_NAME; every
+  # other case takes the pre-#281 shape the two builders describe.
+  write_file(dir, "app/project.yml", project_yml || fixture_project_yml(TOKEN, team_id))
+  write_file(dir, "app/Project.swift", project_swift || fixture_project_swift(TOKEN, team_id))
   write_file(dir, "app/Shared/#{TOKEN}.swift", main_swift(TOKEN))
   write_file(dir, "app/iOS/#{TOKEN}.entitlements", ENTITLEMENTS_IOS)
   write_file(dir, "app/macOS/#{TOKEN}.entitlements", ENTITLEMENTS_MACOS)
@@ -2395,6 +2398,187 @@ Dir.mktmpdir("migrate-entry-rollback") do |box|
            "the rollback left HEAD where it was (#{head_before.inspect})"
     assert porcelain_of(repo).to_s.strip.empty?, "M9-rollback",
            "the tree is clean after the rollback (#{porcelain_of(repo).inspect})"
+  end
+end
+
+# ─── M10: a fork that pinned PRODUCT_NAME (#293) ─────────────────────────────
+#
+# A fork that shipped and drew a Guideline 5.2.5 rejection ("Terms for macOS in
+# the app name that displays on the device") pins PRODUCT_NAME to a literal on
+# each app target, spells TEST_HOST from that literal because XcodeGen derives it
+# from the host TARGET name, pins PRODUCT_MODULE_NAME so the module every test
+# imports keeps its name, and carries the app's name inside a usage-description
+# string. Measured on the fork #293 came from, 2026-09-08. The rewriter's
+# post-conditions count only the $(APP_PRODUCT_NAME) spellings, so that fork
+# exited 4 at d65801d with three counters at 0 — and had the counters been met,
+# the substring residual scan would have refused it over the module name and
+# the prose. These cases put that shape on the M7/M8 tree, plus the two
+# refusals the fix must keep: a literal that DISAGREES with the product name the
+# build resolves, and a PRODUCT_NAME at project level.
+#
+# Each pin is applied by an anchor that must match EXACTLY once, so a fixture
+# builder that drifts makes this group fail by name instead of testing a shape
+# nobody intended.
+
+# `replacement` is a String inserted verbatim, or a Proc handed the MatchData —
+# never a String with `\1` in it, which String#sub's block form does not expand
+# (measured: the first draft of the Tuist host pins landed a literal `\1`).
+def pin_exactly_once(text, anchor, replacement, label)
+  count = text.scan(anchor).length
+  raise "#{label}: fixture anchor matched #{count} time(s), expected 1" unless count == 1
+
+  text.sub(anchor) { replacement.is_a?(Proc) ? replacement.call(Regexp.last_match) : replacement }
+end
+
+PINNED_PROSE = "connects to devices nearby."
+
+def pinned_project_yml(token, macos_literal: token, project_level: false)
+  yml = fixture_project_yml(token, FIXTURE_TEAM_ID)
+  yml = pin_exactly_once(yml, "        CODE_SIGN_ENTITLEMENTS: iOS/#{token}.entitlements\n",
+                         "        PRODUCT_NAME: #{token}\n" \
+                         "        PRODUCT_MODULE_NAME: #{token}_iOS\n" \
+                         "        CODE_SIGN_ENTITLEMENTS: iOS/#{token}.entitlements\n", "yml iOS pin")
+  yml = pin_exactly_once(yml, "        CODE_SIGN_ENTITLEMENTS: macOS/#{token}.entitlements\n",
+                         "        PRODUCT_NAME: #{macos_literal}\n" \
+                         "        PRODUCT_MODULE_NAME: #{token}_macOS\n" \
+                         "        CODE_SIGN_ENTITLEMENTS: macOS/#{token}.entitlements\n", "yml macOS pin")
+  yml = pin_exactly_once(yml, "        ITSAppUsesNonExemptEncryption: false\n",
+                         "        ITSAppUsesNonExemptEncryption: false\n" \
+                         "        NSLocalNetworkUsageDescription: #{token} #{PINNED_PROSE}\n", "yml prose")
+  yml = pin_exactly_once(yml, "        PRODUCT_BUNDLE_IDENTIFIER: #{FIXTURE_BUNDLE_ID}.tests\n" \
+                              "        TEST_TARGET_NAME: #{token}-iOS\n",
+                         "        PRODUCT_BUNDLE_IDENTIFIER: #{FIXTURE_BUNDLE_ID}.tests\n" \
+                         "        TEST_TARGET_NAME: #{token}-iOS\n" \
+                         "        TEST_HOST: $(BUILT_PRODUCTS_DIR)/#{token}.app/#{token}\n", "yml iOS host")
+  yml = pin_exactly_once(yml, "        PRODUCT_BUNDLE_IDENTIFIER: #{FIXTURE_BUNDLE_ID}.mactests\n" \
+                              "        TEST_TARGET_NAME: #{token}-macOS\n",
+                         "        PRODUCT_BUNDLE_IDENTIFIER: #{FIXTURE_BUNDLE_ID}.mactests\n" \
+                         "        TEST_TARGET_NAME: #{token}-macOS\n" \
+                         "        TEST_HOST: $(BUILT_PRODUCTS_DIR)/#{token}.app/Contents/MacOS/#{token}\n",
+                         "yml macOS host")
+  if project_level
+    yml = pin_exactly_once(yml, "    CODE_SIGN_STYLE: Automatic\n",
+                           "    CODE_SIGN_STYLE: Automatic\n    PRODUCT_NAME: #{token}\n", "yml project level")
+  end
+  yml
+end
+
+def pinned_project_swift(token, macos_literal: token)
+  swift = fixture_project_swift(token, FIXTURE_TEAM_ID)
+  swift = pin_exactly_once(swift, "        \"TARGETED_DEVICE_FAMILY\": \"1,2\",\n",
+                           "        \"PRODUCT_NAME\": \"#{token}\",\n" \
+                           "        \"PRODUCT_MODULE_NAME\": \"#{token}_iOS\",\n" \
+                           "        \"TARGETED_DEVICE_FAMILY\": \"1,2\",\n", "swift iOS pin")
+  swift = pin_exactly_once(swift, "        \"ASSETCATALOG_COMPILER_APPICON_NAME\": \"\",\n",
+                           "        \"PRODUCT_NAME\": \"#{macos_literal}\",\n" \
+                           "        \"PRODUCT_MODULE_NAME\": \"#{token}_macOS\",\n" \
+                           "        \"ASSETCATALOG_COMPILER_APPICON_NAME\": \"\",\n", "swift macOS pin")
+  swift = pin_exactly_once(swift, "    \"ITSAppUsesNonExemptEncryption\": false,\n",
+                           "    \"ITSAppUsesNonExemptEncryption\": false,\n" \
+                           "    \"NSLocalNetworkUsageDescription\": \"#{token} #{PINNED_PROSE}\",\n", "swift prose")
+  swift = pin_exactly_once(swift, /(let iosUnitTestTarget = .*?"TEST_TARGET_NAME": "#{Regexp.escape(token)}-iOS",\n)/m,
+                           ->(m) { "#{m[1]}        \"TEST_HOST\": \"$(BUILT_PRODUCTS_DIR)/#{token}.app/#{token}\",\n" },
+                           "swift iOS host")
+  pin_exactly_once(swift, /(let macUnitTestTarget = .*?"TEST_TARGET_NAME": "#{Regexp.escape(token)}-macOS",\n)/m,
+                   ->(m) { "#{m[1]}        \"TEST_HOST\": \"$(BUILT_PRODUCTS_DIR)/#{token}.app/Contents/MacOS/#{token}\",\n" },
+                   "swift macOS host")
+end
+
+puts
+puts "M10 — a fork that pinned PRODUCT_NAME (#293): rewired when it agrees, refused when it does not:"
+
+Dir.mktmpdir("migrate-pinned") do |box|
+  repo = File.join(box, "repo")
+  if (why = build_migration_fixture(repo, project_yml: pinned_project_yml(TOKEN),
+                                          project_swift: pinned_project_swift(TOKEN)))
+    fail_line("M10-pinned", why)
+    @checks += 1
+  else
+    # The build of a pinned fork resolves the literal on BOTH platforms, with no
+    # platform suffix — which is the whole reason the fork pinned it.
+    bin = build_tool_dir(box, ios_product: TOKEN, macos_product: TOKEN)
+    out = assert_exit ["--root", repo], EXIT_OK, ["MIGRATION COMPLETE"], "M10-pinned",
+                      "two app targets pinning PRODUCT_NAME to the value the build resolves migrate at exit 0",
+                      env: { TOOL_DIR_ENV => bin }
+
+    yml  = text_of(File.join(repo, "app/project.yml")).to_s
+    pins = yml.lines.select { |line| line.match?(/\A\s*PRODUCT_NAME:/) }.map(&:strip)
+    assert pins == ["PRODUCT_NAME: $(APP_PRODUCT_NAME)"] * 2, "M10-pinned",
+           "both pinned PRODUCT_NAME lines became $(APP_PRODUCT_NAME) in place and no third appeared " \
+           "(#{pins.inspect})"
+    assert !yml.include?("PRODUCT_NAME: App"), "M10-pinned",
+           "neither literal was swept to the structural constant App by the value-token rule"
+    assert yml.include?("PRODUCT_MODULE_NAME: #{TOKEN}_iOS\n") &&
+           yml.include?("PRODUCT_MODULE_NAME: #{TOKEN}_macOS\n"),
+           "M10-pinned", "PRODUCT_MODULE_NAME is left verbatim on both app targets — the module every test imports"
+    hosts = yml.lines.select { |line| line.match?(/\A\s*TEST_HOST:/) }.map(&:strip)
+    assert hosts == ["TEST_HOST: $(BUILT_PRODUCTS_DIR)/$(APP_PRODUCT_NAME).app/$(APP_PRODUCT_NAME)",
+                     "TEST_HOST: $(BUILT_PRODUCTS_DIR)/$(APP_PRODUCT_NAME).app/Contents/MacOS/$(APP_PRODUCT_NAME)"],
+           "M10-pinned", "both literal TEST_HOST paths are respelled from $(APP_PRODUCT_NAME) (#{hosts.inspect})"
+    assert yml.scan(/^\s*BUNDLE_LOADER: \$\(TEST_HOST\)$/).length == 2, "M10-pinned",
+           "BUNDLE_LOADER: $(TEST_HOST) is AUTHORED beside each host the fork had spelled " \
+           "(found #{yml.scan(/^\s*BUNDLE_LOADER:/).length})"
+    assert yml.include?("NSLocalNetworkUsageDescription: #{TOKEN} #{PINNED_PROSE}\n"), "M10-pinned",
+           "user-visible prose naming the token is left byte-for-byte"
+    assert out.to_s.include?("NSLocalNetworkUsageDescription") && out.to_s.include?("unchanged"),
+           "M10-pinned", "the report names the prose line it left rather than passing over it"
+
+    swift = text_of(File.join(repo, "app/Project.swift")).to_s
+    assert swift.scan(/"PRODUCT_NAME": "\$\(APP_PRODUCT_NAME\)"/).length == 2 &&
+           !swift.include?('"PRODUCT_NAME": "App"'),
+           "M10-pinned", "both Tuist PRODUCT_NAME settings became $(APP_PRODUCT_NAME), never \"App\""
+    assert swift.scan(/productName: "\$\(APP_PRODUCT_NAME\)"/).length == 2, "M10-pinned",
+           "productName: $(APP_PRODUCT_NAME) is still inserted on both app targets"
+    assert swift.include?("\"PRODUCT_MODULE_NAME\": \"#{TOKEN}_iOS\"") &&
+           swift.include?("\"PRODUCT_MODULE_NAME\": \"#{TOKEN}_macOS\""),
+           "M10-pinned", "the Tuist PRODUCT_MODULE_NAME settings are left verbatim"
+    assert swift.include?('"TEST_HOST": "$(BUILT_PRODUCTS_DIR)/$(APP_PRODUCT_NAME).app/$(APP_PRODUCT_NAME)"') &&
+           swift.include?('"TEST_HOST": "$(BUILT_PRODUCTS_DIR)/$(APP_PRODUCT_NAME).app/Contents/MacOS/$(APP_PRODUCT_NAME)"'),
+           "M10-pinned", "both Tuist TEST_HOST literals are respelled from $(APP_PRODUCT_NAME)"
+    assert swift.include?("\"#{TOKEN} #{PINNED_PROSE}\""), "M10-pinned",
+           "the Tuist usage-description prose is left byte-for-byte"
+  end
+end
+
+Dir.mktmpdir("migrate-pinned-disagree") do |box|
+  repo   = File.join(box, "repo")
+  legacy = "#{TOKEN}Legacy"
+  if (why = build_migration_fixture(repo, project_yml: pinned_project_yml(TOKEN, macos_literal: legacy),
+                                          project_swift: pinned_project_swift(TOKEN, macos_literal: legacy)))
+    fail_line("M10-disagree", why)
+    @checks += 1
+  else
+    bin         = build_tool_dir(box, ios_product: TOKEN, macos_product: TOKEN)
+    before      = digest_of(File.join(repo, "app/project.yml"))
+    head_before = head_of(repo)
+    assert_exit ["--root", repo], EXIT_MUTATION, [legacy, "PRODUCT_NAME", "third opinion", "rolled back"],
+                "M10-disagree",
+                "a literal that disagrees with the product name the build resolves exits 4 naming the literal",
+                env: { TOOL_DIR_ENV => bin }
+    assert digest_of(File.join(repo, "app/project.yml")) == before, "M10-disagree",
+           "app/project.yml is restored byte-identically — the disagreeing literal was not rewritten to a reference"
+    assert head_of(repo) == head_before && porcelain_of(repo).to_s.strip.empty?, "M10-disagree",
+           "HEAD is unchanged and the tree is clean after the rollback (#{porcelain_of(repo).inspect})"
+  end
+end
+
+Dir.mktmpdir("migrate-pinned-project-level") do |box|
+  repo = File.join(box, "repo")
+  if (why = build_migration_fixture(repo, project_yml: pinned_project_yml(TOKEN, project_level: true),
+                                          project_swift: pinned_project_swift(TOKEN)))
+    fail_line("M10-project-level", why)
+    @checks += 1
+  else
+    bin         = build_tool_dir(box, ios_product: TOKEN, macos_product: TOKEN)
+    before      = digest_of(File.join(repo, "app/project.yml"))
+    head_before = head_of(repo)
+    assert_exit ["--root", repo], EXIT_MUTATION, ["project level", "targets:", "rolled back"],
+                "M10-project-level",
+                "a PRODUCT_NAME above targets: is refused by name, not rewired in place",
+                env: { TOOL_DIR_ENV => bin }
+    assert digest_of(File.join(repo, "app/project.yml")) == before &&
+           head_of(repo) == head_before && porcelain_of(repo).to_s.strip.empty?,
+           "M10-project-level", "the tree is restored byte-identically after the refusal"
   end
 end
 


### PR DESCRIPTION
Closes #293.

## What was wrong

`bin/migrate-identity.rb`'s post-conditions counted only the `$(APP_PRODUCT_NAME)` spellings, so a fork that pinned `PRODUCT_NAME` to a literal — the only fix App Review accepts for a Guideline 5.2.5 rejection of `<N>-macOS` — exited 4 with `yml-product-name`, `yml-test-host` and `yml-bundle-loader` at 0. Two facts from the issue's second comment shaped the fix: the command had already written Identity.xcconfig, moved the Team ID and `git mv`'d five files before the gate fired (the rollback held), and the fork had no `BUNDLE_LOADER` at all, so that counter could never be met by a rewrite.

## What changes

Both generators, identity rules ahead of structure:

| Line in the fork | Now |
|---|---|
| `PRODUCT_NAME: <N>` equal to the value the build resolves | `PRODUCT_NAME: $(APP_PRODUCT_NAME)`, in place |
| `PRODUCT_NAME: <other>` | exit 4 naming the literal — a third opinion about identity, never rewritten to a reference it would not resolve to |
| `PRODUCT_NAME:` above `targets:` | exit 4 naming the line — project level leaks into all four test bundles |
| `TEST_HOST: $(BUILT_PRODUCTS_DIR)/<N>.app/<N>` (and the `Contents/MacOS` form) | respelled from `$(APP_PRODUCT_NAME)`; `BUNDLE_LOADER: $(TEST_HOST)` **authored** beside it |
| `PRODUCT_MODULE_NAME: <N>_iOS` | claimed unchanged — the module every test imports is neither identity nor structure |
| `<N>` inside a usage-description string | left byte-for-byte and **reported** in the run's output |

The residual-token check reads the token as a whole identifier in a structural position. Comments, the module name and prose are not residuals; prose is reported. The substring scan it replaces would have refused the fork over `<N>_iOS` and the usage description once the counters were met.

## Red, then green — the issue's fixture

`repro-293.sh d65801d` (from #293):

```
MIGRATE-IDENTITY FAILED: app/project.yml is not shaped like a manifest this command can rewire — yml-product-name: expected at least 2, applied 0; yml-test-host: expected at least 2, applied 0; yml-bundle-loader: expected at least 2, applied 0. …
MIGRATE-IDENTITY: rolled back to the pre-migration state.
== EXIT=4
== RED: refused, as #293 describes.
```

`repro-293.sh cae9a2d`:

```
MIGRATE-IDENTITY: left 2 line(s) of app/project.yml that name "Tunnelless" inside user-visible text unchanged — the forker's own words are not structure: 94: NSLocalNetworkUsageDescription: Tunnelless connects directly … | 152: …
MIGRATE-IDENTITY: left 1 line(s) of app/Project.swift that name "Tunnelless" inside user-visible text unchanged — …: 35: "Tunnelless connects directly to devices on your Tailscale network " +
MIGRATE-IDENTITY: ==== MIGRATION COMPLETE ====
== EXIT=0
== GREEN: migration completed. Now build both platforms and compare the four plist keys.
```

## The full acceptance, on the migrated fork

Migrated shape (`app/project.yml`):

```
104:        PRODUCT_NAME: $(APP_PRODUCT_NAME)
108:        PRODUCT_MODULE_NAME: Tunnelless_iOS
166:        PRODUCT_NAME: $(APP_PRODUCT_NAME)
168:        PRODUCT_MODULE_NAME: Tunnelless_macOS
241:        TEST_HOST: $(BUILT_PRODUCTS_DIR)/$(APP_PRODUCT_NAME).app/$(APP_PRODUCT_NAME)
242:        BUNDLE_LOADER: $(TEST_HOST)
284:        TEST_HOST: $(BUILT_PRODUCTS_DIR)/$(APP_PRODUCT_NAME).app/Contents/MacOS/$(APP_PRODUCT_NAME)
285:        BUNDLE_LOADER: $(TEST_HOST)
```

`app/Project.swift`: `productName: "$(APP_PRODUCT_NAME)"` inserted on both app targets (71, 144); `"PRODUCT_NAME": "$(APP_PRODUCT_NAME)"` (92, 170); `"PRODUCT_MODULE_NAME"` verbatim (94, 171); both `"TEST_HOST"` respelled (237, 253).

`xcodebuild` with `CODE_SIGNING_ALLOWED=NO` on the migrated tree: `App-iOS` Release **BUILD SUCCEEDED**, `App-macOS` Release **BUILD SUCCEEDED**, `App-macOS` `build-for-testing` **TEST BUILD SUCCEEDED**.

The four keys, read with `plutil -extract` off the **built** `Info.plist`s (`Release-iphoneos/Tunnelless.app/Info.plist`, `Release/Tunnelless.app/Contents/Info.plist`):

| Key | iOS | macOS |
|---|---|---|
| `CFBundleName` | `Tunnelless` | `Tunnelless` |
| `CFBundleExecutable` | `Tunnelless` | `Tunnelless` |
| `CFBundleDisplayName` | `Tunnelless` | `Tunnelless` |
| `CFBundleIdentifier` | `com.indiagram.tunnelless` | `com.indiagram.tunnelless` |

Identical to the fork's pre-migration table in #293. Resolved by the unit-test targets (`-showBuildSettings`): `TEST_HOST` and `BUNDLE_LOADER` both point at `…/Debug/Tunnelless.app/Contents/MacOS/Tunnelless` (macOS) and `…/Debug-iphoneos/Tunnelless.app/Tunnelless` (iOS).

## Unit contract

`test/migrate_identity_test.rb` gains **M10**: the pinned shape on the M7/M8 fixture (both generators, module name, prose, literal hosts, no BUNDLE_LOADER), a literal that disagrees, and a project-level PRODUCT_NAME.

- against this branch: **All 217 migrate-identity assertions passed** (ruby 3.3)
- against `d65801d` with the same test file: **10 of 217 FAIL**, all M10 — eight on the pinned case (exit 4, counters at 0, no report line), and the two refusals fail with *"exit 4 was right but the message named nothing"*, which is the difference between the old count message and a refusal that names the literal or the line

## Not tested here

- `xcodebuild test` of the migrated fork's macOS unit tests (build-for-testing only; the fork's tests need its own entitlements)
- `tuist generate` on the migrated fork — the fixture generates with XcodeGen; the Tuist manifest was rewired and read, not generated
- #295: the collapse banner still prints *"Nothing in this tree sets PRODUCT_NAME"* on a pinned fork; separate issue, separate PR
- #296: the fixture satisfies the team-id gate by substituting in the manifests, as that issue describes; unchanged here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
